### PR TITLE
fix: disable actions in the holders table when contract is paused

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/holders/_components/columns.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/holders/_components/columns.tsx
@@ -107,6 +107,7 @@ export function columns({ mintMaxLimit }: { mintMaxLimit?: number }) {
                     onOpenChange={onOpenChange}
                   />
                 ),
+                disabled: row.original.asset.paused,
                 hidden: !hasBlocklist(row.original.asset.type),
               },
               {
@@ -124,6 +125,7 @@ export function columns({ mintMaxLimit }: { mintMaxLimit?: number }) {
                     onOpenChange={onOpenChange}
                   />
                 ),
+                disabled: row.original.asset.paused,
                 hidden: !hasFreeze(row.original.asset.type),
               },
               {
@@ -139,6 +141,7 @@ export function columns({ mintMaxLimit }: { mintMaxLimit?: number }) {
                     maxLimit={mintMaxLimit}
                   />
                 ),
+                disabled: row.original.asset.paused,
               },
             ]}
           />


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Disable blocklist, freeze, and mint actions in the holders table when the corresponding asset is paused.