### PR TITLE
fix: collateral proof validity

### DIFF
--- a/kit/dapp/src/lib/providers/exchange-rates/exchange-rates-api.ts
+++ b/kit/dapp/src/lib/providers/exchange-rates/exchange-rates-api.ts
@@ -4,10 +4,6 @@ import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { Elysia, t } from "elysia";
 import { getExchangeRatesForBase } from "./exchange-rates";
 
-const FiatCurrencyEnum = Object.fromEntries(
-  fiatCurrencies.map((currency) => [currency, currency])
-);
-
 const ExchangeRateSchema = t.Object({
   id: t.String({
     description: "Unique identifier for the exchange rate record",
@@ -40,7 +36,7 @@ export const ExchangeRatesApi = new Elysia()
     {
       auth: true,
       params: t.Object({
-        base: t.Enum(FiatCurrencyEnum, {
+        base: t.UnionEnum(fiatCurrencies, {
           description: "The base currency code (e.g., USD)",
         }),
       }),

--- a/kit/dapp/src/lib/queries/stablecoin/stablecoin-calculated.test.ts
+++ b/kit/dapp/src/lib/queries/stablecoin/stablecoin-calculated.test.ts
@@ -1,0 +1,87 @@
+import type { OnChainStableCoin } from "@/lib/queries/stablecoin/stablecoin-schema";
+import { describe, expect, it } from "bun:test";
+import { addSeconds } from "date-fns";
+import { stablecoinCalculateFields } from "./stablecoin-calculated";
+
+describe("stablecoinCalculateFields", () => {
+  it("should calculate concentration correctly when totalSupplyExact is non-zero", () => {
+    const onChainStableCoin: Partial<OnChainStableCoin> = {
+      holders: [
+        { valueExact: 500n },
+        { valueExact: 300n },
+        { valueExact: 200n },
+      ],
+      totalSupplyExact: 1000n,
+      lastCollateralUpdate: new Date(0),
+      liveness: 0n,
+    };
+
+    const result = stablecoinCalculateFields(
+      onChainStableCoin as OnChainStableCoin
+    );
+    expect(result.concentration).toBe(100); // (500 + 300 + 200) / 1000 * 100 = 100%
+  });
+
+  it("should calculate concentration as 0 when totalSupplyExact is zero", () => {
+    const onChainStableCoin: Partial<OnChainStableCoin> = {
+      holders: [{ valueExact: 500n }, { valueExact: 300n }],
+      totalSupplyExact: 0n,
+      lastCollateralUpdate: new Date(0),
+      liveness: 0n,
+    };
+
+    const result = stablecoinCalculateFields(
+      onChainStableCoin as OnChainStableCoin
+    );
+    expect(result.concentration).toBe(0);
+  });
+
+  it("should calculate collateralProofValidity correctly when lastCollateralUpdate is non-zero", () => {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const liveness = "86400"; // 24 hours in seconds
+    const onChainStableCoin: Partial<OnChainStableCoin> = {
+      holders: [],
+      totalSupplyExact: 1000n,
+      lastCollateralUpdate: new Date(Number(timestamp) * 1000),
+      liveness: BigInt(liveness),
+    };
+
+    const result = stablecoinCalculateFields(
+      onChainStableCoin as OnChainStableCoin
+    );
+    const expectedDate = addSeconds(
+      new Date(Number(timestamp) * 1000),
+      Number(liveness)
+    );
+
+    expect(result.collateralProofValidity).toEqual(expectedDate);
+  });
+
+  it("should set collateralProofValidity to undefined when lastCollateralUpdate is set to zero", () => {
+    const onChainStableCoin: Partial<OnChainStableCoin> = {
+      holders: [],
+      totalSupplyExact: 1000n,
+      lastCollateralUpdate: new Date(0),
+      liveness: 86400n,
+    };
+
+    const result = stablecoinCalculateFields(
+      onChainStableCoin as OnChainStableCoin
+    );
+    expect(result.collateralProofValidity).toBeUndefined();
+  });
+
+  it("should handle empty holders array", () => {
+    const onChainStableCoin: Partial<OnChainStableCoin> = {
+      holders: [],
+      totalSupplyExact: 1000n,
+      lastCollateralUpdate: new Date(0),
+      liveness: 0n,
+    };
+
+    const result = stablecoinCalculateFields(
+      onChainStableCoin as OnChainStableCoin
+    );
+    expect(result.concentration).toBe(0);
+  });
+});

--- a/kit/dapp/src/lib/queries/stablecoin/stablecoin-calculated.ts
+++ b/kit/dapp/src/lib/queries/stablecoin/stablecoin-calculated.ts
@@ -31,9 +31,9 @@ export function stablecoinCalculateFields(
 
   // Calculate collateral proof validity date
   const collateralProofValidity =
-    Number(onChainStableCoin.lastCollateralUpdate) > 0
+    onChainStableCoin.lastCollateralUpdate.getTime() > 0
       ? addSeconds(
-          new Date(Number(onChainStableCoin.lastCollateralUpdate) * 1000),
+          onChainStableCoin.lastCollateralUpdate,
           Number(onChainStableCoin.liveness)
         )
       : undefined;


### PR DESCRIPTION
## Summary by Sourcery

Fixes an issue where the collateral proof validity date was not being calculated correctly. Also, updates the exchange rates API to use t.UnionEnum instead of t.Enum.

Bug Fixes:
- Fixes an issue where the collateral proof validity date was not being calculated correctly by comparing the timestamp to 0 instead of the date time value.
- Updates the exchange rates API to use t.UnionEnum instead of t.Enum to avoid a type error.