### PR TITLE
fix: value needs to be 0 or higher

### DIFF
--- a/kit/dapp/src/components/blocks/create-forms/bonds/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bonds/steps/configuration.tsx
@@ -53,6 +53,7 @@ export function Configuration({ baseCurrency }: ConfigurationProps) {
         <FormInput
           control={control}
           name="valueInBaseCurrency"
+          min={0}
           type="number"
           step={0.01}
           label={t("parameters.common.value-in-base-currency-label", {

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrencies/steps/configuration.tsx
@@ -33,6 +33,7 @@ export function Configuration({ baseCurrency }: ConfigurationProps) {
           control={control}
           name="valueInBaseCurrency"
           type="number"
+          min={0}
           step={0.01}
           label={t("parameters.common.value-in-base-currency-label", {
             baseCurrency,

--- a/kit/dapp/src/components/blocks/create-forms/equities/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equities/steps/configuration.tsx
@@ -32,6 +32,7 @@ export function Configuration({ baseCurrency }: ConfigurationProps) {
           name="valueInBaseCurrency"
           type="number"
           step={0.01}
+          min={0}
           label={t("parameters.common.value-in-base-currency-label", {
             baseCurrency,
           })}

--- a/kit/dapp/src/components/blocks/create-forms/funds/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/funds/steps/configuration.tsx
@@ -39,6 +39,7 @@ export function Configuration({ baseCurrency }: ConfigurationProps) {
           name="valueInBaseCurrency"
           type="number"
           step={0.01}
+          min={0}
           label={t("parameters.common.value-in-base-currency-label", {
             baseCurrency,
           })}

--- a/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoins/steps/configuration.tsx
@@ -33,6 +33,7 @@ export function Configuration({ baseCurrency }: ConfigurationProps) {
           name="valueInBaseCurrency"
           type="number"
           step={0.01}
+          min={0}
           label={t("parameters.common.value-in-base-currency-label", {
             baseCurrency,
           })}

--- a/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/tokenized-deposits/steps/configuration.tsx
@@ -33,6 +33,7 @@ export function Configuration({ baseCurrency }: ConfigurationProps) {
           name="valueInBaseCurrency"
           type="number"
           step={0.01}
+          min={0}
           label={t("parameters.common.value-in-base-currency-label", {
             baseCurrency,
           })}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure that the value entered in the valueInBaseCurrency field is not negative.