### PR TITLE
fix: allow empty asset admins array as default

### DIFF
--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -58,6 +58,7 @@ export function CreateDepositForm({
             amount: 1,
             currency: userDetails.currency,
           },
+          assetAdmins: [],
         }}
       >
         <Basics />

--- a/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
@@ -53,6 +53,7 @@ export function CreateEquityForm({
             amount: 1,
             currency: userDetails.currency,
           },
+          assetAdmins: [],
         }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);

--- a/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
@@ -55,8 +55,6 @@ export function CreateFundForm({
             amount: 1,
             currency: userDetails.currency,
           },
-          verificationType: "pincode",
-          predictedAddress: "0x0000000000000000000000000000000000000000",
           assetAdmins: [],
         }}
         onAnyFieldChange={({ clearErrors }) => {

--- a/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
@@ -55,6 +55,9 @@ export function CreateFundForm({
             amount: 1,
             currency: userDetails.currency,
           },
+          verificationType: "pincode",
+          predictedAddress: "0x0000000000000000000000000000000000000000",
+          assetAdmins: [],
         }}
         onAnyFieldChange={({ clearErrors }) => {
           clearErrors(["predictedAddress"]);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure that asset admins are initialized as an empty array by default in create forms for deposit, equity, and fund