### PR TITLE
fix: default decimals to 6 for stablecoins

### DIFF
--- a/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/basics.tsx
@@ -39,7 +39,7 @@ export function Basics() {
           type="number"
           name="decimals"
           label={t("parameters.common.decimals-label")}
-          defaultValue={18}
+          defaultValue={6}
           required
         />
       </div>


### PR DESCRIPTION
## Summary by Sourcery

Set the default number of decimals to 6 for stablecoins.