### PR TITLE
fix: create form input validation for long names

### DIFF
--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
@@ -17,6 +17,7 @@ export function Basics() {
           label={t("parameters.common.name-label")}
           placeholder={t("parameters.bonds.name-placeholder")}
           required
+          maxLength={50}
         />
         <div className="grid grid-cols-2 gap-6">
           <FormInput
@@ -26,6 +27,7 @@ export function Basics() {
             placeholder={t("parameters.bonds.symbol-placeholder")}
             textOnly
             required
+            maxLength={10}
           />
           <FormInput
             control={control}

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
@@ -17,6 +17,7 @@ export function Basics() {
           label={t("parameters.common.name-label")}
           placeholder={t("parameters.cryptocurrencies.name-placeholder")}
           required
+          maxLength={50}
         />
         <FormInput
           control={control}
@@ -25,6 +26,7 @@ export function Basics() {
           placeholder={t("parameters.cryptocurrencies.symbol-placeholder")}
           textOnly
           required
+          maxLength={10}
         />
         <FormInput
           control={control}

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
@@ -17,6 +17,7 @@ export function Basics() {
           label={t("parameters.common.name-label")}
           placeholder={t("parameters.deposits.name-placeholder")}
           required
+          maxLength={50}
         />
         <div className="grid grid-cols-2 gap-6">
           <FormInput
@@ -26,6 +27,7 @@ export function Basics() {
             placeholder={t("parameters.deposits.symbol-placeholder")}
             textOnly
             required
+            maxLength={10}
           />
           <FormInput
             control={control}

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
@@ -17,6 +17,7 @@ export function Basics() {
           label={t("parameters.common.name-label")}
           placeholder={t("parameters.equities.name-placeholder")}
           required
+          maxLength={50}
         />
         <div className="grid grid-cols-2 gap-6">
           <FormInput
@@ -26,6 +27,7 @@ export function Basics() {
             placeholder={t("parameters.equities.symbol-placeholder")}
             textOnly
             required
+            maxLength={10}
           />
           <FormInput
             control={control}

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
@@ -17,6 +17,7 @@ export function Basics() {
           label={t("parameters.common.name-label")}
           placeholder={t("parameters.funds.name-placeholder")}
           required
+          maxLength={50}
         />
         <div className="grid grid-cols-2 gap-6">
           <FormInput
@@ -26,6 +27,7 @@ export function Basics() {
             placeholder={t("parameters.funds.symbol-placeholder")}
             textOnly
             required
+            maxLength={10}
           />
           <FormInput
             control={control}

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
@@ -17,6 +17,7 @@ export function Basics() {
           label={t("parameters.common.name-label")}
           placeholder={t("parameters.stablecoins.name-placeholder")}
           required
+          maxLength={50}
         />
         <div className="grid grid-cols-2 gap-6">
           <FormInput
@@ -26,6 +27,7 @@ export function Basics() {
             placeholder={t("parameters.stablecoins.symbol-placeholder")}
             textOnly
             required
+            maxLength={10}
           />
         </div>
         <FormInput

--- a/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
@@ -1,4 +1,4 @@
-import { AssetAdminsSchemaFragment } from '@/lib/mutations/common/asset-admins-schema';
+import { AssetAdminsSchemaFragment } from "@/lib/mutations/common/asset-admins-schema";
 import { isAddressAvailable } from "@/lib/queries/bond-factory/bond-factory-address-available";
 import { type StaticDecode, t } from "@/lib/utils/typebox";
 import { addHours, isFuture } from "date-fns";
@@ -34,9 +34,11 @@ export function CreateBondSchema({
       assetName: t.String({
         description: "The name of the bond",
         minLength: 1,
+        maxLength: 50,
       }),
       symbol: t.AssetSymbol({
         description: "The symbol of the bond (ticker)",
+        maxLength: 10,
       }),
       decimals: t.Decimals({
         description: "The number of decimal places for the token",

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
@@ -25,9 +25,11 @@ export function CreateCryptoCurrencySchema({
       assetName: t.String({
         description: "The name of the cryptocurrency",
         minLength: 1,
+        maxLength: 50,
       }),
       symbol: t.AssetSymbol({
         description: "The symbol of the cryptocurrency (ticker)",
+        maxLength: 10,
       }),
       decimals: t.Decimals({
         description: "The number of decimal places for the token",

--- a/kit/dapp/src/lib/mutations/deposit/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-schema.ts
@@ -21,9 +21,11 @@ export function CreateDepositSchema() {
       assetName: t.String({
         description: "The name of the tokenized deposit",
         minLength: 1,
+        maxLength: 50,
       }),
       symbol: t.AssetSymbol({
         description: "The symbol of the tokenized deposit (ticker)",
+        maxLength: 10,
       }),
       decimals: t.Decimals({
         description: "The number of decimal places for the token",

--- a/kit/dapp/src/lib/mutations/equity/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-schema.ts
@@ -21,9 +21,11 @@ export function CreateEquitySchema() {
       assetName: t.String({
         description: "The name of the equity",
         minLength: 1,
+        maxLength: 50,
       }),
       symbol: t.AssetSymbol({
         description: "The symbol of the equity (ticker)",
+        maxLength: 10,
       }),
       decimals: t.Decimals({
         description: "The number of decimal places for the token",

--- a/kit/dapp/src/lib/mutations/fund/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-schema.ts
@@ -22,9 +22,11 @@ export function CreateFundSchema() {
       assetName: t.String({
         description: "The name of the fund",
         minLength: 1,
+        maxLength: 50,
       }),
       symbol: t.AssetSymbol({
         description: "The symbol of the fund (ticker)",
+        maxLength: 10,
       }),
       decimals: t.Decimals({
         description: "The number of decimal places for the token",

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
@@ -23,9 +23,11 @@ export function CreateStablecoinSchema() {
         assetName: t.String({
           description: "The name of the stablecoin",
           minLength: 1,
+          maxLength: 50,
         }),
         symbol: t.AssetSymbol({
           description: "The symbol of the stablecoin (ticker)",
+          maxLength: 10,
         }),
         decimals: t.Decimals({
           description: "The number of decimal places for the token",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Implement maximum length constraints for asset names (50 characters) and symbols (10 characters) in form inputs and validation schemas