### PR TITLE
fix: tablink focus color

### DIFF
--- a/kit/dapp/src/app/globals.css
+++ b/kit/dapp/src/app/globals.css
@@ -46,7 +46,7 @@ h3: text-xl
   --muted: var(--sm-muted);
   --muted-foreground: var(--sm-muted);
   --accent: var(--sm-accent);
-  --accent-foreground: var(--sm-background-gradient-start);
+  --accent-foreground: var(--sm-text);
   --accent-hover: var(--sm-accent-hover);
   --destructive: var(--sm-state-error-background);
   --destructive-foreground: var(--sm-state-error);

--- a/kit/dapp/src/components/blocks/charts/pie-chart.tsx
+++ b/kit/dapp/src/components/blocks/charts/pie-chart.tsx
@@ -62,9 +62,9 @@ export function PieChartComponent({
               {data.map((entry, index) => (
                 <Cell
                   key={`cell-${index}`}
-                  fill={config[entry[nameKey]].color}
+                  fill={config[entry[nameKey]]?.color}
                   fillOpacity={0.5}
-                  stroke={config[entry[nameKey]].color}
+                  stroke={config[entry[nameKey]]?.color}
                 />
               ))}
             </Pie>


### PR DESCRIPTION
## Summary by Sourcery

Fixes the tab link focus color and addresses a potential issue in the PieChart component where the color configuration might be undefined.

Bug Fixes:
- Corrects the accent foreground color to ensure proper focus indication for tab links.
- Adds a check for undefined color configuration in the PieChart component to prevent potential errors.