### PR TITLE
fix: all assets shown in transfer asset select drop down

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/portfolio/_components/transfer-form/form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/_components/transfer-form/form.tsx
@@ -81,7 +81,7 @@ export function TransferForm({
       disabled={disabled}
     >
       {!address && !selectedAsset ? (
-        <SelectAsset onSelect={setSelectedAsset} />
+        <SelectAsset onSelect={setSelectedAsset} userWallet={userAddress} />
       ) : (
         <Form
           action={transfer}

--- a/kit/dapp/src/app/[locale]/(private)/portfolio/_components/transfer-form/select-asset.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/_components/transfer-form/select-asset.tsx
@@ -1,6 +1,7 @@
 import { FormAssets } from "@/components/blocks/form/inputs/form-assets";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
+import { authClient } from "@/lib/auth/client";
 import {
   AssetUsersSchema,
   type AssetUsers,
@@ -9,13 +10,16 @@ import { t as tb } from "@/lib/utils/typebox";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
+import type { Address } from "viem";
 
 interface SelectAssetProps {
   onSelect: (asset: AssetUsers) => void;
+  userWallet?: Address;
 }
 
-export function SelectAsset({ onSelect }: SelectAssetProps) {
+export function SelectAsset({ onSelect, userWallet }: SelectAssetProps) {
   const t = useTranslations("portfolio.transfer-form.select-asset");
+  const { data: session } = authClient.useSession();
   const form = useForm<{ asset: AssetUsers }>({
     resolver: typeboxResolver(tb.Object({ asset: AssetUsersSchema })),
     mode: "onChange",
@@ -37,6 +41,7 @@ export function SelectAsset({ onSelect }: SelectAssetProps) {
           name="asset"
           label={t("asset-label")}
           description={t("asset-description")}
+          userWallet={userWallet}
         />
         <div className="mt-6 text-right">
           <Button disabled={!isValid} onClick={handleConfirm}>

--- a/kit/dapp/src/components/blocks/form/inputs/form-assets.tsx
+++ b/kit/dapp/src/components/blocks/form/inputs/form-assets.tsx
@@ -67,8 +67,6 @@ export function FormAssets<T extends FieldValues>({
   userWallet,
   ...props
 }: FormSearchSelectProps<T>) {
-  console.log('FormAssets', userWallet);
-
   const [open, setOpen] = useState(false);
   const t = useTranslations("components.form.assets");
   const defaultPlaceholder = t("default-placeholder");


### PR DESCRIPTION
## Summary by Sourcery

Add filtering capability to asset selection to show only assets held by a specific user

Bug Fixes:
- Resolve issue where all assets were shown in transfer asset selection, now allowing filtering to user-owned assets

Enhancements:
- Introduced an optional userWallet parameter to filter assets based on user ownership