### PR TITLE
feat: platform admins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
         "rtl-detect": "1.1.2",
         "sharp": "0.33.5",
         "simple-icons": "14.11.1",
-        "sonner": "2.0.1",
+        "sonner": "2.0.2",
         "superjson": "2.2.2",
         "swr": "2.3.3",
         "tailwind-merge": "3.0.2",
@@ -110,7 +110,7 @@
         "@types/rtl-detect": "1.0.3",
         "babel-plugin-react-compiler": "19.0.0-beta-e552027-20250112",
         "dotenv": "16.4.7",
-        "drizzle-kit": "0.30.5",
+        "drizzle-kit": "0.30.6",
         "eslint": "9.23.0",
         "eslint-config-next": "15.2.4",
         "languine": "3.1.2",
@@ -156,7 +156,7 @@
   "overrides": {
     "ws": "8.18.1",
     "react-is": "19.0.0",
-    "undici": "7.5.0",
+    "undici": "7.6.0",
     "adm-zip": "0.5.16",
     "elliptic": "6.6.1",
     "graphql": "16.10.0",
@@ -1835,7 +1835,7 @@
 
     "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
-    "drizzle-kit": ["drizzle-kit@0.30.5", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-l6dMSE100u7sDaTbLczibrQZjA35jLsHNqIV+jmhNVO3O8jzM6kywMOmV9uOz9ZVSCMPQhAZEFjL/qDPVrqpUA=="],
+    "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 
     "drizzle-orm": ["drizzle-orm@0.41.0", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q=="],
 
@@ -3261,7 +3261,7 @@
 
     "solidity-coverage": ["solidity-coverage@0.8.14", "", { "dependencies": { "@ethersproject/abi": "^5.0.9", "@solidity-parser/parser": "^0.19.0", "chalk": "^2.4.2", "death": "^1.1.0", "difflib": "^0.2.4", "fs-extra": "^8.1.0", "ghost-testrpc": "^0.0.2", "global-modules": "^2.0.0", "globby": "^10.0.1", "jsonschema": "^1.2.4", "lodash": "^4.17.21", "mocha": "^10.2.0", "node-emoji": "^1.10.0", "pify": "^4.0.1", "recursive-readdir": "^2.2.2", "sc-istanbul": "^0.4.5", "semver": "^7.3.4", "shelljs": "^0.8.3", "web3-utils": "^1.3.6" }, "peerDependencies": { "hardhat": "^2.11.0" }, "bin": { "solidity-coverage": "plugins/bin.js" } }, "sha512-ItAAObe5GaEOp20kXC2BZRnph+9P7Rtoqg2mQc2SXGEHgSDF2wWd1Wxz3ntzQWXkbCtIIGdJT918HG00cObwbA=="],
 
-    "sonner": ["sonner@2.0.1", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ=="],
+    "sonner": ["sonner@2.0.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-xOeXErZ4blqQd11ZnlDmoRmg+ctUJBkTU8H+HVh9rnWi9Ke28xiL39r4iCTeDX31ODTe/s1MaiaY333dUzLCtA=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -3491,7 +3491,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.5.0", "", {}, "sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ=="],
+    "undici": ["undici@7.6.0", "", {}, "sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
@@ -3830,6 +3830,8 @@
     "@sentry/tracing/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "@sentry/utils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "@settlemint/sdk-hasura/drizzle-kit": ["drizzle-kit@0.30.5", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-l6dMSE100u7sDaTbLczibrQZjA35jLsHNqIV+jmhNVO3O8jzM6kywMOmV9uOz9ZVSCMPQhAZEFjL/qDPVrqpUA=="],
 
     "@settlemint/sdk-utils/find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
 

--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -183,6 +183,7 @@
         "admin-count": "Admins",
         "manage-admins": "Manage platform admins",
         "platform-management": "Platform management",
+        "platform-admins": "Platform Admins",
         "save": "Save",
         "save-changes": "Save changes",
         "saving": "Saving...",

--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -154,6 +154,16 @@
     },
     "platform": {
       "settings": {
+        "add-admin": {
+          "title": "Add Admin",
+          "description": "Add a new admin to the platform",
+          "wallet-address-label": "Wallet Address",
+          "first-name-label": "First Name",
+          "last-name-label": "Last Name",
+          "adding": "Adding admin...",
+          "added": "Admin added successfully"
+        },
+        "add-admin-button": "Add Admin",
         "base-currency-label": "Base Currency",
         "base-currency-title": "Base Currency",
         "base-currency-description": "Set the default currency for displaying asset values across the platform",

--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -168,6 +168,10 @@
           "gbp": "British Pound (GBP)",
           "chf": "Swiss Franc (CHF)"
         },
+        "permissions-title": "Permissions",
+        "permissions-description": "Manage platform administrators and their access levels",
+        "admin-count": "Admins",
+        "manage-admins": "Manage platform admins",
         "platform-management": "Platform management",
         "save": "Save",
         "save-changes": "Save changes",

--- a/kit/dapp/src/app/[locale]/(private)/platform/admins/_components/actions.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/admins/_components/actions.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { AddAdminForm } from "@/app/[locale]/(private)/platform/admins/_components/add-admin-form/form";
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+export function AdminsActions() {
+  const t = useTranslations("admin.platform.settings");
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>{t("add-admin-button")}</Button>
+      <AddAdminForm open={isOpen} onCloseAction={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/kit/dapp/src/app/[locale]/(private)/platform/admins/_components/add-admin-form/form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/admins/_components/add-admin-form/form.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Form } from "@/components/blocks/form/form";
+import { FormSheet } from "@/components/blocks/form/form-sheet";
+import { addAdmin } from "@/lib/mutations/admin/add-admin-action";
+import { getAddAdminFormSchema } from "@/lib/mutations/admin/add-admin-schema";
+import { typeboxResolver } from "@hookform/resolvers/typebox";
+import { useTranslations } from "next-intl";
+import { Admin } from "./steps/admin";
+
+export function AddAdminForm({
+  open,
+  onCloseAction,
+}: {
+  open: boolean;
+  onCloseAction: () => void;
+}) {
+  const t = useTranslations("admin.platform.settings");
+
+  return (
+    <FormSheet
+      open={open}
+      onOpenChange={onCloseAction}
+      title={t("add-admin.title")}
+      description={t("add-admin.description")}
+    >
+      <Form
+        action={addAdmin}
+        resolver={typeboxResolver(getAddAdminFormSchema())}
+        onOpenChange={onCloseAction}
+        buttonLabels={{
+          label: t("add-admin.title"),
+        }}
+        secureForm={false}
+        toastMessages={{
+          loading: t("add-admin.adding"),
+          success: t("add-admin.added"),
+        }}
+      >
+        <Admin />
+      </Form>
+    </FormSheet>
+  );
+}

--- a/kit/dapp/src/app/[locale]/(private)/platform/admins/_components/add-admin-form/steps/admin.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/admins/_components/add-admin-form/steps/admin.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { FormStep } from "@/components/blocks/form/form-step";
+import { FormInput } from "@/components/blocks/form/inputs/form-input";
+import type { AddAdminFormType } from "@/lib/mutations/admin/add-admin-schema";
+import { useTranslations } from "next-intl";
+import { useFormContext } from "react-hook-form";
+
+export function Admin() {
+  const { control } = useFormContext<AddAdminFormType>();
+  const t = useTranslations("admin.platform.settings");
+
+  return (
+    <FormStep
+      title={t("add-admin.title")}
+      description={t("add-admin.description")}
+    >
+      <div className="grid grid-cols-1 gap-6">
+        <FormInput
+          control={control}
+          name="address"
+          label={t("add-admin.wallet-address-label")}
+          placeholder="0x0000000000000000000000000000000000000000"
+        />
+        <FormInput
+          control={control}
+          name="firstName"
+          label={t("add-admin.first-name-label")}
+          placeholder="John"
+        />
+        <FormInput
+          control={control}
+          name="lastName"
+          label={t("add-admin.last-name-label")}
+          placeholder="Doe"
+        />
+      </div>
+    </FormStep>
+  );
+}
+
+Admin.validatedFields = [
+  "address",
+  "firstName",
+  "lastName",
+] satisfies (keyof AddAdminFormType)[];

--- a/kit/dapp/src/app/[locale]/(private)/platform/admins/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/admins/page.tsx
@@ -12,7 +12,7 @@ export default async function AdminsPage() {
   return (
     <>
       <PageHeader
-        title={t("permissions-title")}
+        title={t("platform-admins")}
         section={t("platform-management")}
         button={<AdminsActions />}
       />

--- a/kit/dapp/src/app/[locale]/(private)/platform/admins/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/admins/page.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { getAdminUserList } from "@/lib/queries/user/user-list";
 import { getTranslations } from "next-intl/server";
 import { Columns, icons } from "../users/(table)/_components/columns";
+import { AdminsActions } from "./_components/actions";
 
 export default async function AdminsPage() {
   const admins = await getAdminUserList();
@@ -13,6 +14,7 @@ export default async function AdminsPage() {
       <PageHeader
         title={t("permissions-title")}
         section={t("platform-management")}
+        button={<AdminsActions />}
       />
       <DataTable
         columns={Columns}

--- a/kit/dapp/src/app/[locale]/(private)/platform/admins/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/admins/page.tsx
@@ -1,0 +1,26 @@
+import { DataTable } from "@/components/blocks/data-table/data-table";
+import { PageHeader } from "@/components/layout/page-header";
+import { getAdminUserList } from "@/lib/queries/user/user-list";
+import { getTranslations } from "next-intl/server";
+import { Columns, icons } from "../users/(table)/_components/columns";
+
+export default async function AdminsPage() {
+  const admins = await getAdminUserList();
+  const t = await getTranslations("admin.platform.settings");
+
+  return (
+    <>
+      <PageHeader
+        title={t("permissions-title")}
+        section={t("platform-management")}
+      />
+      <DataTable
+        columns={Columns}
+        data={admins}
+        icons={icons}
+        name="admin"
+        initialSorting={[{ id: "name", desc: false }]}
+      />
+    </>
+  );
+}

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/permissions-card.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/permissions-card.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Link } from "@/i18n/routing";
+import { Users } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+interface PermissionsCardProps {
+  adminCount: number;
+}
+
+export function PermissionsCard({ adminCount }: PermissionsCardProps) {
+  const t = useTranslations("admin.platform.settings");
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <Users className="size-4" />
+          </div>
+          <div>
+            <CardTitle>{t("permissions-title")}</CardTitle>
+            <CardDescription>{t("permissions-description")}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col space-y-4">
+          <div>
+            <div className="flex flex-col gap-4 justify-between">
+              <div className="flex flex-col gap-2">
+                <span className="text-sm text-foreground">
+                  {t("admin-count", { count: adminCount })}
+                </span>
+                <span className="text-sm font-bold text-foreground">
+                  {adminCount}
+                </span>
+              </div>
+              <Link
+                className="text-accent hover:underline"
+                href="/platform/admins"
+              >
+                {t("manage-admins")}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-form.tsx
@@ -22,13 +22,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Link } from "@/i18n/routing";
 import type { CurrencyCode } from "@/lib/db/schema-settings";
 import { t as tb } from "@/lib/utils/typebox";
 import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks";
-import { DollarSign, Users } from "lucide-react";
+import { DollarSign } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { updateSettings } from "./settings-action";
@@ -134,52 +133,6 @@ export function SettingsForm({ defaultBaseCurrency }: SettingsFormProps) {
             </div>
           </form>
         </Form>
-      </CardContent>
-    </Card>
-  );
-}
-
-interface PermissionsCardProps {
-  adminCount: number;
-}
-
-export function PermissionsCard({ adminCount }: PermissionsCardProps) {
-  const t = useTranslations("admin.platform.settings");
-
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <div className="rounded-lg bg-primary/10 p-2 text-primary">
-            <Users className="size-4" />
-          </div>
-          <div>
-            <CardTitle>{t("permissions-title")}</CardTitle>
-            <CardDescription>{t("permissions-description")}</CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-col space-y-4">
-          <div>
-            <div className="flex flex-col gap-4 justify-between">
-              <div className="flex flex-col gap-2">
-                <span className="text-sm text-foreground">
-                  {t("admin-count")}
-                </span>
-                <span className="text-sm font-bold text-foreground">
-                  {adminCount}
-                </span>
-              </div>
-              <Link
-                className="text-accent hover:underline"
-                href="/platform/admins"
-              >
-                {t("manage-admins")}
-              </Link>
-            </div>
-          </div>
-        </div>
       </CardContent>
     </Card>
   );

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/settings-form.tsx
@@ -22,12 +22,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Link } from "@/i18n/routing";
 import type { CurrencyCode } from "@/lib/db/schema-settings";
 import { t as tb } from "@/lib/utils/typebox";
 import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useHookFormAction } from "@next-safe-action/adapter-react-hook-form/hooks";
-import { DollarSign } from "lucide-react";
+import { DollarSign, Users } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { updateSettings } from "./settings-action";
@@ -100,10 +101,7 @@ export function SettingsForm({ defaultBaseCurrency }: SettingsFormProps) {
       </CardHeader>
       <CardContent>
         <Form {...form}>
-          <form
-            onSubmit={handleSubmitWithAction}
-            className="w-full max-w-2xl space-y-4"
-          >
+          <form onSubmit={handleSubmitWithAction} className="w-full space-y-4">
             <FormField
               name="baseCurrency"
               render={({ field }) => (
@@ -131,11 +129,57 @@ export function SettingsForm({ defaultBaseCurrency }: SettingsFormProps) {
                 </FormItem>
               )}
             />
-            <div className="flex justify-end gap-4 pt-4">
+            <div className="flex justify-end pt-4">
               <Button type="submit">{t("save-changes")}</Button>
             </div>
           </form>
         </Form>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface PermissionsCardProps {
+  adminCount: number;
+}
+
+export function PermissionsCard({ adminCount }: PermissionsCardProps) {
+  const t = useTranslations("admin.platform.settings");
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <Users className="size-4" />
+          </div>
+          <div>
+            <CardTitle>{t("permissions-title")}</CardTitle>
+            <CardDescription>{t("permissions-description")}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col space-y-4">
+          <div>
+            <div className="flex flex-col gap-4 justify-between">
+              <div className="flex flex-col gap-2">
+                <span className="text-sm text-foreground">
+                  {t("admin-count")}
+                </span>
+                <span className="text-sm font-bold text-foreground">
+                  {adminCount}
+                </span>
+              </div>
+              <Link
+                className="text-accent hover:underline"
+                href="/platform/admins"
+              >
+                {t("manage-admins")}
+              </Link>
+            </div>
+          </div>
+        </div>
       </CardContent>
     </Card>
   );

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/page.tsx
@@ -1,12 +1,14 @@
 import { PageHeader } from "@/components/layout/page-header";
 import { getSetting } from "@/lib/config/settings";
 import { SETTING_KEYS } from "@/lib/db/schema-settings";
+import { getUserCount } from "@/lib/queries/user/user-count";
 import { getTranslations } from "next-intl/server";
-import { SettingsForm } from "./_components/settings-form";
+import { PermissionsCard, SettingsForm } from "./_components/settings-form";
 
 export default async function SettingsPage() {
   const t = await getTranslations("admin.platform.settings");
   const baseCurrency = await getSetting(SETTING_KEYS.BASE_CURRENCY);
+  const { adminUsersCount } = await getUserCount();
 
   return (
     <>
@@ -14,8 +16,9 @@ export default async function SettingsPage() {
         title={t("platform-management")}
         section={t("platform-management")}
       />
-      <div className="mb-4 grid grid-cols-1 gap-4 max-w-2xl">
+      <div className="mb-4 grid grid-cols-2 gap-4">
         <SettingsForm defaultBaseCurrency={baseCurrency} />
+        <PermissionsCard adminCount={adminUsersCount} />
       </div>
     </>
   );

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/page.tsx
@@ -3,7 +3,8 @@ import { getSetting } from "@/lib/config/settings";
 import { SETTING_KEYS } from "@/lib/db/schema-settings";
 import { getUserCount } from "@/lib/queries/user/user-count";
 import { getTranslations } from "next-intl/server";
-import { PermissionsCard, SettingsForm } from "./_components/settings-form";
+import { PermissionsCard } from "./_components/permissions-card";
+import { SettingsForm } from "./_components/settings-form";
 
 export default async function SettingsPage() {
   const t = await getTranslations("admin.platform.settings");

--- a/kit/dapp/src/components/blocks/form/inputs/form-assets.tsx
+++ b/kit/dapp/src/components/blocks/form/inputs/form-assets.tsx
@@ -44,6 +44,14 @@ type RecentAsset = {
   selectedAt: number;
 };
 
+// Define a type for asset holders
+type AssetHolder = {
+  account: {
+    id: string;
+  };
+  value: string;
+};
+
 const MAX_RECENT_ASSETS = 5;
 const LOCAL_STORAGE_KEY = "recently-selected-assets";
 const INITIAL_RECENT_ASSETS: RecentAsset[] = [];
@@ -172,14 +180,15 @@ function FormAssetsList({
 
       // Filter by user wallet if provided
       if (userWallet) {
-         return results.filter(asset =>
-          asset.holders.some(holder =>
-            holder.account.id.toLowerCase() === userWallet.toLowerCase() &&
-            BigInt(holder.value) > 0n
+        return results.filter((asset: AssetUsers) =>
+          asset.holders.some(
+            (holder: AssetHolder) =>
+              holder.account.id.toLowerCase() === userWallet.toLowerCase() &&
+              BigInt(holder.value) > 0n
           )
         );
       }
-
+      return results;
     },
     {
       revalidateOnFocus: false,
@@ -228,7 +237,7 @@ function FormAssetsList({
 
     return recentAssets
       .map((recent) => {
-        const asset = assets.find((a) => a.id === recent.id);
+        const asset = assets.find((a: AssetUsers) => a.id === recent.id);
         return asset ? { ...asset, selectedAt: recent.selectedAt } : null;
       })
       .filter(Boolean) as (AssetUsers & { selectedAt: number })[];
@@ -296,7 +305,7 @@ function FormAssetsList({
 
       {/* Show search results */}
       <CommandGroup>
-        {assets.map((asset) => (
+        {assets.map((asset: AssetUsers) => (
           <AssetItem
             key={asset.id}
             asset={asset}

--- a/kit/dapp/src/components/blocks/search/search.tsx
+++ b/kit/dapp/src/components/blocks/search/search.tsx
@@ -11,6 +11,7 @@ import { useDebounce } from "@/hooks/use-debounce";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { Link } from "@/i18n/routing";
 import { getAssetSearch } from "@/lib/queries/asset/asset-search";
+import type { AssetUsers } from "@/lib/queries/asset/asset-users-schema";
 import { getUserSearch } from "@/lib/queries/user/user-search";
 import { cn } from "@/lib/utils";
 import { sanitizeSearchTerm } from "@/lib/utils/string";
@@ -21,7 +22,6 @@ import { useForm, useWatch } from "react-hook-form";
 import useSWR from "swr";
 import { getAddress } from "viem";
 import { EvmAddress } from "../evm-address/evm-address";
-
 // Define types for recent items
 type RecentAsset = {
   id: string;
@@ -259,7 +259,7 @@ export const Search = () => {
                 <div className="overflow-hidden p-1 px-2 py-1.5 font-medium text-muted-foreground text-xs">
                   {t("assets-section")}
                 </div>
-                {assets.map((asset) => (
+                {assets.map((asset: AssetUsers) => (
                   <div
                     key={asset.id}
                     className="relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"

--- a/kit/dapp/src/lib/mutations/admin/add-admin-action.ts
+++ b/kit/dapp/src/lib/mutations/admin/add-admin-action.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { t } from "@/lib/utils/typebox";
+import { action } from "../safe-action";
+import { addAdminFunction } from "./add-admin-function";
+import { getAddAdminFormSchema } from "./add-admin-schema";
+
+export const addAdmin = action
+  .schema(getAddAdminFormSchema())
+  .outputSchema(t.Array(t.String()))
+  .action(addAdminFunction);

--- a/kit/dapp/src/lib/mutations/admin/add-admin-function.ts
+++ b/kit/dapp/src/lib/mutations/admin/add-admin-function.ts
@@ -1,0 +1,66 @@
+import type { User } from "@/lib/auth/types";
+import { UserFragment } from "@/lib/queries/user/user-fragment";
+import { hasuraClient, hasuraGraphql } from "@/lib/settlemint/hasura";
+import { revalidatePath } from "next/cache";
+import type { AddAdminFormType } from "./add-admin-schema";
+
+/**
+ * GraphQL mutation for adding an admin
+ */
+const AddAdmin = hasuraGraphql(
+  `
+  mutation AddAdmin($address: String!, $name: String!, $id: String!, $role: String!) {
+    insert_user_one(
+      object: {
+        id: $id,
+        wallet: $address,
+        name: $name,
+        role: $role
+      }
+    ) {
+      ...UserFragment
+    }
+  }
+`,
+  [UserFragment]
+);
+
+/**
+ * Function to add an admin user
+ *
+ * @param input - Validated input for adding an admin
+ * @param user - The user adding the admin
+ * @returns An array containing a mock transaction hash
+ */
+export async function addAdminFunction({
+  parsedInput: { address, firstName, lastName },
+  ctx: { user },
+}: {
+  parsedInput: AddAdminFormType;
+  ctx: { user: User };
+}) {
+  try {
+    const data = await hasuraClient.request(AddAdmin, {
+      id: crypto.randomUUID(),
+      address: address,
+      name: `${firstName} ${lastName}`,
+      role: "admin",
+    });
+
+    const admin = data?.insert_user_one;
+    if (!admin) {
+      throw new Error("Failed to add admin: No data returned");
+    }
+
+    // Revalidate both the parent and specific route to ensure table refresh
+    revalidatePath("/platform/admins", "page");
+
+    // Return a mock Ethereum transaction hash (0x + 64 hex chars)
+    return [`0x${"0".repeat(64)}`];
+  } catch (error) {
+    console.error("Error adding admin:", error);
+    throw new Error(
+      error instanceof Error ? error.message : "Failed to add admin"
+    );
+  }
+}

--- a/kit/dapp/src/lib/mutations/admin/add-admin-schema.ts
+++ b/kit/dapp/src/lib/mutations/admin/add-admin-schema.ts
@@ -1,0 +1,28 @@
+import { type StaticDecode, t } from "@/lib/utils/typebox";
+
+export function getAddAdminFormSchema() {
+  return t.Object(
+    {
+      address: t.EthereumAddress({
+        description: "The wallet address of the admin",
+      }),
+      firstName: t.String({
+        description: "First name of the admin",
+        minLength: 1,
+        errorMessage: "First name is required",
+      }),
+      lastName: t.String({
+        description: "Last name of the admin",
+        minLength: 1,
+        errorMessage: "Last name is required",
+      }),
+    },
+    {
+      description: "Schema for validating add admin form inputs",
+    }
+  );
+}
+
+export type AddAdminFormType = StaticDecode<
+  ReturnType<typeof getAddAdminFormSchema>
+>;

--- a/kit/dapp/src/lib/queries/user/user-count.tsx
+++ b/kit/dapp/src/lib/queries/user/user-count.tsx
@@ -20,6 +20,11 @@ const UserCount = hasuraGraphql(
         ...RecentUsersCountFragment
       }
     }
+    adminUsers: user_aggregate(where: { role: { _eq: "admin" } }) {
+      aggregate {
+        ...RecentUsersCountFragment
+      }
+    }
     user(order_by: { created_at: asc }) {
       ...UserFragment
     }
@@ -46,6 +51,8 @@ export type UserCountResult = {
   recentUsersCount: number;
   /** Total user count */
   totalUsersCount: number;
+  /** Count of admin users */
+  adminUsersCount: number;
 };
 
 /**
@@ -106,6 +113,11 @@ export const getUserCount = cache(async ({ since }: UserCountProps = {}) => {
     result.totalUsers.aggregate
   );
 
+  const adminUsersCount = safeParse(
+    UserCountSchema,
+    result.adminUsers.aggregate
+  );
+
   // Parse and validate each user in the results
   const validatedUsers = safeParse(
     t.Array(UserSchema),
@@ -116,5 +128,6 @@ export const getUserCount = cache(async ({ since }: UserCountProps = {}) => {
     users: calculateCumulativeUsersByDay(validatedUsers),
     recentUsersCount: recentUsersCount.count,
     totalUsersCount: totalUsersCount.count,
+    adminUsersCount: adminUsersCount.count,
   };
 });


### PR DESCRIPTION
## Summary by Sourcery

Add platform admin management features to the settings page, including displaying the number of admin users and providing a link to manage admins

New Features:
- Add a new Permissions Card component to display admin user count
- Introduce a link to manage platform admins from the settings page

Enhancements:
- Update user count query to include admin user count
- Modify settings page layout to accommodate the new permissions card

Chores:
- Add type definitions for asset holders
- Minor UI adjustments to form and search components