### PR TITLE
feat: add bun helm:install and bun helm:reset commands

### DIFF
--- a/kit/charts/atk/charts/besu-network/charts/besu-node/templates/node-statefulset.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-node/templates/node-statefulset.yaml
@@ -42,10 +42,7 @@ spec:
 {{- else }}
       serviceAccountName: {{ include "besu-node.fullname" . }}-sa
 {{- end }}
-      imagePullSecrets:
-        {{- with .Values.imagePullSecrets }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- include "atk.imagePullSecrets" . | nindent 6 }}
       initContainers:
 
 {{- if has .Values.cluster.provider .Values.volumePermissionsFix }}

--- a/kit/charts/atk/charts/erpc/templates/deployment.yaml
+++ b/kit/charts/atk/charts/erpc/templates/deployment.yaml
@@ -23,10 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "atk.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "erpc.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/kit/charts/atk/charts/portal/templates/deployment.yaml
+++ b/kit/charts/atk/charts/portal/templates/deployment.yaml
@@ -23,10 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "atk.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "portal.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/kit/charts/atk/templates/_helpers.tpl
+++ b/kit/charts/atk/templates/_helpers.tpl
@@ -85,3 +85,13 @@ Common annotations
 {{- toYaml .Values.global.annotations }}
 {{- end }}
 {{- end }}
+
+{{/*
+Common image pull secrets for all deployments/statefulsets
+*/}}
+{{- define "atk.imagePullSecrets" -}}
+imagePullSecrets:
+  - name: image-pull-secret-docker
+  - name: image-pull-secret-ghcr
+  - name: image-pull-secret-harbor
+{{- end }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "test:e2e": "bun run --cwd kit/e2e test:e2e",
     "test:e2e:ui": "bun run --cwd kit/e2e test:e2e:ui",
     "secrets": "op inject --force -i kit/charts/atk/values-example.1p.yaml -o kit/charts/atk/values-example.yaml",
-    "helm:delete": "helm uninstall atk -n atk --wait && kubectl delete pvc --all -n atk"
+    "abis": "bun run --cwd kit/contracts dependencies && bun run --cwd kit/contracts compile:forge && bun run --cwd kit/contracts abi-output && mkdir -p kit/charts/atk/charts/portal/abis && cp kit/contracts/portal/*.json kit/charts/atk/charts/portal/abis/",
+    "helm:install": "bun run secrets && bun run abis && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
+    "helm:delete": "helm uninstall atk -n atk --wait && kubectl delete pvc --all -n atk",
+    "helm:reset": "bun run helm:delete && bun run helm:install"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Add Helm installation and reset commands to simplify deployment and management of the Kubernetes environment

New Features:
- Introduce new Helm installation command that prepares secrets and ABIs before deploying
- Add a Helm reset command to delete and reinstall the Kubernetes deployment

Enhancements:
- Standardize image pull secrets across different Helm charts using a common helper template
- Simplify deployment scripts with new npm run commands

Chores:
- Update package.json scripts to include new Helm-related commands