### PR TITLE
fix: rollback to react-hook-form v7.54.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,36 +1,40 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:recommended",
-		":automergeMinor",
-		":automergePr",
-		":automergeRequireAllStatusChecks",
-		":gitSignOff",
-		":pinAllExceptPeerDependencies",
-		":semanticCommits",
-		":semanticCommitTypeAll(chore)",
-		":enableVulnerabilityAlerts",
-		":combinePatchMinorReleases",
-		":prConcurrentLimitNone",
-		":prHourlyLimitNone",
-		":widenPeerDependencies",
-		":updateNotScheduled",
-		"security:openssf-scorecard",
-		"schedule:nonOfficeHours",
-		"customManagers:biomeVersions"
-	],
-	"labels": ["dependencies"],
-	"rebaseWhen": "conflicted",
-	"packageRules": [
-		{
-			"groupName": "SettleMint SDK",
-			"groupSlug": "settlemint",
-			"matchPackageNames": ["/^@settlemint//"]
-		}
-	],
-	"hostRules": [
-		{
-			"timeout": 3000000
-		}
-	]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":automergeMinor",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks",
+    ":gitSignOff",
+    ":pinAllExceptPeerDependencies",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":enableVulnerabilityAlerts",
+    ":combinePatchMinorReleases",
+    ":prConcurrentLimitNone",
+    ":prHourlyLimitNone",
+    ":widenPeerDependencies",
+    ":updateNotScheduled",
+    "security:openssf-scorecard",
+    "schedule:nonOfficeHours",
+    "customManagers:biomeVersions"
+  ],
+  "labels": ["dependencies"],
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "groupName": "SettleMint SDK",
+      "groupSlug": "settlemint",
+      "matchPackageNames": ["/^@settlemint//"]
+    },
+    {
+      "matchPackageNames": ["react-hook-form"],
+      "enabled": false
+    }
+  ],
+  "hostRules": [
+    {
+      "timeout": 3000000
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
         "react": "19.1.0",
         "react-awesome-gravatar": "2.0.3",
         "react-dom": "19.1.0",
-        "react-hook-form": "7.55.0",
+        "react-hook-form": "7.54.0",
         "recharts": "2.15.1",
         "resend": "4.2.0",
         "rtl-detect": "1.1.2",
@@ -3093,7 +3093,7 @@
 
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
-    "react-hook-form": ["react-hook-form@7.55.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog=="],
+    "react-hook-form": ["react-hook-form@7.54.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-PS05+UQy/IdSbJNojBypxAo9wllhHgGmyr8/dyGQcPoiMf3e7Dfb9PWYVRco55bLbxH9S+1yDDJeTdlYCSxO3A=="],
 
     "react-is": ["react-is@19.1.0", "", {}, "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="],
 

--- a/kit/dapp/package.json
+++ b/kit/dapp/package.json
@@ -84,7 +84,7 @@
     "react": "19.1.0",
     "react-awesome-gravatar": "2.0.3",
     "react-dom": "19.1.0",
-    "react-hook-form": "7.55.0",
+    "react-hook-form": "7.54.0",
     "recharts": "2.15.1",
     "resend": "4.2.0",
     "rtl-detect": "1.1.2",


### PR DESCRIPTION
## Summary by Sourcery
We have a runtime Max callstack error in the latest version of RHF

Bug Fixes:
- Downgrade react-hook-form from version 7.55.0 to 7.54.0 to address potential compatibility or stability issues