### PR TITLE
fix: show app name in authenticator app

### DIFF
--- a/kit/dapp/src/components/blocks/auth/two-factor/setup-two-factor-dialog.tsx
+++ b/kit/dapp/src/components/blocks/auth/two-factor/setup-two-factor-dialog.tsx
@@ -76,29 +76,24 @@ export function SetupTwoFactorDialog({
           onFirstOtpChange={setFirstOtp}
         />
         <DialogFooter>
-          <div className="flex w-full justify-between items-center">
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                onClick={() => {
-                  onOpenChange(false);
-                }}
-                disabled={isLoading}
-              >
-                {t("setup-mfa.cancel")}
-              </Button>
-
-              <Button
-                onClick={(e) => {
-                  e.preventDefault();
-                  onSetupFinished();
-                }}
-                disabled={!firstOtp.trim() || isLoading}
-              >
-                {isLoading ? t("setup-mfa.loading") : t("setup-mfa.enable")}
-              </Button>
-            </div>
-          </div>
+          <Button
+            variant="outline"
+            onClick={() => {
+              onOpenChange(false);
+            }}
+            disabled={isLoading}
+          >
+            {t("setup-mfa.cancel")}
+          </Button>
+          <Button
+            onClick={(e) => {
+              e.preventDefault();
+              onSetupFinished();
+            }}
+            disabled={!firstOtp.trim() || isLoading}
+          >
+            {isLoading ? t("setup-mfa.loading") : t("setup-mfa.enable")}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/kit/dapp/src/lib/mutations/user/two-factor/enable-two-factor-function.ts
+++ b/kit/dapp/src/lib/mutations/user/two-factor/enable-two-factor-function.ts
@@ -1,5 +1,6 @@
 import type { User } from "@/lib/auth/types";
 import { getUser } from "@/lib/auth/utils";
+import { metadata } from "@/lib/config/metadata";
 import { portalClient, portalGraphql } from "@/lib/settlemint/portal";
 import { revalidateTag } from "next/cache";
 import { ApiError } from "next/dist/server/api-utils";
@@ -9,10 +10,24 @@ import type { EnableTwoFactorInput } from "./enable-two-factor-schema";
  * GraphQL mutation to enable a two-factor authentication for wallet verification
  */
 const EnableTwoFactor = portalGraphql(`
-  mutation EnableTwoFactor($address: String!, $algorithm: OTPAlgorithm!, $digits: Int!, $period: Int!) {
+  mutation EnableTwoFactor(
+    $address: String!,
+    $algorithm: OTPAlgorithm!,
+    $digits: Int!,
+    $period: Int!,
+    $issuer: String!
+  ) {
     createWalletVerification(
       userWalletAddress: $address
-      verificationInfo: { otp: { name: "OTP", algorithm: $algorithm, digits: $digits, period: $period } }
+      verificationInfo: {
+        otp: {
+          name: "OTP",
+          algorithm: $algorithm,
+          digits: $digits,
+          period: $period,
+          issuer: $issuer
+        }
+      }
     ) {
       id
       name
@@ -45,6 +60,7 @@ export async function enableTwoFactorFunction({
     algorithm,
     digits,
     period,
+    issuer: metadata.title.default,
   });
   const parameters = result.createWalletVerification?.parameters as {
     uri?: string;


### PR DESCRIPTION
## Summary by Sourcery

Add app name (issuer) to two-factor authentication setup for authenticator apps

Bug Fixes:
- Improve two-factor authentication setup by including the app name in the QR code generation

Enhancements:
- Modify GraphQL mutation to support adding an issuer name for two-factor authentication