### PR TITLE
fix: hide or disable burn when not possible

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/manage-dropdown/manage-dropdown.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/manage-dropdown/manage-dropdown.tsx
@@ -122,8 +122,12 @@ export function ManageDropdown({
     {
       id: "burn",
       label: t("actions.burn"),
-      hidden: false,
-      disabled: isBlocked || isPaused || !userIsSupplyManager,
+      hidden: assettype === "cryptocurrency",
+      disabled:
+        isBlocked ||
+        isPaused ||
+        !userIsSupplyManager ||
+        (userBalance?.available ?? 0) > 0,
       form: (
         <BurnForm
           key="burn"


### PR DESCRIPTION
## Summary by Sourcery

Hides or disables the burn option in the manage dropdown based on asset type and user balance.