### PR TITLE
fix: [object Object] in holder, asset type columns

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/holders/_components/columns.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/holders/_components/columns.tsx
@@ -45,9 +45,12 @@ export function columns() {
         variant: 'numeric',
       },
     }),
-    columnHelper.accessor((row) => <ColumnHolderType assetBalance={row} />, {
+    columnHelper.accessor('asset', {
       id: t('holder-type-header'),
       header: t('holder-type-header'),
+      cell: ({ row }) => {
+        return <ColumnHolderType assetBalance={row.original} />;
+      },
     }),
     columnHelper.accessor('frozen', {
       header: t('frozen-header'),

--- a/kit/dapp/src/components/blocks/asset-info/column-holder-type.ts
+++ b/kit/dapp/src/components/blocks/asset-info/column-holder-type.ts
@@ -9,7 +9,6 @@ interface HolderTypeProps {
 
 export function ColumnHolderType({ assetBalance }: HolderTypeProps) {
   const t = useTranslations('asset-info');
-
   if (assetBalance.asset.creator.id === assetBalance.account.id) {
     return t('creator-owner');
   }

--- a/kit/dapp/src/components/blocks/my-assets-table/my-assets-table-columns-small.tsx
+++ b/kit/dapp/src/components/blocks/my-assets-table/my-assets-table-columns-small.tsx
@@ -20,13 +20,13 @@ export function columnsSmall() {
       header: t('symbol-header'),
       enableColumnFilter: false,
     }),
-    columnHelper.accessor(
-      (row) => <ColumnAssetType assettype={row.asset.type} />,
-      {
-        id: t('type-header'),
-        header: t('type-header'),
-      }
-    ),
+    columnHelper.accessor('asset.type', {
+      id: t('type-header'),
+      header: t('type-header'),
+      cell: ({ getValue }) => {
+        return <ColumnAssetType assettype={getValue()} />;
+      },
+    }),
     columnHelper.accessor('value', {
       header: t('balance-header'),
       meta: {

--- a/kit/dapp/src/components/blocks/user-assets-table/user-assets-table-columns.tsx
+++ b/kit/dapp/src/components/blocks/user-assets-table/user-assets-table-columns.tsx
@@ -24,13 +24,13 @@ export function columns() {
       header: t('symbol-header'),
       enableColumnFilter: false,
     }),
-    columnHelper.accessor(
-      (row) => <ColumnAssetType assettype={row.asset.type} />,
-      {
-        id: t('type-header'),
-        header: t('type-header'),
-      }
-    ),
+    columnHelper.accessor('asset.type', {
+      id: t('type-header'),
+      header: t('type-header'),
+      cell: ({ getValue }) => {
+        return <ColumnAssetType assettype={getValue()} />;
+      },
+    }),
     columnHelper.accessor('value', {
       header: t('balance-header'),
       meta: {
@@ -40,9 +40,12 @@ export function columns() {
         formatNumber(getValue(), { token: row.original.asset.symbol }),
       enableColumnFilter: false,
     }),
-    columnHelper.accessor((row) => <ColumnHolderType assetBalance={row} />, {
+    columnHelper.accessor('asset', {
       id: t('holder-type-header'),
       header: t('holder-type-header'),
+      cell: ({ row }) => {
+        return <ColumnHolderType assetBalance={row.original} />;
+      },
     }),
     columnHelper.accessor((row) => <ColumnAssetStatus assetOrBalance={row} />, {
       id: t('status-header'),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes the display of '[object Object]' in the holder and asset type columns.