### PR TITLE
feat: automate subgraph deployment

### DIFF
--- a/kit/charts/atk/Chart.lock
+++ b/kit/charts/atk/Chart.lock
@@ -2,38 +2,23 @@ dependencies:
 - name: support
   repository: ""
   version: '*'
-- name: besu-genesis
+- name: observability
   repository: ""
   version: '*'
-- name: besu-node
-  repository: ""
-  version: '*'
-- name: besu-node
-  repository: ""
-  version: '*'
-- name: besu-node
-  repository: ""
-  version: '*'
-- name: besu-node
-  repository: ""
-  version: '*'
-- name: besu-node
-  repository: ""
-  version: '*'
-- name: besu-node
+- name: besu-network
   repository: ""
   version: '*'
 - name: erpc
   repository: ""
   version: '*'
-- name: blockscout-stack
-  repository: https://blockscout.github.io/helm-charts
-  version: 2.0.3
-- name: graph-node
-  repository: http://graphops.github.io/launchpad-charts
-  version: 0.5.9
-- name: graphql-engine
-  repository: https://hasura.github.io/helm-charts
-  version: 0.8.0
-digest: sha256:72bda5d742f2d28e411672de0f83aadfcb950b9425ffb5efd591ed3a0e20f75f
-generated: "2025-03-30T08:30:30.277189+02:00"
+- name: blockscout
+  repository: ""
+  version: '*'
+- name: thegraph
+  repository: ""
+  version: '*'
+- name: portal
+  repository: ""
+  version: '*'
+digest: sha256:192a456022084d224ece64f8bb7a2c14bf4f577d7fa5413618fe9292a1251483
+generated: "2025-04-09T15:26:01.166377+03:00"

--- a/kit/charts/atk/charts/observability/values.yaml
+++ b/kit/charts/atk/charts/observability/values.yaml
@@ -168,7 +168,7 @@ loki:
   deploymentMode: SingleBinary
   singleBinary:
     persistence:
-      size: 50Gi
+      size: 10Gi
     replicas: 1
     resources: {}
     # extraEnv:

--- a/kit/charts/atk/charts/thegraph/Chart.lock
+++ b/kit/charts/atk/charts/thegraph/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: http://graphops.github.io/launchpad-charts
   version: 0.5.9
 digest: sha256:d437a20463efb67af06f6ba2fbe88aa9c25941e924ea03220a31ad62c123e32c
-generated: "2025-03-30T11:13:22.84116+02:00"
+generated: "2025-04-09T15:38:21.891901+03:00"

--- a/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
+++ b/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
@@ -1,0 +1,142 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-{{ .Values.job.fullnameOverride }}-deploy-subgraph
+  labels:
+    {{- include "thegraph.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      {{- with .Values.job.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "thegraph.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.job.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.job.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-graph-node
+          image: busybox
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Waiting for {{ index .Values "graph-node" "fullnameOverride" }}-query:8020 to be available..."
+              until nc -z -w 2 {{ index .Values "graph-node" "fullnameOverride" }}-query 8020; do
+                echo "Service not ready yet, waiting..."
+                sleep 5
+              done
+              echo "Service is available, proceeding..."
+        - name: clone-repo
+          image: alpine/git:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -ex
+              if [ -z "$(ls -A /workspace)" ]; then
+                git clone https://github.com/settlemint/asset-tokenization-kit.git /workspace
+              else
+                cd /workspace
+                git pull
+              fi
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.job.securityContext | nindent 12 }}
+          image: {{ .Values.job.image.repository }}:{{ .Values.job.image.tag }}
+          imagePullPolicy: {{ .Values.job.image.pullPolicy }}
+          resources:
+            requests:
+              memory: {{ .Values.job.resources.requests.memory | quote }}
+              cpu: {{ .Values.job.resources.requests.cpu | quote }}
+            limits:
+              memory: {{ .Values.job.resources.limits.memory | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -ex
+
+              echo "Updating apt..."
+              apt-get update
+              apt-get install -y jq yq curl git
+
+              echo "Checking for Foundry..."
+              if ! command -v forge &> /dev/null
+              then
+                echo "Foundry not found, installing..."
+                curl -L https://foundry.paradigm.xyz | bash
+                . /root/.bashrc
+                foundryup
+              else
+                echo "Foundry is already installed."
+              fi
+
+              echo "Installing Bun..."
+              npm install -g bun
+
+              # Verify Bun installation
+              bun --version
+
+              echo "Installing dependencies..."
+              cd /workspace
+              bun install
+
+              echo "Dependencies installed"
+              bunx turbo dependencies
+
+              # Replace localhost with graph-node-query for subgraph deployment
+              sed -i 's|http://localhost:8020|http://{{ index .Values "graph-node" "fullnameOverride" }}-query:8020|g' /workspace/kit/subgraph/graph-local-deploy.sh
+              sed -i 's/yq -i/yq -i -y/g' /workspace/kit/subgraph/graph-local-deploy.sh
+
+              echo "Build forge contracts..."
+              cd /workspace/kit/contracts
+              forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} +
+              forge build --sizes
+
+              echo "Build hardhat contracts..."
+              npx hardhat compile
+
+              echo "Build genesis..."
+              bash -ex genesis-output.sh
+
+              echo "Build abi-output..."
+              bash -ex abi-output.sh
+
+              echo "Start hardhat node..."
+              nohup npx hardhat node &
+
+              echo "Deploy contracts..."
+              bun deploy:local
+
+              echo "Build subgraph..."
+              cd /workspace/kit/subgraph
+              npx graph codegen
+              graph build --ipfs=https://ipfs.console.settlemint.com subgraph.yaml | tee subgraph-output.txt
+
+              /bin/bash /workspace/kit/subgraph/graph-local-deploy.sh
+
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ include "thegraph.fullname" . }}-workspace
+  backoffLimit: 0

--- a/kit/charts/atk/charts/thegraph/templates/pvc-workspace.yaml
+++ b/kit/charts/atk/charts/thegraph/templates/pvc-workspace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "thegraph.fullname" . }}-workspace
+  labels:
+    {{- include "thegraph.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.job.workspace.size | default "1Gi" }}
+  storageClassName: {{ .Values.job.workspace.storageClass | default "standard" }}

--- a/kit/charts/atk/charts/thegraph/values.yaml
+++ b/kit/charts/atk/charts/thegraph/values.yaml
@@ -1,3 +1,6 @@
+global:
+  labels: {}
+
 # https://github.com/graphops/launchpad-charts/blob/main/charts/graph-node/values.yaml
 graph-node:
   fullnameOverride: graph-node
@@ -94,3 +97,38 @@ graph-node:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+job:
+  fullnameOverride: graph
+
+  # Pod Security Context
+  podSecurityContext: {}
+
+  # Container Security Context
+  securityContext: {}
+
+  # Image configuration
+  image:
+    repository: node
+    tag: "23-slim"
+    pullPolicy: IfNotPresent
+
+  # Pod annotations
+  podAnnotations: {}
+
+  # Image pull secrets
+  imagePullSecrets: []
+
+  # Resource configuration
+  resources:
+    requests:
+      memory: "2Gi"
+      cpu: "250m"
+    limits:
+      memory: "3Gi"
+
+  workspace:
+    # Size of the workspace PVC
+    size: 1Gi
+    # Storage class to use for the workspace PVC
+    storageClass: local-path

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -331,6 +331,14 @@ thegraph:
               pathType: ImplementationSpecific
               port: 8050
               serviceName: graph-node-index
+  job:
+    fullnameOverride: graph
+    image:
+      repository: node
+      tag: "23-slim"
+      pullPolicy: IfNotPresent
+    workspace:
+      size: 1Gi
 
 hasura:
   enabled: true

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "secrets": "op inject --force -i kit/charts/atk/values-example.1p.yaml -o kit/charts/atk/values-example.yaml",
     "abis": "bun run --cwd kit/contracts dependencies && bun run --cwd kit/contracts compile:forge && bun run --cwd kit/contracts abi-output && mkdir -p kit/charts/atk/charts/portal/abis && cp kit/contracts/portal/*.json kit/charts/atk/charts/portal/abis/",
     "helm:full": "bun run secrets && bun run abis && bunx turbo genesis && cp kit/contracts/genesis-output.json kit/charts/atk/charts/besu-network/charts/besu-genesis/files/genesis-output.json && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
-    "helm:install": "helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
+    "helm:dependency": "helm dependency update kit/charts/atk",
+    "helm:install": "bun run helm:dependency && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
     "helm:delete": "helm uninstall atk -n atk --wait && kubectl delete pvc --all -n atk && kubectl delete namespace atk",
     "helm:reset": "bun run helm:delete && bun run helm:install"
   },


### PR DESCRIPTION

<img width="865" alt="Screenshot 2025-04-09 at 16 18 05" src="https://github.com/user-attachments/assets/2a008707-6b45-4ead-aabe-414e02102889" />


## Summary by Sourcery

Automate subgraph deployment by adding a Kubernetes job that handles the entire deployment process for The Graph subgraph in the asset tokenization kit

New Features:
- Introduce a Kubernetes job that automatically clones the repository, sets up development tools, builds contracts, and deploys the subgraph in a post-install/upgrade hook

Enhancements:
- Update Helm chart configuration to support automated subgraph deployment
- Modify deployment scripts to work with Kubernetes environment

Build:
- Add new Helm chart templates for job and persistent volume claim
- Update package.json scripts to include helm dependency update

Chores:
- Reduce Loki persistent volume size from 50Gi to 10Gi
- Add global labels configuration to chart values