### PR TITLE
feat: add asset type to asset evens (subgraph changes)

### DIFF
--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -250,6 +250,7 @@ interface AssetEvent {
   timestamp: BigInt! # Timestamp of the event
   emitter: Asset! # The contract that emitted the event
   sender: Account! # The account that sent the transaction
+  assetType: String! # The type of asset that was affected
 }
 
 # --------------------------------------------------
@@ -279,6 +280,7 @@ type TransferEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   from: Account! # Sender address
   to: Account! # Recipient address
   value: BigDecimal! # Amount transferred
@@ -295,6 +297,7 @@ type MintEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   to: Account! # Recipient address
   value: BigDecimal! # Amount transferred
   valueExact: BigInt! # Amount transferred in exact precision
@@ -310,6 +313,7 @@ type BurnEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   from: Account!
   value: BigDecimal! # Amount transferred
   valueExact: BigInt! # Amount transferred in exact precision
@@ -325,6 +329,7 @@ type ApprovalEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   owner: Account! # Token owner
   spender: Account! # Approved spender
   value: BigDecimal! # Approved amount
@@ -341,6 +346,7 @@ type PausedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
 }
 
 """
@@ -353,6 +359,7 @@ type UnpausedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
 }
 
 """
@@ -365,6 +372,7 @@ type TokensFrozenEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   user: Account! # The user whose tokens were frozen
   amount: BigDecimal! # The amount frozen
   amountExact: BigInt! # The amount frozen in exact precision
@@ -380,6 +388,7 @@ type RoleGrantedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   role: Bytes! # Role identifier (e.g. SUPPLY_MANAGEMENT_ROLE)
   account: Account! # The account that received the role
 }
@@ -394,6 +403,7 @@ type RoleRevokedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   role: Bytes!
   account: Account! # The account that lost the role
 }
@@ -408,6 +418,7 @@ type RoleAdminChangedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   role: Bytes! # The role being modified
   previousAdminRole: Bytes! # The old admin role
   newAdminRole: Bytes! # The new admin role
@@ -423,6 +434,7 @@ type UserBlockedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   user: Account! # The blocked user's address
 }
 
@@ -436,6 +448,7 @@ type UserUnblockedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   user: Account! # The unblocked user's address
 }
 
@@ -449,6 +462,7 @@ type AssetCreatedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
 }
 
 # --------------------------------------------------
@@ -465,6 +479,7 @@ type CollateralUpdatedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   oldAmount: BigDecimal! # Previous collateral amount
   oldAmountExact: BigInt! # Previous collateral amount in exact precision
   newAmount: BigDecimal! # New collateral amount
@@ -486,6 +501,7 @@ type ManagementFeeCollectedEvent implements AssetEvent
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   amount: BigDecimal! # Fee amount collected
   amountExact: BigInt! # Fee amount collected in exact precision
 }
@@ -501,6 +517,7 @@ type PerformanceFeeCollectedEvent implements AssetEvent
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   amount: BigDecimal! # Fee amount collected
   amountExact: BigInt! # Fee amount collected in exact precision
 }
@@ -515,6 +532,7 @@ type TokenWithdrawnEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   token: Asset!
   to: Account! # Recipient address
   amount: BigDecimal! # Amount withdrawn
@@ -543,6 +561,7 @@ type BondMaturedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
 }
 
 """
@@ -555,6 +574,7 @@ type BondRedeemedEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   holder: Account! # The address redeeming the bond
   bondAmount: BigDecimal! # The number of bonds redeemed
   bondAmountExact: BigInt! # The number of bonds redeemed in exact precision
@@ -576,6 +596,7 @@ type UnderlyingAssetTopUpEvent implements AssetEvent @entity(immutable: true) {
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   from: Account! # The address providing the top-up
   amount: BigDecimal! # The amount of underlying assets added
   amountExact: BigInt! # The amount of underlying assets added in exact precision
@@ -592,6 +613,7 @@ type UnderlyingAssetWithdrawnEvent implements AssetEvent
   timestamp: BigInt!
   emitter: Asset!
   sender: Account!
+  assetType: String!
   to: Account! # The recipient address for the withdrawn assets
   amount: BigDecimal! # The amount withdrawn
   amountExact: BigInt! # The amount withdrawn in exact precision

--- a/kit/subgraph/src/assets/bond.ts
+++ b/kit/subgraph/src/assets/bond.ts
@@ -22,7 +22,7 @@ import {
   UnderlyingAssetWithdrawn,
   Unpaused,
   UserBlocked,
-  UserUnblocked
+  UserUnblocked,
 } from "../../generated/templates/Bond/Bond";
 import { fetchAccount } from "../fetch/account";
 import { fetchAssetBalance, hasBalance } from "../fetch/balance";
@@ -66,6 +66,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.bond,
       to.id,
       event.params.value,
       bond.decimals
@@ -135,6 +136,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.bond,
       from.id,
       event.params.value,
       bond.decimals
@@ -211,6 +213,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.bond,
       from.id,
       to.id,
       event.params.value,
@@ -327,6 +330,7 @@ export function handleRoleGranted(event: RoleGranted): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     event.params.role,
     account.id
   );
@@ -415,6 +419,7 @@ export function handleRoleRevoked(event: RoleRevoked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     event.params.role,
     account.id
   );
@@ -506,6 +511,7 @@ export function handleApproval(event: Approval): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     owner.id,
     spender.id,
     event.params.value,
@@ -555,6 +561,7 @@ export function handleRoleAdminChanged(event: RoleAdminChanged): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     event.params.role,
     event.params.previousAdminRole,
     event.params.newAdminRole
@@ -702,7 +709,13 @@ export function handlePaused(event: Paused): void {
     }
   }
 
-  pausedEvent(eventId(event), event.block.timestamp, event.address, sender.id);
+  pausedEvent(
+    eventId(event),
+    event.block.timestamp,
+    event.address,
+    sender.id,
+    AssetType.bond
+  );
   accountActivityEvent(
     sender,
     EventName.Paused,
@@ -762,7 +775,8 @@ export function handleUnpaused(event: Unpaused): void {
     eventId(event),
     event.block.timestamp,
     event.address,
-    sender.id
+    sender.id,
+    AssetType.bond
   );
   accountActivityEvent(
     sender,
@@ -809,6 +823,7 @@ export function handleTokensFrozen(event: TokensFrozen): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     user.id,
     event.params.amount,
     bond.decimals
@@ -855,6 +870,7 @@ export function handleUserBlocked(event: UserBlocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     user.id
   );
   accountActivityEvent(
@@ -898,6 +914,7 @@ export function handleUserUnblocked(event: UserUnblocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.bond,
     user.id
   );
   accountActivityEvent(
@@ -1010,16 +1027,21 @@ export function handleUnderlyingAssetWithdrawn(
 
 function calculateTotalUnderlyingNeeded(bond: Bond): void {
   // Calculate exact value first
-  bond.totalUnderlyingNeededExact = bond.totalSupplyExact.times(bond.faceValue).div(
-    BigInt.fromI32(10).pow(bond.decimals as u8)
-  );
+  bond.totalUnderlyingNeededExact = bond.totalSupplyExact
+    .times(bond.faceValue)
+    .div(BigInt.fromI32(10).pow(bond.decimals as u8));
 
   // Convert to decimal for display
-  bond.totalUnderlyingNeeded = toDecimals(bond.totalUnderlyingNeededExact, bond.decimals);
+  bond.totalUnderlyingNeeded = toDecimals(
+    bond.totalUnderlyingNeededExact,
+    bond.decimals
+  );
 }
 
 export function updateDerivedFields(bond: Bond): void {
   calculateTotalUnderlyingNeeded(bond);
   // Compare using exact values
-  bond.hasSufficientUnderlying = bond.underlyingBalance.ge(bond.totalUnderlyingNeededExact);
+  bond.hasSufficientUnderlying = bond.underlyingBalance.ge(
+    bond.totalUnderlyingNeededExact
+  );
 }

--- a/kit/subgraph/src/assets/cryptocurrency.ts
+++ b/kit/subgraph/src/assets/cryptocurrency.ts
@@ -49,6 +49,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.cryptocurrency,
       to.id,
       event.params.value,
       cryptoCurrency.decimals
@@ -130,6 +131,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.cryptocurrency,
       from.id,
       event.params.value,
       cryptoCurrency.decimals
@@ -223,6 +225,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.cryptocurrency,
       from.id,
       to.id,
       event.params.value,
@@ -349,6 +352,7 @@ export function handleRoleGranted(event: RoleGranted): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.cryptocurrency,
     event.params.role,
     account.id
   );
@@ -443,6 +447,7 @@ export function handleRoleRevoked(event: RoleRevoked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.cryptocurrency,
     event.params.role,
     account.id
   );
@@ -539,6 +544,7 @@ export function handleApproval(event: Approval): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.cryptocurrency,
     owner.id,
     spender.id,
     event.params.value,
@@ -590,6 +596,7 @@ export function handleRoleAdminChanged(event: RoleAdminChanged): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.cryptocurrency,
     event.params.role,
     event.params.previousAdminRole,
     event.params.newAdminRole

--- a/kit/subgraph/src/assets/equity.ts
+++ b/kit/subgraph/src/assets/equity.ts
@@ -62,6 +62,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.equity,
       to.id,
       event.params.value,
       equity.decimals
@@ -131,6 +132,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.equity,
       from.id,
       event.params.value,
       equity.decimals
@@ -207,6 +209,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.equity,
       from.id,
       to.id,
       event.params.value,
@@ -322,6 +325,7 @@ export function handleRoleGranted(event: RoleGranted): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     event.params.role,
     account.id
   );
@@ -409,6 +413,7 @@ export function handleRoleRevoked(event: RoleRevoked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     event.params.role,
     account.id
   );
@@ -495,6 +500,7 @@ export function handleApproval(event: Approval): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     owner.id,
     spender.id,
     event.params.value,
@@ -546,6 +552,7 @@ export function handleRoleAdminChanged(event: RoleAdminChanged): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     event.params.role,
     event.params.previousAdminRole,
     event.params.newAdminRole
@@ -618,7 +625,13 @@ export function handlePaused(event: Paused): void {
     }
   }
 
-  pausedEvent(eventId(event), event.block.timestamp, event.address, sender.id);
+  pausedEvent(
+    eventId(event),
+    event.block.timestamp,
+    event.address,
+    sender.id,
+    AssetType.equity
+  );
   accountActivityEvent(
     sender,
     EventName.Paused,
@@ -677,7 +690,8 @@ export function handleUnpaused(event: Unpaused): void {
     eventId(event),
     event.block.timestamp,
     event.address,
-    sender.id
+    sender.id,
+    AssetType.equity
   );
   accountActivityEvent(
     sender,
@@ -730,6 +744,7 @@ export function handleTokensFrozen(event: TokensFrozen): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     user.id,
     event.params.amount,
     equity.decimals
@@ -775,6 +790,7 @@ export function handleUserBlocked(event: UserBlocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     user.id
   );
   accountActivityEvent(
@@ -817,6 +833,7 @@ export function handleUserUnblocked(event: UserUnblocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.equity,
     user.id
   );
   accountActivityEvent(

--- a/kit/subgraph/src/assets/events/approval.ts
+++ b/kit/subgraph/src/assets/events/approval.ts
@@ -8,10 +8,11 @@ export function approvalEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   owner: Bytes,
   spender: Bytes,
   value: BigInt,
-  decimals: i32,
+  decimals: i32
 ): ApprovalEvent {
   const event = new ApprovalEvent(id);
   event.eventName = EventName.Approval;
@@ -20,6 +21,7 @@ export function approvalEvent(
   event.sender = sender;
   event.owner = owner;
   event.spender = spender;
+  event.assetType = assetType;
   event.valueExact = value;
   event.value = toDecimals(value, decimals);
   event.save();

--- a/kit/subgraph/src/assets/events/assetcreated.ts
+++ b/kit/subgraph/src/assets/events/assetcreated.ts
@@ -7,12 +7,14 @@ export function assetCreatedEvent(
   timestamp: BigInt,
   asset: Bytes,
   sender: Bytes,
+  assetType: string
 ): AssetCreatedEvent {
   const assetCreatedEvent = new AssetCreatedEvent(id);
   assetCreatedEvent.eventName = EventName.AssetCreated;
   assetCreatedEvent.timestamp = timestamp;
   assetCreatedEvent.emitter = asset;
   assetCreatedEvent.sender = sender;
+  assetCreatedEvent.assetType = assetType;
   assetCreatedEvent.save();
   return assetCreatedEvent;
 }

--- a/kit/subgraph/src/assets/events/bondmatured.ts
+++ b/kit/subgraph/src/assets/events/bondmatured.ts
@@ -1,18 +1,19 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { BondMaturedEvent } from "../../../generated/schema";
-import { EventName } from "../../utils/enums";
+import { AssetType, EventName } from "../../utils/enums";
 
 export function bondMaturedEvent(
   id: Bytes,
   timestamp: BigInt,
   emitter: Bytes,
-  sender: Bytes,
+  sender: Bytes
 ): BondMaturedEvent {
   const event = new BondMaturedEvent(id);
   event.eventName = EventName.BondMatured;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.bond;
   event.save();
   return event;
 }

--- a/kit/subgraph/src/assets/events/bondredeemed.ts
+++ b/kit/subgraph/src/assets/events/bondredeemed.ts
@@ -1,7 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { BondRedeemedEvent } from "../../../generated/schema";
 import { toDecimals } from "../../utils/decimals";
-import { EventName } from "../../utils/enums";
+import { AssetType, EventName } from "../../utils/enums";
 
 export function bondRedeemedEvent(
   id: Bytes,
@@ -11,13 +11,14 @@ export function bondRedeemedEvent(
   holder: Bytes,
   bondAmount: BigInt,
   underlyingAmount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): BondRedeemedEvent {
   const event = new BondRedeemedEvent(id);
   event.eventName = EventName.BondRedeemed;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.bond;
   event.holder = holder;
   event.bondAmount = toDecimals(bondAmount, decimals);
   event.bondAmountExact = bondAmount;

--- a/kit/subgraph/src/assets/events/burn.ts
+++ b/kit/subgraph/src/assets/events/burn.ts
@@ -8,15 +8,17 @@ export function burnEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   from: Bytes,
   value: BigInt,
-  decimals: number,
+  decimals: number
 ): BurnEvent {
   const burnEvent = new BurnEvent(id);
   burnEvent.eventName = EventName.Burn;
   burnEvent.timestamp = timestamp;
   burnEvent.emitter = emitter;
   burnEvent.sender = sender;
+  burnEvent.assetType = assetType;
   burnEvent.from = from;
   burnEvent.value = toDecimals(value, decimals);
   burnEvent.valueExact = value;

--- a/kit/subgraph/src/assets/events/managementfeecollected.ts
+++ b/kit/subgraph/src/assets/events/managementfeecollected.ts
@@ -1,7 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { ManagementFeeCollectedEvent } from "../../../generated/schema";
 import { toDecimals } from "../../utils/decimals";
-import { EventName } from "../../utils/enums";
+import { AssetType, EventName } from "../../utils/enums";
 
 export function managementFeeCollectedEvent(
   id: Bytes,
@@ -9,13 +9,14 @@ export function managementFeeCollectedEvent(
   emitter: Bytes,
   sender: Bytes,
   amount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): ManagementFeeCollectedEvent {
   const event = new ManagementFeeCollectedEvent(id);
   event.eventName = EventName.ManagementFeeCollected;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.fund;
   event.amount = toDecimals(amount, decimals);
   event.amountExact = amount;
   event.save();

--- a/kit/subgraph/src/assets/events/mint.ts
+++ b/kit/subgraph/src/assets/events/mint.ts
@@ -8,15 +8,17 @@ export function mintEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   to: Bytes,
   value: BigInt,
-  decimals: number,
+  decimals: number
 ): MintEvent {
   const mintEvent = new MintEvent(id);
   mintEvent.eventName = EventName.Mint;
   mintEvent.timestamp = timestamp;
   mintEvent.emitter = emitter;
   mintEvent.sender = sender;
+  mintEvent.assetType = assetType;
   mintEvent.to = to;
   mintEvent.value = toDecimals(value, decimals);
   mintEvent.valueExact = value;

--- a/kit/subgraph/src/assets/events/paused.ts
+++ b/kit/subgraph/src/assets/events/paused.ts
@@ -7,12 +7,14 @@ export function pausedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string
 ): PausedEvent {
   const event = new PausedEvent(id);
   event.eventName = EventName.Paused;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.save();
   return event;
 }

--- a/kit/subgraph/src/assets/events/performancefeecollected.ts
+++ b/kit/subgraph/src/assets/events/performancefeecollected.ts
@@ -1,7 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { PerformanceFeeCollectedEvent } from "../../../generated/schema";
 import { toDecimals } from "../../utils/decimals";
-import { EventName } from "../../utils/enums";
+import { AssetType, EventName } from "../../utils/enums";
 
 export function performanceFeeCollectedEvent(
   id: Bytes,
@@ -9,13 +9,14 @@ export function performanceFeeCollectedEvent(
   emitter: Bytes,
   sender: Bytes,
   amount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): PerformanceFeeCollectedEvent {
   const event = new PerformanceFeeCollectedEvent(id);
   event.eventName = EventName.PerformanceFeeCollected;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.fund;
   event.amount = toDecimals(amount, decimals);
   event.amountExact = amount;
   event.save();

--- a/kit/subgraph/src/assets/events/roleadminchanged.ts
+++ b/kit/subgraph/src/assets/events/roleadminchanged.ts
@@ -7,15 +7,17 @@ export function roleAdminChangedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   role: Bytes,
   previousAdminRole: Bytes,
-  newAdminRole: Bytes,
+  newAdminRole: Bytes
 ): RoleAdminChangedEvent {
   const event = new RoleAdminChangedEvent(id);
   event.eventName = EventName.RoleAdminChanged;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.role = role;
   event.previousAdminRole = previousAdminRole;
   event.newAdminRole = newAdminRole;

--- a/kit/subgraph/src/assets/events/rolegranted.ts
+++ b/kit/subgraph/src/assets/events/rolegranted.ts
@@ -7,14 +7,16 @@ export function roleGrantedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   role: Bytes,
-  account: Bytes,
+  account: Bytes
 ): RoleGrantedEvent {
   const roleGrantedEvent = new RoleGrantedEvent(id);
   roleGrantedEvent.eventName = EventName.RoleGranted;
   roleGrantedEvent.timestamp = timestamp;
   roleGrantedEvent.emitter = emitter;
   roleGrantedEvent.sender = sender;
+  roleGrantedEvent.assetType = assetType;
   roleGrantedEvent.role = role;
   roleGrantedEvent.account = account;
   roleGrantedEvent.save();

--- a/kit/subgraph/src/assets/events/rolerevoked.ts
+++ b/kit/subgraph/src/assets/events/rolerevoked.ts
@@ -7,14 +7,16 @@ export function roleRevokedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   role: Bytes,
-  account: Bytes,
+  account: Bytes
 ): RoleRevokedEvent {
   const roleRevokedEvent = new RoleRevokedEvent(id);
   roleRevokedEvent.eventName = EventName.RoleRevoked;
   roleRevokedEvent.timestamp = timestamp;
   roleRevokedEvent.emitter = emitter;
   roleRevokedEvent.sender = sender;
+  roleRevokedEvent.assetType = assetType;
   roleRevokedEvent.role = role;
   roleRevokedEvent.account = account;
   roleRevokedEvent.save();

--- a/kit/subgraph/src/assets/events/stablecoincollateralupdated.ts
+++ b/kit/subgraph/src/assets/events/stablecoincollateralupdated.ts
@@ -1,8 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { CollateralUpdatedEvent } from "../../../generated/schema";
 import { toDecimals } from "../../utils/decimals";
-import { EventName } from "../../utils/enums";
-
+import { AssetType, EventName } from "../../utils/enums";
 export function stablecoinCollateralUpdatedEvent(
   id: Bytes,
   timestamp: BigInt,
@@ -10,13 +9,14 @@ export function stablecoinCollateralUpdatedEvent(
   sender: Bytes,
   oldAmount: BigInt,
   newAmount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): void {
   const event = new CollateralUpdatedEvent(id);
   event.eventName = EventName.CollateralUpdated;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.stablecoin;
   event.oldAmount = toDecimals(oldAmount, decimals);
   event.oldAmountExact = oldAmount;
   event.newAmount = toDecimals(newAmount, decimals);

--- a/kit/subgraph/src/assets/events/tokensfrozen.ts
+++ b/kit/subgraph/src/assets/events/tokensfrozen.ts
@@ -8,15 +8,17 @@ export function tokensFrozenEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   user: Bytes,
   amount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): TokensFrozenEvent {
   const event = new TokensFrozenEvent(id);
   event.eventName = EventName.TokensFrozen;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.user = user;
   event.amount = toDecimals(amount, decimals);
   event.amountExact = amount;

--- a/kit/subgraph/src/assets/events/tokenwithdrawn.ts
+++ b/kit/subgraph/src/assets/events/tokenwithdrawn.ts
@@ -8,16 +8,18 @@ export function tokenWithdrawnEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   token: Bytes,
   to: Bytes,
   amount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): TokenWithdrawnEvent {
   const event = new TokenWithdrawnEvent(id);
   event.eventName = EventName.TokenWithdrawn;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.token = token;
   event.to = to;
   event.amount = toDecimals(amount, decimals);

--- a/kit/subgraph/src/assets/events/transfer.ts
+++ b/kit/subgraph/src/assets/events/transfer.ts
@@ -8,16 +8,18 @@ export function transferEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string,
   from: Bytes,
   to: Bytes,
   value: BigInt,
-  decimals: number,
+  decimals: number
 ): TransferEvent {
   const transferEvent = new TransferEvent(id);
   transferEvent.eventName = EventName.Transfer;
   transferEvent.timestamp = timestamp;
   transferEvent.emitter = emitter;
   transferEvent.sender = sender;
+  transferEvent.assetType = assetType;
   transferEvent.from = from;
   transferEvent.to = to;
   transferEvent.value = toDecimals(value, decimals);

--- a/kit/subgraph/src/assets/events/underlyingassettopup.ts
+++ b/kit/subgraph/src/assets/events/underlyingassettopup.ts
@@ -1,7 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { UnderlyingAssetTopUpEvent } from "../../../generated/schema";
 import { toDecimals } from "../../utils/decimals";
-import { EventName } from "../../utils/enums";
+import { AssetType, EventName } from "../../utils/enums";
 
 export function underlyingAssetTopUpEvent(
   id: Bytes,
@@ -10,13 +10,14 @@ export function underlyingAssetTopUpEvent(
   sender: Bytes,
   from: Bytes,
   amount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): UnderlyingAssetTopUpEvent {
   const event = new UnderlyingAssetTopUpEvent(id);
   event.eventName = EventName.UnderlyingAssetTopUp;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.bond;
   event.from = from;
   event.amount = toDecimals(amount, decimals);
   event.amountExact = amount;

--- a/kit/subgraph/src/assets/events/underlyingassetwithdrawn.ts
+++ b/kit/subgraph/src/assets/events/underlyingassetwithdrawn.ts
@@ -1,7 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { UnderlyingAssetWithdrawnEvent } from "../../../generated/schema";
 import { toDecimals } from "../../utils/decimals";
-import { EventName } from "../../utils/enums";
+import { AssetType, EventName } from "../../utils/enums";
 
 export function underlyingAssetWithdrawnEvent(
   id: Bytes,
@@ -10,13 +10,14 @@ export function underlyingAssetWithdrawnEvent(
   sender: Bytes,
   to: Bytes,
   amount: BigInt,
-  decimals: i32,
+  decimals: i32
 ): UnderlyingAssetWithdrawnEvent {
   const event = new UnderlyingAssetWithdrawnEvent(id);
   event.eventName = EventName.UnderlyingAssetWithdrawn;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = AssetType.bond;
   event.to = to;
   event.amount = toDecimals(amount, decimals);
   event.amountExact = amount;

--- a/kit/subgraph/src/assets/events/unpaused.ts
+++ b/kit/subgraph/src/assets/events/unpaused.ts
@@ -7,12 +7,14 @@ export function unpausedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
+  assetType: string
 ): UnpausedEvent {
   const event = new UnpausedEvent(id);
   event.eventName = EventName.Unpaused;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.save();
   return event;
 }

--- a/kit/subgraph/src/assets/events/userblocked.ts
+++ b/kit/subgraph/src/assets/events/userblocked.ts
@@ -7,13 +7,15 @@ export function userBlockedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
-  user: Bytes,
+  assetType: string,
+  user: Bytes
 ): UserBlockedEvent {
   const event = new UserBlockedEvent(id);
   event.eventName = EventName.UserBlocked;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.user = user;
   event.save();
 

--- a/kit/subgraph/src/assets/events/userunblocked.ts
+++ b/kit/subgraph/src/assets/events/userunblocked.ts
@@ -7,13 +7,15 @@ export function userUnblockedEvent(
   timestamp: BigInt,
   emitter: Bytes,
   sender: Bytes,
-  user: Bytes,
+  assetType: string,
+  user: Bytes
 ): UserUnblockedEvent {
   const event = new UserUnblockedEvent(id);
   event.eventName = EventName.UserUnblocked;
   event.timestamp = timestamp;
   event.emitter = emitter;
   event.sender = sender;
+  event.assetType = assetType;
   event.user = user;
   event.save();
 

--- a/kit/subgraph/src/assets/fund.ts
+++ b/kit/subgraph/src/assets/fund.ts
@@ -68,6 +68,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.fund,
       to.id,
       event.params.value,
       fund.decimals
@@ -137,6 +138,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.fund,
       from.id,
       event.params.value,
       fund.decimals
@@ -213,6 +215,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.fund,
       from.id,
       to.id,
       event.params.value,
@@ -328,6 +331,7 @@ export function handleRoleGranted(event: RoleGranted): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     event.params.role,
     account.id
   );
@@ -415,6 +419,7 @@ export function handleRoleRevoked(event: RoleRevoked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     event.params.role,
     account.id
   );
@@ -500,6 +505,7 @@ export function handleApproval(event: Approval): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     owner.id,
     spender.id,
     event.params.value,
@@ -548,6 +554,7 @@ export function handleRoleAdminChanged(event: RoleAdminChanged): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     event.params.role,
     event.params.previousAdminRole,
     event.params.newAdminRole
@@ -620,7 +627,13 @@ export function handlePaused(event: Paused): void {
     }
   }
 
-  pausedEvent(eventId(event), event.block.timestamp, event.address, sender.id);
+  pausedEvent(
+    eventId(event),
+    event.block.timestamp,
+    event.address,
+    sender.id,
+    AssetType.fund
+  );
   accountActivityEvent(
     sender,
     EventName.Paused,
@@ -679,7 +692,8 @@ export function handleUnpaused(event: Unpaused): void {
     eventId(event),
     event.block.timestamp,
     event.address,
-    sender.id
+    sender.id,
+    AssetType.fund
   );
   accountActivityEvent(
     sender,
@@ -730,6 +744,7 @@ export function handleTokensFrozen(event: TokensFrozen): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     user.id,
     event.params.amount,
     fund.decimals
@@ -774,6 +789,7 @@ export function handleUserBlocked(event: UserBlocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     user.id
   );
   accountActivityEvent(
@@ -816,6 +832,7 @@ export function handleUserUnblocked(event: UserUnblocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     user.id
   );
   accountActivityEvent(
@@ -931,6 +948,7 @@ export function handleTokenWithdrawn(event: TokenWithdrawn): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.fund,
     token.id,
     to.id,
     event.params.amount,

--- a/kit/subgraph/src/assets/stablecoin.ts
+++ b/kit/subgraph/src/assets/stablecoin.ts
@@ -60,6 +60,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.stablecoin,
       to.id,
       event.params.value,
       stableCoin.decimals
@@ -145,6 +146,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.stablecoin,
       from.id,
       event.params.value,
       stableCoin.decimals
@@ -240,6 +242,7 @@ export function handleTransfer(event: Transfer): void {
       event.block.timestamp,
       event.address,
       sender.id,
+      AssetType.stablecoin,
       from.id,
       to.id,
       event.params.value,
@@ -364,6 +367,7 @@ export function handleRoleGranted(event: RoleGranted): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     event.params.role,
     account.id
   );
@@ -456,6 +460,7 @@ export function handleRoleRevoked(event: RoleRevoked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     event.params.role,
     account.id
   );
@@ -549,6 +554,7 @@ export function handleApproval(event: Approval): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     owner.id,
     spender.id,
     event.params.value,
@@ -599,6 +605,7 @@ export function handleRoleAdminChanged(event: RoleAdminChanged): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     event.params.role,
     event.params.previousAdminRole,
     event.params.newAdminRole
@@ -671,7 +678,13 @@ export function handlePaused(event: Paused): void {
     }
   }
 
-  pausedEvent(eventId(event), event.block.timestamp, event.address, sender.id);
+  pausedEvent(
+    eventId(event),
+    event.block.timestamp,
+    event.address,
+    sender.id,
+    AssetType.stablecoin
+  );
   accountActivityEvent(
     sender,
     EventName.Paused,
@@ -730,7 +743,8 @@ export function handleUnpaused(event: Unpaused): void {
     eventId(event),
     event.block.timestamp,
     event.address,
-    sender.id
+    sender.id,
+    AssetType.stablecoin
   );
   accountActivityEvent(
     sender,
@@ -782,6 +796,7 @@ export function handleTokensFrozen(event: TokensFrozen): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     user.id,
     event.params.amount,
     stableCoin.decimals
@@ -830,6 +845,7 @@ export function handleUserBlocked(event: UserBlocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     user.id
   );
   accountActivityEvent(
@@ -879,6 +895,7 @@ export function handleUserUnblocked(event: UserUnblocked): void {
     event.block.timestamp,
     event.address,
     sender.id,
+    AssetType.stablecoin,
     user.id
   );
   accountActivityEvent(

--- a/kit/subgraph/src/factories/bond-factory.ts
+++ b/kit/subgraph/src/factories/bond-factory.ts
@@ -24,7 +24,8 @@ export function handleBondCreated(event: BondCreated): void {
     eventId(event),
     event.block.timestamp,
     asset.id,
-    creator.id
+    creator.id,
+    AssetType.bond
   );
   accountActivityEvent(
     creator,

--- a/kit/subgraph/src/factories/cryptocurrency-factory.ts
+++ b/kit/subgraph/src/factories/cryptocurrency-factory.ts
@@ -26,7 +26,8 @@ export function handleCryptoCurrencyCreated(
     eventId(event),
     event.block.timestamp,
     asset.id,
-    creator.id
+    creator.id,
+    AssetType.cryptocurrency
   );
   accountActivityEvent(
     creator,

--- a/kit/subgraph/src/factories/equity-factory.ts
+++ b/kit/subgraph/src/factories/equity-factory.ts
@@ -24,7 +24,8 @@ export function handleEquityCreated(event: EquityCreated): void {
     eventId(event),
     event.block.timestamp,
     asset.id,
-    creator.id
+    creator.id,
+    AssetType.equity
   );
   accountActivityEvent(
     creator,

--- a/kit/subgraph/src/factories/fund-factory.ts
+++ b/kit/subgraph/src/factories/fund-factory.ts
@@ -24,7 +24,8 @@ export function handleFundCreated(event: FundCreated): void {
     eventId(event),
     event.block.timestamp,
     asset.id,
-    creator.id
+    creator.id,
+    AssetType.fund
   );
   accountActivityEvent(
     creator,

--- a/kit/subgraph/src/factories/stablecoin-factory.ts
+++ b/kit/subgraph/src/factories/stablecoin-factory.ts
@@ -24,7 +24,8 @@ export function handleStableCoinCreated(event: StableCoinCreated): void {
     eventId(event),
     event.block.timestamp,
     asset.id,
-    creator.id
+    creator.id,
+    AssetType.stablecoin
   );
   accountActivityEvent(
     creator,


### PR DESCRIPTION
## Summary by Sourcery

Adds the asset type to asset events in the subgraph.

Enhancements:
- Adds an assetType field to the AssetEvent interface and its implementations to track the type of asset affected by an event.
- Modifies event handlers for different asset types (bond, fund, equity, stablecoin, cryptocurrency) to include the corresponding AssetType when creating event entities.