### PR TITLE
feat: allow to set an initial price

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -688,7 +688,8 @@
             "isin-label": "ISIN",
             "name-label": "Name",
             "seconds-unit-label": "seconds",
-            "symbol-label": "Symbol"
+            "symbol-label": "Symbol",
+            "value-in-base-currency-label": "Value in {baseCurrency}"
           },
           "cryptocurrencies": {
             "initial-supply-description": "Initial amount of tokens to be minted",
@@ -1234,6 +1235,7 @@
         "not-available": "N/A",
         "ownership-concentration": "Ownership concentration",
         "ownership-concentration-info": "Percentage owned by the top 5 holders",
+        "price-header": "Price",
         "proven-collateral": "Proven collateral",
         "proven-collateral-info": "The amount of collateral that has been proven to be held by the token",
         "redeemed": "Redeemed",

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/bonds.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/bonds.tsx
@@ -5,6 +5,7 @@ import { ColumnAssetStatus } from "@/components/blocks/asset-info/column-asset-s
 import { DataTableRowActions } from "@/components/blocks/data-table/data-table-row-actions";
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { getBondList } from "@/lib/queries/bond/bond-list";
 import { formatNumber } from "@/lib/utils/number";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -13,7 +14,7 @@ import { useTranslations } from "next-intl";
 const columnHelper =
   createColumnHelper<Awaited<ReturnType<typeof getBondList>>[number]>();
 
-export function bondColumns() {
+export function bondColumns({ baseCurrency }: { baseCurrency: CurrencyCode }) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const t = useTranslations("private.assets.fields");
 
@@ -35,6 +36,15 @@ export function bondColumns() {
     columnHelper.accessor("symbol", {
       header: t("symbol-header"),
       cell: ({ getValue }) => getValue(),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor("value_in_base_currency", {
+      header: t("price-header"),
+      cell: ({ getValue }) =>
+        formatNumber(getValue(), {
+          currency: baseCurrency,
+          decimals: 2,
+        }),
       enableColumnFilter: false,
     }),
     columnHelper.accessor("totalSupply", {

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/cryptocurrencies.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/cryptocurrencies.tsx
@@ -3,6 +3,7 @@
 import { DataTableRowActions } from "@/components/blocks/data-table/data-table-row-actions";
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { getCryptoCurrencyList } from "@/lib/queries/cryptocurrency/cryptocurrency-list";
 import { formatNumber } from "@/lib/utils/number";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -13,7 +14,11 @@ const columnHelper =
     Awaited<ReturnType<typeof getCryptoCurrencyList>>[number]
   >();
 
-export function cryptocurrencyColumns() {
+export function cryptocurrencyColumns({
+  baseCurrency,
+}: {
+  baseCurrency: CurrencyCode;
+}) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const t = useTranslations("private.assets.fields");
 
@@ -35,6 +40,15 @@ export function cryptocurrencyColumns() {
     columnHelper.accessor("symbol", {
       header: t("symbol-header"),
       cell: ({ getValue }) => getValue(),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor("value_in_base_currency", {
+      header: t("price-header"),
+      cell: ({ getValue }) =>
+        formatNumber(getValue(), {
+          currency: baseCurrency,
+          decimals: 2,
+        }),
       enableColumnFilter: false,
     }),
     columnHelper.accessor("totalSupply", {

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/equities.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/equities.tsx
@@ -5,6 +5,7 @@ import { ColumnAssetStatus } from "@/components/blocks/asset-info/column-asset-s
 import { DataTableRowActions } from "@/components/blocks/data-table/data-table-row-actions";
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { getEquityList } from "@/lib/queries/equity/equity-list";
 import { formatNumber } from "@/lib/utils/number";
 import type { equityCategories, equityClasses } from "@/lib/utils/zod";
@@ -17,7 +18,11 @@ const columnHelper =
 type EquityCategory = (typeof equityCategories)[number];
 type EquityClass = (typeof equityClasses)[number];
 
-export function equityColumns() {
+export function equityColumns({
+  baseCurrency,
+}: {
+  baseCurrency: CurrencyCode;
+}) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const t = useTranslations("private.assets.fields");
 
@@ -107,12 +112,13 @@ export function equityColumns() {
       cell: ({ getValue }) => getValue(),
       enableColumnFilter: false,
     }),
-    columnHelper.accessor("totalSupply", {
-      header: t("total-supply-header"),
-      meta: {
-        variant: "numeric",
-      },
-      cell: ({ getValue }) => formatNumber(getValue()),
+    columnHelper.accessor("value_in_base_currency", {
+      header: t("price-header"),
+      cell: ({ getValue }) =>
+        formatNumber(getValue(), {
+          currency: baseCurrency,
+          decimals: 2,
+        }),
       enableColumnFilter: false,
     }),
     columnHelper.accessor("equityCategory", {

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/funds.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/funds.tsx
@@ -5,6 +5,7 @@ import { ColumnAssetStatus } from "@/components/blocks/asset-info/column-asset-s
 import { DataTableRowActions } from "@/components/blocks/data-table/data-table-row-actions";
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { getFundList } from "@/lib/queries/fund/fund-list";
 import { formatNumber } from "@/lib/utils/number";
 import type { fundCategories, fundClasses } from "@/lib/utils/zod";
@@ -17,7 +18,7 @@ const columnHelper =
 type FundCategory = (typeof fundCategories)[number];
 type FundClass = (typeof fundClasses)[number];
 
-export function fundColumns() {
+export function fundColumns({ baseCurrency }: { baseCurrency: CurrencyCode }) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const t = useTranslations("private.assets.fields");
 
@@ -88,6 +89,15 @@ export function fundColumns() {
     columnHelper.accessor("symbol", {
       header: t("symbol-header"),
       cell: ({ getValue }) => getValue(),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor("value_in_base_currency", {
+      header: t("price-header"),
+      cell: ({ getValue }) =>
+        formatNumber(getValue(), {
+          currency: baseCurrency,
+          decimals: 2,
+        }),
       enableColumnFilter: false,
     }),
     columnHelper.accessor("totalSupply", {

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/stablecoins.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/stablecoins.tsx
@@ -6,6 +6,7 @@ import { DataTableRowActions } from "@/components/blocks/data-table/data-table-r
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
 import { PercentageProgressBar } from "@/components/blocks/percentage-progress/percentage-progress";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { getStableCoinList } from "@/lib/queries/stablecoin/stablecoin-list";
 import { formatNumber } from "@/lib/utils/number";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -14,7 +15,11 @@ import { useTranslations } from "next-intl";
 const columnHelper =
   createColumnHelper<Awaited<ReturnType<typeof getStableCoinList>>[number]>();
 
-export function stablecoinColumns() {
+export function stablecoinColumns({
+  baseCurrency,
+}: {
+  baseCurrency: CurrencyCode;
+}) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const t = useTranslations("private.assets.fields");
 
@@ -36,6 +41,15 @@ export function stablecoinColumns() {
     columnHelper.accessor("symbol", {
       header: t("symbol-header"),
       cell: ({ getValue }) => getValue(),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor("value_in_base_currency", {
+      header: t("price-header"),
+      cell: ({ getValue }) =>
+        formatNumber(getValue(), {
+          currency: baseCurrency,
+          decimals: 2,
+        }),
       enableColumnFilter: false,
     }),
     columnHelper.accessor("totalSupply", {

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/tokenizeddeposits.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/columns/tokenizeddeposits.tsx
@@ -5,6 +5,7 @@ import { ColumnAssetStatus } from "@/components/blocks/asset-info/column-asset-s
 import { DataTableRowActions } from "@/components/blocks/data-table/data-table-row-actions";
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { getTokenizedDepositList } from "@/lib/queries/tokenizeddeposit/tokenizeddeposit-list";
 import { formatNumber } from "@/lib/utils/number";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -15,7 +16,11 @@ const columnHelper =
     Awaited<ReturnType<typeof getTokenizedDepositList>>[number]
   >();
 
-export function tokenizedDepositColumns() {
+export function tokenizedDepositColumns({
+  baseCurrency,
+}: {
+  baseCurrency: CurrencyCode;
+}) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const t = useTranslations("private.assets.fields");
 
@@ -37,6 +42,15 @@ export function tokenizedDepositColumns() {
     columnHelper.accessor("symbol", {
       header: t("symbol-header"),
       cell: ({ getValue }) => getValue(),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor("value_in_base_currency", {
+      header: t("price-header"),
+      cell: ({ getValue }) =>
+        formatNumber(getValue(), {
+          currency: baseCurrency,
+          decimals: 2,
+        }),
       enableColumnFilter: false,
     }),
     columnHelper.accessor("totalSupply", {

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/table.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/table.tsx
@@ -1,4 +1,6 @@
 import { DataTable } from "@/components/blocks/data-table/data-table";
+import { getSetting } from "@/lib/config/settings";
+import { SETTING_KEYS } from "@/lib/db/schema-settings";
 import { getBondList } from "@/lib/queries/bond/bond-list";
 import { getCryptoCurrencyList } from "@/lib/queries/cryptocurrency/cryptocurrency-list";
 import { getEquityList } from "@/lib/queries/equity/equity-list";
@@ -18,6 +20,8 @@ interface TableProps {
 }
 
 export async function Table({ assettype }: TableProps) {
+  const baseCurrency = await getSetting(SETTING_KEYS.BASE_CURRENCY);
+
   switch (assettype) {
     case "bond":
       return (
@@ -25,6 +29,7 @@ export async function Table({ assettype }: TableProps) {
           columns={bondColumns}
           data={await getBondList()}
           name={assettype}
+          columnParams={{ baseCurrency }}
         />
       );
     case "cryptocurrency":
@@ -33,6 +38,7 @@ export async function Table({ assettype }: TableProps) {
           columns={cryptocurrencyColumns}
           data={await getCryptoCurrencyList()}
           name={assettype}
+          columnParams={{ baseCurrency }}
         />
       );
     case "stablecoin":
@@ -41,6 +47,7 @@ export async function Table({ assettype }: TableProps) {
           columns={stablecoinColumns}
           data={await getStableCoinList()}
           name={assettype}
+          columnParams={{ baseCurrency }}
         />
       );
     case "tokenizeddeposit":
@@ -49,6 +56,7 @@ export async function Table({ assettype }: TableProps) {
           columns={tokenizedDepositColumns}
           data={await getTokenizedDepositList()}
           name={assettype}
+          columnParams={{ baseCurrency }}
         />
       );
     case "equity":
@@ -57,6 +65,7 @@ export async function Table({ assettype }: TableProps) {
           columns={equityColumns}
           data={await getEquityList()}
           name={assettype}
+          columnParams={{ baseCurrency }}
         />
       );
     case "fund":
@@ -65,6 +74,7 @@ export async function Table({ assettype }: TableProps) {
           columns={fundColumns}
           data={await getFundList()}
           name={assettype}
+          columnParams={{ baseCurrency }}
         />
       );
     default:

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-action.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-action.tsx
@@ -1,12 +1,12 @@
 "use server";
 
 import { setSetting } from "@/lib/config/settings";
-import { FiatCurrencies, SETTING_KEYS } from "@/lib/db/schema-settings";
+import { SETTING_KEYS } from "@/lib/db/schema-settings";
 import { action } from "@/lib/mutations/safe-action";
-import { z } from "zod";
+import { z } from "@/lib/utils/zod";
 
 const schema = z.object({
-  baseCurrency: z.enum(FiatCurrencies),
+  baseCurrency: z.fiatCurrency(),
 });
 
 export const updateSettings = action

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-form.tsx
@@ -16,15 +16,15 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { type CurrencyCode, FiatCurrencies } from "@/lib/db/schema-settings";
+import { z } from "@/lib/utils/zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
-import { z } from "zod";
 import { updateSettings } from "./settings-action";
 
 const schema = z.object({
-  baseCurrency: z.enum(FiatCurrencies),
+  baseCurrency: z.fiatCurrency(),
 });
 
 const currencyKeys = {

--- a/kit/dapp/src/components/blocks/create-forms/bonds/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bonds/form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from "@/components/blocks/form/form";
 import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { useSettings } from "@/hooks/use-settings";
 import { createBond } from "@/lib/mutations/bond/create/create-action";
 import { CreateBondSchema } from "@/lib/mutations/bond/create/create-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,7 @@ export function CreateBondForm({
   const isExternallyControlled =
     open !== undefined && onOpenChange !== undefined;
   const [localOpen, setLocalOpen] = useState(false);
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormSheet
@@ -45,13 +47,15 @@ export function CreateBondForm({
         buttonLabels={{
           label: t("trigger-label.bonds"),
         }}
-        defaultValues={{}}
+        defaultValues={{
+          valueInBaseCurrency: 1,
+        }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);
         }}
       >
         <Basics />
-        <Configuration />
+        <Configuration baseCurrency={baseCurrency} />
         <Summary />
       </Form>
     </FormSheet>

--- a/kit/dapp/src/components/blocks/create-forms/bonds/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bonds/steps/configuration.tsx
@@ -1,11 +1,16 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormAssets } from "@/components/blocks/form/inputs/form-assets";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { CreateBondInput } from "@/lib/mutations/bond/create/create-schema";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function Configuration() {
+interface ConfigurationProps {
+  baseCurrency: CurrencyCode;
+}
+
+export function Configuration({ baseCurrency }: ConfigurationProps) {
   const { control } = useFormContext<CreateBondInput>();
   const t = useTranslations("private.assets.create");
 
@@ -43,6 +48,16 @@ export function Configuration() {
           name="underlyingAsset"
           label={t("parameters.bonds.underlying-asset-label")}
           description={t("parameters.bonds.underlying-asset-description")}
+          required
+        />
+        <FormInput
+          control={control}
+          name="valueInBaseCurrency"
+          type="number"
+          step={0.01}
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
           required
         />
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/bonds/steps/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bonds/steps/summary.tsx
@@ -1,6 +1,7 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormSummaryDetailCard } from "@/components/blocks/form/summary/card";
 import { FormSummaryDetailItem } from "@/components/blocks/form/summary/item";
+import { useSettings } from "@/hooks/use-settings";
 import type { CreateBondInput } from "@/lib/mutations/bond/create/create-schema";
 import { getPredictedAddress } from "@/lib/queries/bond-factory/predict-address";
 import { formatDate } from "@/lib/utils/date";
@@ -14,6 +15,7 @@ export function Summary() {
     control: control,
   });
   const t = useTranslations("private.assets.create");
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormStep title={t("summary.title")} description={t("summary.description")}>
@@ -60,6 +62,12 @@ export function Summary() {
         <FormSummaryDetailItem
           label={t("parameters.bonds.underlying-asset-label")}
           value={values.underlyingAsset || "-"}
+        />
+        <FormSummaryDetailItem
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          value={values.valueInBaseCurrency || "-"}
         />
       </FormSummaryDetailCard>
     </FormStep>

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from "@/components/blocks/form/form";
 import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { useSettings } from "@/hooks/use-settings";
 import { createCryptoCurrency } from "@/lib/mutations/cryptocurrency/create/create-action";
 import { CreateCryptoCurrencySchema } from "@/lib/mutations/cryptocurrency/create/create-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,7 @@ export function CreateCryptoCurrencyForm({
   const isExternallyControlled =
     open !== undefined && onOpenChange !== undefined;
   const [localOpen, setLocalOpen] = useState(false);
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormSheet
@@ -45,13 +47,15 @@ export function CreateCryptoCurrencyForm({
         buttonLabels={{
           label: t("trigger-label.cryptocurrencies"),
         }}
-        defaultValues={{}}
+        defaultValues={{
+          valueInBaseCurrency: 1,
+        }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);
         }}
       >
         <Basics />
-        <Configuration />
+        <Configuration baseCurrency={baseCurrency} />
         <Summary />
       </Form>
     </FormSheet>

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/steps/configuration.tsx
@@ -1,10 +1,15 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { CreateCryptoCurrencyInput } from "@/lib/mutations/cryptocurrency/create/create-schema";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function Configuration() {
+interface ConfigurationProps {
+  baseCurrency: CurrencyCode;
+}
+
+export function Configuration({ baseCurrency }: ConfigurationProps) {
   const { control } = useFormContext<CreateCryptoCurrencyInput>();
   const t = useTranslations("private.assets.create");
 
@@ -22,6 +27,16 @@ export function Configuration() {
           description={t(
             "parameters.cryptocurrencies.initial-supply-description"
           )}
+          required
+        />
+        <FormInput
+          control={control}
+          name="valueInBaseCurrency"
+          type="number"
+          step={0.01}
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
           required
         />
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/steps/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/steps/summary.tsx
@@ -1,6 +1,7 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormSummaryDetailCard } from "@/components/blocks/form/summary/card";
 import { FormSummaryDetailItem } from "@/components/blocks/form/summary/item";
+import { useSettings } from "@/hooks/use-settings";
 import type { CreateCryptoCurrencyInput } from "@/lib/mutations/cryptocurrency/create/create-schema";
 import { getPredictedAddress } from "@/lib/queries/cryptocurrency-factory/predict-address";
 import { DollarSign, Settings } from "lucide-react";
@@ -13,6 +14,7 @@ export function Summary() {
     control: control,
   });
   const t = useTranslations("private.assets.create");
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormStep title={t("summary.title")} description={t("summary.description")}>
@@ -43,6 +45,12 @@ export function Summary() {
         <FormSummaryDetailItem
           label={t("parameters.cryptocurrencies.initial-supply-label")}
           value={values.initialSupply || "-"}
+        />
+        <FormSummaryDetailItem
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          value={values.valueInBaseCurrency || "-"}
         />
       </FormSummaryDetailCard>
     </FormStep>

--- a/kit/dapp/src/components/blocks/create-forms/equities/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equities/form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from "@/components/blocks/form/form";
 import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { useSettings } from "@/hooks/use-settings";
 import { createEquity } from "@/lib/mutations/equity/create/create-action";
 import { CreateEquitySchema } from "@/lib/mutations/equity/create/create-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,8 @@ export function CreateEquityForm({
   const isExternallyControlled =
     open !== undefined && onOpenChange !== undefined;
   const [localOpen, setLocalOpen] = useState(false);
+  const baseCurrency = useSettings("baseCurrency");
+
   return (
     <FormSheet
       open={open ?? localOpen}
@@ -44,13 +47,15 @@ export function CreateEquityForm({
         buttonLabels={{
           label: t("trigger-label.equities"),
         }}
-        defaultValues={{}}
+        defaultValues={{
+          valueInBaseCurrency: 1,
+        }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);
         }}
       >
         <Basics />
-        <Configuration />
+        <Configuration baseCurrency={baseCurrency} />
         <Summary />
       </Form>
     </FormSheet>

--- a/kit/dapp/src/components/blocks/create-forms/equities/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equities/steps/configuration.tsx
@@ -1,9 +1,18 @@
 import { FormStep } from "@/components/blocks/form/form-step";
+import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
+import type { CreateEquityInput } from "@/lib/mutations/equity/create/create-schema";
 import { useTranslations } from "next-intl";
+import { useFormContext } from "react-hook-form";
 import { EquityCategoriesSelect } from "./_components/equity-categories";
 import { EquityClassesSelect } from "./_components/equity-classes";
 
-export function Configuration() {
+interface ConfigurationProps {
+  baseCurrency: CurrencyCode;
+}
+
+export function Configuration({ baseCurrency }: ConfigurationProps) {
+  const { control } = useFormContext<CreateEquityInput>();
   const t = useTranslations("private.assets.create");
 
   return (
@@ -17,6 +26,16 @@ export function Configuration() {
         />
         <EquityCategoriesSelect
           label={t("parameters.equities.equity-category-label")}
+        />
+        <FormInput
+          control={control}
+          name="valueInBaseCurrency"
+          type="number"
+          step={0.01}
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          required
         />
       </div>
     </FormStep>

--- a/kit/dapp/src/components/blocks/create-forms/equities/steps/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equities/steps/summary.tsx
@@ -1,6 +1,7 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormSummaryDetailCard } from "@/components/blocks/form/summary/card";
 import { FormSummaryDetailItem } from "@/components/blocks/form/summary/item";
+import { useSettings } from "@/hooks/use-settings";
 import type { CreateEquityInput } from "@/lib/mutations/equity/create/create-schema";
 import { getPredictedAddress } from "@/lib/queries/equity-factory/predict-address";
 import type { equityCategories, equityClasses } from "@/lib/utils/zod";
@@ -16,6 +17,7 @@ export function Summary() {
     control: control,
   });
   const t = useTranslations("private.assets.create");
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormStep title={t("summary.title")} description={t("summary.description")}>
@@ -72,6 +74,12 @@ export function Summary() {
               "-"
             )
           }
+        />
+        <FormSummaryDetailItem
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          value={values.valueInBaseCurrency || "-"}
         />
       </FormSummaryDetailCard>
     </FormStep>

--- a/kit/dapp/src/components/blocks/create-forms/funds/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/funds/form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from "@/components/blocks/form/form";
 import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { useSettings } from "@/hooks/use-settings";
 import { createFund } from "@/lib/mutations/fund/create/create-action";
 import { CreateFundSchema } from "@/lib/mutations/fund/create/create-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,7 @@ export function CreateFundForm({
   const isExternallyControlled =
     open !== undefined && onOpenChange !== undefined;
   const [localOpen, setLocalOpen] = useState(false);
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormSheet
@@ -47,13 +49,14 @@ export function CreateFundForm({
         }}
         defaultValues={{
           managementFeeBps: 100, // Default 1% management fee
+          valueInBaseCurrency: 1,
         }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);
         }}
       >
         <Basics />
-        <Configuration />
+        <Configuration baseCurrency={baseCurrency} />
         <Summary />
       </Form>
     </FormSheet>

--- a/kit/dapp/src/components/blocks/create-forms/funds/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/funds/steps/configuration.tsx
@@ -1,12 +1,17 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { CreateFundInput } from "@/lib/mutations/fund/create/create-schema";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 import { FundCategoriesSelect } from "./_components/fund-categories";
 import { FundClassesSelect } from "./_components/fund-classes";
 
-export function Configuration() {
+interface ConfigurationProps {
+  baseCurrency: CurrencyCode;
+}
+
+export function Configuration({ baseCurrency }: ConfigurationProps) {
   const { control } = useFormContext<CreateFundInput>();
   const t = useTranslations("private.assets.create");
 
@@ -27,6 +32,16 @@ export function Configuration() {
           label={t("parameters.funds.management-fee-label")}
           description={t("parameters.funds.management-fee-description")}
           postfix={t("parameters.funds.basis-points")}
+          required
+        />
+        <FormInput
+          control={control}
+          name="valueInBaseCurrency"
+          type="number"
+          step={0.01}
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
           required
         />
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/funds/steps/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/funds/steps/summary.tsx
@@ -1,6 +1,7 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormSummaryDetailCard } from "@/components/blocks/form/summary/card";
 import { FormSummaryDetailItem } from "@/components/blocks/form/summary/item";
+import { useSettings } from "@/hooks/use-settings";
 import type { CreateFundInput } from "@/lib/mutations/fund/create/create-schema";
 import { getPredictedAddress } from "@/lib/queries/fund-factory/predict-address";
 import type { fundCategories, fundClasses } from "@/lib/utils/zod";
@@ -16,6 +17,7 @@ export function Summary() {
     control: control,
   });
   const t = useTranslations("private.assets.create");
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormStep title={t("summary.title")} description={t("summary.description")}>
@@ -78,6 +80,12 @@ export function Summary() {
               ? `${values.managementFeeBps / 100}% (${values.managementFeeBps} ${t("parameters.funds.basis-points")})`
               : "-"
           }
+        />
+        <FormSummaryDetailItem
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          value={values.valueInBaseCurrency || "-"}
         />
       </FormSummaryDetailCard>
     </FormStep>

--- a/kit/dapp/src/components/blocks/create-forms/stablecoins/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoins/form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from "@/components/blocks/form/form";
 import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { useSettings } from "@/hooks/use-settings";
 import { createStablecoin } from "@/lib/mutations/stablecoin/create/create-action";
 import { CreateStablecoinSchema } from "@/lib/mutations/stablecoin/create/create-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,7 @@ export function CreateStablecoinForm({
   const isExternallyControlled =
     open !== undefined && onOpenChange !== undefined;
   const [localOpen, setLocalOpen] = useState(false);
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormSheet
@@ -47,13 +49,14 @@ export function CreateStablecoinForm({
         }}
         defaultValues={{
           collateralLivenessSeconds: 3600 * 24 * 365,
+          valueInBaseCurrency: 1,
         }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);
         }}
       >
         <Basics />
-        <Configuration />
+        <Configuration baseCurrency={baseCurrency} />
         <Summary />
       </Form>
     </FormSheet>

--- a/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/configuration.tsx
@@ -1,10 +1,15 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { CreateStablecoinInput } from "@/lib/mutations/stablecoin/create/create-schema";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function Configuration() {
+interface ConfigurationProps {
+  baseCurrency: CurrencyCode;
+}
+
+export function Configuration({ baseCurrency }: ConfigurationProps) {
   const { control } = useFormContext<CreateStablecoinInput>();
   const t = useTranslations("private.assets.create");
 
@@ -20,6 +25,16 @@ export function Configuration() {
           name="collateralLivenessSeconds"
           label={t("parameters.common.collateral-proof-validity-label")}
           postfix={t("parameters.common.seconds-unit-label")}
+          required
+        />
+        <FormInput
+          control={control}
+          name="valueInBaseCurrency"
+          type="number"
+          step={0.01}
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
           required
         />
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/summary.tsx
@@ -1,6 +1,7 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormSummaryDetailCard } from "@/components/blocks/form/summary/card";
 import { FormSummaryDetailItem } from "@/components/blocks/form/summary/item";
+import { useSettings } from "@/hooks/use-settings";
 import type { CreateStablecoinInput } from "@/lib/mutations/stablecoin/create/create-schema";
 import { getPredictedAddress } from "@/lib/queries/stablecoin-factory/predict-address";
 import { DollarSign, Settings } from "lucide-react";
@@ -13,6 +14,7 @@ export function Summary() {
     control: control,
   });
   const t = useTranslations("private.assets.create");
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormStep title={t("summary.title")} description={t("summary.description")}>
@@ -47,6 +49,12 @@ export function Summary() {
         <FormSummaryDetailItem
           label={t("parameters.common.collateral-proof-validity-label")}
           value={`${values.collateralLivenessSeconds} ${t("parameters.common.seconds-unit-label")}`}
+        />
+        <FormSummaryDetailItem
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          value={values.valueInBaseCurrency || "-"}
         />
       </FormSummaryDetailCard>
     </FormStep>

--- a/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/form.tsx
@@ -2,6 +2,7 @@
 
 import { Form } from "@/components/blocks/form/form";
 import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { useSettings } from "@/hooks/use-settings";
 import { createTokenizedDeposit } from "@/lib/mutations/tokenized-deposit/create/create-action";
 import { CreateTokenizedDepositSchema } from "@/lib/mutations/tokenized-deposit/create/create-schema";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,6 +27,7 @@ export function CreateTokenizedDepositForm({
   const isExternallyControlled =
     open !== undefined && onOpenChange !== undefined;
   const [localOpen, setLocalOpen] = useState(false);
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormSheet
@@ -52,10 +54,11 @@ export function CreateTokenizedDepositForm({
         }}
         defaultValues={{
           collateralLivenessSeconds: 3600 * 24 * 365,
+          valueInBaseCurrency: 1,
         }}
       >
         <Basics />
-        <Configuration />
+        <Configuration baseCurrency={baseCurrency} />
         <Summary />
       </Form>
     </FormSheet>

--- a/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/steps/configuration.tsx
@@ -1,10 +1,15 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { CurrencyCode } from "@/lib/db/schema-settings";
 import type { CreateTokenizedDepositInput } from "@/lib/mutations/tokenized-deposit/create/create-schema";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function Configuration() {
+interface ConfigurationProps {
+  baseCurrency: CurrencyCode;
+}
+
+export function Configuration({ baseCurrency }: ConfigurationProps) {
   const { control } = useFormContext<CreateTokenizedDepositInput>();
   const t = useTranslations("private.assets.create");
 
@@ -20,6 +25,16 @@ export function Configuration() {
           name="collateralLivenessSeconds"
           label={t("parameters.common.collateral-proof-validity-label")}
           postfix={t("parameters.common.seconds-unit-label")}
+          required
+        />
+        <FormInput
+          control={control}
+          name="valueInBaseCurrency"
+          type="number"
+          step={0.01}
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
           required
         />
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/steps/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/steps/summary.tsx
@@ -1,6 +1,7 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormSummaryDetailCard } from "@/components/blocks/form/summary/card";
 import { FormSummaryDetailItem } from "@/components/blocks/form/summary/item";
+import { useSettings } from "@/hooks/use-settings";
 import type { CreateTokenizedDepositInput } from "@/lib/mutations/tokenized-deposit/create/create-schema";
 import { getPredictedAddress } from "@/lib/queries/tokenizeddeposit-factory/predict-address";
 import { DollarSign, Settings } from "lucide-react";
@@ -13,6 +14,7 @@ export function Summary() {
     control: control,
   });
   const t = useTranslations("private.assets.create");
+  const baseCurrency = useSettings("baseCurrency");
 
   return (
     <FormStep title={t("summary.title")} description={t("summary.description")}>
@@ -49,6 +51,12 @@ export function Summary() {
           value={`${values.collateralLivenessSeconds} ${t(
             "parameters.common.seconds-unit-label"
           )}`}
+        />
+        <FormSummaryDetailItem
+          label={t("parameters.common.value-in-base-currency-label", {
+            baseCurrency,
+          })}
+          value={values.valueInBaseCurrency || "-"}
         />
       </FormSummaryDetailCard>
     </FormStep>

--- a/kit/dapp/src/hooks/use-settings.ts
+++ b/kit/dapp/src/hooks/use-settings.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { DEFAULT_SETTINGS, type SettingKey } from "@/lib/db/schema-settings";
+import { hasuraClient, hasuraGraphql } from "@/lib/settlemint/hasura";
+import { useEffect, useState } from "react";
+
+type Settings = typeof DEFAULT_SETTINGS;
+
+const GetSetting = hasuraGraphql(`
+  query GetSetting($_eq: String = "") {
+    settings(where: {key: {_eq: $_eq}}) {
+      value
+    }
+  }
+`);
+
+export function useSettings(key: SettingKey): Settings[SettingKey] {
+  const [value, setValue] = useState<Settings[SettingKey]>(
+    DEFAULT_SETTINGS[key]
+  );
+
+  useEffect(() => {
+    const loadSetting = async () => {
+      try {
+        const result = await hasuraClient.request(GetSetting, { _eq: key });
+        const settingValue = result.settings[0]?.value as Settings[SettingKey];
+        setValue(settingValue ?? DEFAULT_SETTINGS[key]);
+      } catch (error) {
+        console.error("Failed to load setting:", error);
+        setValue(DEFAULT_SETTINGS[key]);
+      }
+    };
+
+    void loadSetting();
+  }, [key]);
+
+  return value;
+}

--- a/kit/dapp/src/lib/mutations/bond/create/create-action.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-action.ts
@@ -36,8 +36,8 @@ const BondFactoryCreate = portalGraphql(`
  * Stores additional metadata about the bond in Hasura
  */
 const CreateOffchainBond = hasuraGraphql(`
-  mutation CreateOffchainBond($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+  mutation CreateOffchainBond($id: String!, $isin: String, $value_in_base_currency: numeric) {
+    insert_asset_one(object: {id: $id, isin: $isin, value_in_base_currency: $value_in_base_currency}) {
       id
     }
   }
@@ -59,6 +59,7 @@ export const createBond = action
         maturityDate,
         underlyingAsset,
         predictedAddress,
+        valueInBaseCurrency,
       },
       ctx: { user },
     }) => {
@@ -70,6 +71,7 @@ export const createBond = action
       await hasuraClient.request(CreateOffchainBond, {
         id: predictedAddress,
         isin: isin,
+        value_in_base_currency: String(valueInBaseCurrency),
       });
 
       const data = await portalClient.request(BondFactoryCreate, {

--- a/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
@@ -36,6 +36,7 @@ export const CreateBondSchema = z.object({
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "bond.duplicate",
   }),
+  valueInBaseCurrency: z.fiatCurrencyAmount(),
 });
 
 export type CreateBondInput = ZodInfer<typeof CreateBondSchema>;

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-action.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-action.ts
@@ -2,6 +2,7 @@
 
 import { handleChallenge } from "@/lib/challenge";
 import { CRYPTO_CURRENCY_FACTORY_ADDRESS } from "@/lib/contracts";
+import { hasuraClient, hasuraGraphql } from "@/lib/settlemint/hasura";
 import { portalClient, portalGraphql } from "@/lib/settlemint/portal";
 import { z } from "@/lib/utils/zod";
 import { parseUnits } from "viem";
@@ -33,25 +34,38 @@ const CryptoCurrencyFactoryCreate = portalGraphql(`
  * @remarks
  * Stores additional metadata about the cryptocurrency in Hasura
  */
-// const CreateOffchainCryptoCurrency = hasuraGraphql(`
-//   mutation CreateOffchainCryptoCurrency($id: String!) {
-//     insert_asset_one(object: {id: $id}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
-//       id
-//     }
-//   }
-// `);
+const CreateOffchainCryptoCurrency = hasuraGraphql(`
+  mutation CreateOffchainCryptoCurrency($id: String!, $value_in_base_currency: numeric) {
+    insert_asset_one(object: {id: $id, value_in_base_currency: $value_in_base_currency}) {
+      id
+    }
+  }
+`);
 
 export const createCryptoCurrency = action
   .schema(CreateCryptoCurrencySchema)
   .outputSchema(z.hashes())
   .action(
     async ({
-      parsedInput: { assetName, symbol, decimals, pincode, initialSupply },
+      parsedInput: {
+        assetName,
+        symbol,
+        decimals,
+        pincode,
+        initialSupply,
+        predictedAddress,
+        valueInBaseCurrency,
+      },
       ctx: { user },
     }) => {
       const initialSupplyExact = String(
         parseUnits(String(initialSupply), decimals)
       );
+
+      await hasuraClient.request(CreateOffchainCryptoCurrency, {
+        id: predictedAddress,
+        value_in_base_currency: String(valueInBaseCurrency),
+      });
 
       const data = await portalClient.request(CryptoCurrencyFactoryCreate, {
         address: CRYPTO_CURRENCY_FACTORY_ADDRESS,

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
@@ -24,6 +24,7 @@ export const CreateCryptoCurrencySchema = z.object({
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "cryptocurrency.duplicate",
   }),
+  valueInBaseCurrency: z.fiatCurrencyAmount(),
 });
 
 export type CreateCryptoCurrencyInput = ZodInfer<

--- a/kit/dapp/src/lib/mutations/equity/create/create-action.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-action.ts
@@ -34,10 +34,10 @@ const EquityFactoryCreate = portalGraphql(`
  * Stores additional metadata about the equity in Hasura
  */
 const CreateOffchainEquity = hasuraGraphql(`
-  mutation CreateOffchainEquity($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
-      id
-    }
+    mutation CreateOffchainEquity($id: String!, $isin: String, $value_in_base_currency: numeric) {
+      insert_asset_one(object: {id: $id, isin: $isin, value_in_base_currency: $value_in_base_currency}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+        id
+      }
   }
 `);
 
@@ -55,12 +55,14 @@ export const createEquity = action
         equityCategory,
         equityClass,
         predictedAddress,
+        valueInBaseCurrency,
       },
       ctx: { user },
     }) => {
       await hasuraClient.request(CreateOffchainEquity, {
         id: predictedAddress,
         isin: isin,
+        value_in_base_currency: String(valueInBaseCurrency),
       });
 
       const data = await portalClient.request(EquityFactoryCreate, {

--- a/kit/dapp/src/lib/mutations/equity/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-schema.ts
@@ -23,6 +23,7 @@ export const CreateEquitySchema = z.object({
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "equity.duplicate",
   }),
+  valueInBaseCurrency: z.fiatCurrencyAmount(),
 });
 
 export type CreateEquityInput = ZodInfer<typeof CreateEquitySchema>;

--- a/kit/dapp/src/lib/mutations/fund/create/create-action.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-action.ts
@@ -34,8 +34,8 @@ const FundFactoryCreate = portalGraphql(`
  * Stores additional metadata about the fund in Hasura
  */
 const CreateOffchainFund = hasuraGraphql(`
-  mutation CreateOffchainFund($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+  mutation CreateOffchainFund($id: String!, $isin: String, $value_in_base_currency: numeric) {
+    insert_asset_one(object: {id: $id, isin: $isin, value_in_base_currency: $value_in_base_currency}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
       id
       isin
     }
@@ -57,12 +57,14 @@ export const createFund = action
         fundClass,
         managementFeeBps,
         predictedAddress,
+        valueInBaseCurrency,
       },
       ctx: { user },
     }) => {
       await hasuraClient.request(CreateOffchainFund, {
         id: predictedAddress,
         isin,
+        value_in_base_currency: String(valueInBaseCurrency),
       });
 
       const data = await portalClient.request(FundFactoryCreate, {

--- a/kit/dapp/src/lib/mutations/fund/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-schema.ts
@@ -33,6 +33,7 @@ export const CreateFundSchema = z.object({
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "fund.duplicate",
   }),
+  valueInBaseCurrency: z.fiatCurrencyAmount(),
 });
 
 export type CreateFundInput = ZodInfer<typeof CreateFundSchema>;

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-action.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-action.ts
@@ -34,10 +34,10 @@ const StableCoinFactoryCreate = portalGraphql(`
  * Stores additional metadata about the stablecoin in Hasura
  */
 const CreateOffchainStablecoin = hasuraGraphql(`
-  mutation CreateOffchainStablecoin($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
-      id
-    }
+    mutation CreateOffchainStablecoin($id: String!, $isin: String, $value_in_base_currency: numeric) {
+      insert_asset_one(object: {id: $id, isin: $isin, value_in_base_currency: $value_in_base_currency}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+        id
+      }
   }
 `);
 
@@ -54,12 +54,14 @@ export const createStablecoin = action
         isin,
         collateralLivenessSeconds,
         predictedAddress,
+        valueInBaseCurrency,
       },
       ctx: { user },
     }) => {
       await hasuraClient.request(CreateOffchainStablecoin, {
         id: predictedAddress,
         isin,
+        value_in_base_currency: String(valueInBaseCurrency),
       });
 
       const data = await portalClient.request(StableCoinFactoryCreate, {

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
@@ -24,6 +24,7 @@ export const CreateStablecoinSchema = z.object({
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "stablecoin.duplicate",
   }),
+  valueInBaseCurrency: z.fiatCurrencyAmount(),
 });
 
 export type CreateStablecoinInput = ZodInfer<typeof CreateStablecoinSchema>;

--- a/kit/dapp/src/lib/mutations/tokenized-deposit/create/create-action.ts
+++ b/kit/dapp/src/lib/mutations/tokenized-deposit/create/create-action.ts
@@ -34,8 +34,8 @@ const TokenizedDepositFactoryCreate = portalGraphql(`
  * Stores additional metadata about the stablecoin in Hasura
  */
 const CreateOffchainTokenizedDeposit = hasuraGraphql(`
-  mutation CreateOffchainStablecoin($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+  mutation CreateOffchainTokenizedDeposit($id: String!, $isin: String, $value_in_base_currency: numeric) {
+    insert_asset_one(object: {id: $id, isin: $isin, value_in_base_currency: $value_in_base_currency}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
       id
     }
   }
@@ -54,12 +54,14 @@ export const createTokenizedDeposit = action
         pincode,
         isin,
         predictedAddress,
+        valueInBaseCurrency,
       },
       ctx: { user },
     }) => {
       await hasuraClient.request(CreateOffchainTokenizedDeposit, {
         id: predictedAddress,
         isin,
+        value_in_base_currency: String(valueInBaseCurrency),
       });
 
       const data = await portalClient.request(TokenizedDepositFactoryCreate, {

--- a/kit/dapp/src/lib/mutations/tokenized-deposit/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/tokenized-deposit/create/create-schema.ts
@@ -23,6 +23,7 @@ export const CreateTokenizedDepositSchema = z.object({
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "tokenized-deposit.duplicate",
   }),
+  valueInBaseCurrency: z.fiatCurrencyAmount(),
 });
 
 export type CreateTokenizedDepositInput = ZodInfer<

--- a/kit/dapp/src/lib/queries/asset/asset-fragment.ts
+++ b/kit/dapp/src/lib/queries/asset/asset-fragment.ts
@@ -102,6 +102,8 @@ export type Asset = ZodInfer<typeof AssetFragmentSchema>;
 export const OffchainAssetFragment = hasuraGraphql(`
   fragment OffchainAssetFragment on asset {
     id
+    isin
+    value_in_base_currency
   }
 `);
 
@@ -111,6 +113,8 @@ export const OffchainAssetFragment = hasuraGraphql(`
  */
 export const OffchainAssetFragmentSchema = z.object({
   id: z.address(),
+  isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/queries/bond/bond-fragment.ts
+++ b/kit/dapp/src/lib/queries/bond/bond-fragment.ts
@@ -91,6 +91,7 @@ export const OffchainBondFragment = hasuraGraphql(`
   fragment OffchainBondFragment on asset {
     id
     isin
+    value_in_base_currency
   }
 `);
 
@@ -101,6 +102,7 @@ export const OffchainBondFragment = hasuraGraphql(`
 export const OffchainBondFragmentSchema = z.object({
   id: z.address(),
   isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-fragment.ts
+++ b/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-fragment.ts
@@ -62,6 +62,8 @@ export type CryptoCurrency = ZodInfer<typeof CryptoCurrencyFragmentSchema>;
 export const OffchainCryptoCurrencyFragment = hasuraGraphql(`
   fragment OffchainCryptoCurrencyFragment on asset {
     id
+    isin
+    value_in_base_currency
   }
 `);
 
@@ -71,6 +73,8 @@ export const OffchainCryptoCurrencyFragment = hasuraGraphql(`
  */
 export const OffchainCryptoCurrencyFragmentSchema = z.object({
   id: z.address(),
+  isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/queries/equity/equity-fragment.ts
+++ b/kit/dapp/src/lib/queries/equity/equity-fragment.ts
@@ -73,6 +73,7 @@ export const OffchainEquityFragment = hasuraGraphql(`
   fragment OffchainEquityFragment on asset {
     id
     isin
+    value_in_base_currency
   }
 `);
 
@@ -83,6 +84,7 @@ export const OffchainEquityFragment = hasuraGraphql(`
 export const OffchainEquityFragmentSchema = z.object({
   id: z.address(),
   isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/queries/fund/fund-fragment.ts
+++ b/kit/dapp/src/lib/queries/fund/fund-fragment.ts
@@ -87,6 +87,7 @@ export const OffchainFundFragment = hasuraGraphql(`
   fragment OffchainFundFragment on asset {
     id
     isin
+    value_in_base_currency
   }
 `);
 
@@ -97,6 +98,7 @@ export const OffchainFundFragment = hasuraGraphql(`
 export const OffchainFundFragmentSchema = z.object({
   id: z.address(),
   isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/queries/stablecoin/stablecoin-fragment.ts
+++ b/kit/dapp/src/lib/queries/stablecoin/stablecoin-fragment.ts
@@ -79,6 +79,7 @@ export const OffchainStableCoinFragment = hasuraGraphql(`
   fragment OffchainStableCoinFragment on asset {
     id
     isin
+    value_in_base_currency
   }
 `);
 
@@ -89,6 +90,7 @@ export const OffchainStableCoinFragment = hasuraGraphql(`
 export const OffchainStableCoinFragmentSchema = z.object({
   id: z.address(),
   isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/queries/tokenizeddeposit/tokenizeddeposit-fragment.ts
+++ b/kit/dapp/src/lib/queries/tokenizeddeposit/tokenizeddeposit-fragment.ts
@@ -79,6 +79,7 @@ export const OffchainTokenizedDepositFragment = hasuraGraphql(`
   fragment OffchainTokenizedDepositFragment on asset {
     id
     isin
+    value_in_base_currency
   }
 `);
 
@@ -89,6 +90,7 @@ export const OffchainTokenizedDepositFragment = hasuraGraphql(`
 export const OffchainTokenizedDepositFragmentSchema = z.object({
   id: z.address(),
   isin: z.isin().nullish(),
+  value_in_base_currency: z.number().nullish().default(0),
 });
 
 /**

--- a/kit/dapp/src/lib/utils/zod.ts
+++ b/kit/dapp/src/lib/utils/zod.ts
@@ -10,6 +10,7 @@ import { fromUnixTime } from "date-fns";
 import type { Address, Hash } from "viem";
 import { getAddress, isAddress, isHash } from "viem";
 import { z } from "zod";
+import { FiatCurrencies } from "../db/schema-settings";
 
 /**
  * Safely parses data with a Zod schema and provides standardized error logging
@@ -405,6 +406,24 @@ const extendedZod = {
    * @returns A Zod schema that validates fund classes
    */
   fundClass: () => z.enum(fundClasses),
+
+  /**
+   * Validates a value in base currency
+   *
+   * @returns A Zod schema that validates a value in base currency
+   */
+  fiatCurrency: () => z.enum(FiatCurrencies),
+
+  /**
+   * Validates a currency amount with proper decimal handling
+   *
+   * @returns A Zod schema that validates currency amounts
+   */
+  fiatCurrencyAmount: () =>
+    z
+      .number()
+      .or(z.string())
+      .pipe(z.coerce.number().min(0, { message: "Amount must be positive" })),
 };
 
 /**

--- a/kit/dapp/tsconfig.json
+++ b/kit/dapp/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "lib": ["es2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "es2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -53,8 +57,12 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@schemas/*": ["./*.d.ts"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@schemas/*": [
+        "./*.d.ts"
+      ]
     },
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -78,5 +86,7 @@
     "next-env.d.ts",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Adds the ability to set an initial price when creating assets like cryptocurrencies, equities, bonds, funds, stablecoins and tokenized deposits. This price is stored in the Hasura database and displayed in the asset table.

New Features:
- Allows setting an initial price for assets during creation.
- Displays the initial price in the asset table.