### PR TITLE
fix: getValues() returns string even for number form inputs

### DIFF
--- a/kit/dapp/src/components/blocks/form/inputs/form-input.tsx
+++ b/kit/dapp/src/components/blocks/form/inputs/form-input.tsx
@@ -59,6 +59,7 @@ export function FormInput<T extends FieldValues>({
   ...props
 }: FormInputProps<T>) {
   const form = useFormContext<T>();
+  const { register } = form;
   const t = useTranslations("components.form.input");
 
   return (
@@ -104,6 +105,9 @@ export function FormInput<T extends FieldValues>({
                 <Input
                   {...field}
                   {...props}
+                  {...register(field.name, {
+                    valueAsNumber: props.type === "number",
+                  })}
                   className={cn(
                     className,
                     postfix &&

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
@@ -19,7 +19,7 @@ export const CreateStablecoinSchema = z.object({
   collateralLivenessSeconds: z
     .number()
     .or(z.string())
-    .pipe(z.coerce.number().min(0)),
+    .pipe(z.coerce.number().min(1, { message: "Must be at least 1" })),
   pincode: z.pincode(),
   predictedAddress: z.address().refine(isAddressAvailable, {
     message: "stablecoin.duplicate",


### PR DESCRIPTION
When we access the value before onSubmit using getValues(), the form inputs are not parsed, and remain strings. (Because all HTML input element values are strings) Setting `valueAsNumber` from react hook form parses the strings to numbers for number type inputs: https://stackoverflow.com/a/73206877/14332340 https://github.com/shadcn-ui/ui/issues/421#issuecomment-1978897790

## Summary by Sourcery

Ensures number inputs in forms are parsed as numbers when accessed via getValues() by setting the valueAsNumber property in react-hook-form. Also, updates the CreateStablecoinSchema to enforce a minimum value of 1 for collateralLivenessSeconds.

Bug Fixes:
- Fixes an issue where number form inputs were not parsed as numbers when accessed via getValues().

Enhancements:
- Updates the CreateStablecoinSchema to enforce a minimum value of 1 for collateralLivenessSeconds.

## Summary by Sourcery

Ensure number inputs in forms are parsed as numbers when accessed via getValues() by setting the valueAsNumber property in react-hook-form. Update the CreateStablecoinSchema to enforce a minimum value of 1 for collateralLivenessSeconds.

Bug Fixes:
- Fix an issue where number form inputs were not parsed as numbers when accessed via getValues().

Enhancements:
- Update the CreateStablecoinSchema to enforce a minimum value of 1 for collateralLivenessSeconds.