### PR TITLE
fix: use client for hooks 

### DIFF
--- a/kit/dapp/src/hooks/use-debounce.ts
+++ b/kit/dapp/src/hooks/use-debounce.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 
 export function useDebounce<T>(value: T, delay = 500): T {

--- a/kit/dapp/src/hooks/use-mobile.ts
+++ b/kit/dapp/src/hooks/use-mobile.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Mark custom React hooks as client-side components to ensure proper rendering in Next.js applications