### PR TITLE
fix: long detail grid item text overflows in next column

### DIFF
--- a/kit/dapp/src/components/blocks/detail-grid/detail-grid-item.tsx
+++ b/kit/dapp/src/components/blocks/detail-grid/detail-grid-item.tsx
@@ -1,4 +1,9 @@
 import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -17,6 +22,7 @@ interface DetailGridItemProps extends PropsWithChildren {
 
 export function DetailGridItem({ label, children, info, className }: DetailGridItemProps) {
   const t = useTranslations("components.detail-grid");
+  const contentIsString = typeof children === 'string';
 
   return (
     <div className={cn("space-y-1", className)}>
@@ -40,7 +46,18 @@ export function DetailGridItem({ label, children, info, className }: DetailGridI
           </TooltipProvider>
         )}
       </div>
-      <div className="text-md">{children}</div>
+      {contentIsString ? (
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <div className="text-md truncate cursor-default">{children}</div>
+          </HoverCardTrigger>
+          <HoverCardContent className="w-auto max-w-96">
+            <div className="font-mono break-all text-sm">{children}</div>
+          </HoverCardContent>
+        </HoverCard>
+      ) : (
+        <div className="text-md truncate">{children}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
![Screenshot 2025-04-02 at 11 19 45](https://github.com/user-attachments/assets/f824154e-c4ad-4685-8045-6a8cfa5d0970)

## Summary by Sourcery

Improve handling of long text in detail grid items by adding truncation and hover card for string content

Bug Fixes:
- Prevent long text from overflowing to next column by adding truncation to detail grid item content

Enhancements:
- Add hover card to display full text when truncated string content is hovered