### PR TITLE
fix: default range takes into account the age of the asset

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/(details)/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/(details)/page.tsx
@@ -9,14 +9,13 @@ import { TotalSupplyChanged } from "@/components/blocks/charts/assets/total-supp
 import { TotalTransfers } from "@/components/blocks/charts/assets/total-transfers";
 import { TotalVolume } from "@/components/blocks/charts/assets/total-volume";
 import { WalletDistribution } from "@/components/blocks/charts/assets/wallet-distribution";
-import type { TimeRange } from "@/components/blocks/charts/time-series";
 import { getUser } from "@/lib/auth/utils";
 import { getAssetBalanceDetail } from "@/lib/queries/asset-balance/asset-balance-detail";
 import { getAssetDetail } from "@/lib/queries/asset-detail";
 import { getAssetStats } from "@/lib/queries/asset-stats/asset-stats";
 import { getAssetUsersDetail } from "@/lib/queries/asset/asset-users-detail";
 import type { AssetType } from "@/lib/utils/typebox/asset-types";
-import { differenceInSeconds } from "date-fns";
+import { calculateMaxRange } from "@/utils/timeRange";
 import type { Locale } from "next-intl";
 import { getLocale, getTranslations } from "next-intl/server";
 import type { Address } from "viem";
@@ -67,29 +66,6 @@ export default async function AssetDetailsPage({ params }: PageProps) {
     getAssetStats({ address }),
     getLocale(),
   ]);
-
-  const calculateMaxRange = (deployedOn: bigint): TimeRange => {
-    const now = new Date();
-    // Convert bigint seconds to milliseconds for Date constructor
-    const deployedDate = new Date(Number(deployedOn) * 1000);
-    const diffSeconds = differenceInSeconds(now, deployedDate);
-
-    // Determine the appropriate range based on the age of the asset
-    if (diffSeconds < 24 * 60 * 60) {
-      // Less than 24 hours
-      return "24h";
-    }
-    if (diffSeconds < 7 * 24 * 60 * 60) {
-      // Less than 7 days
-      return "7d";
-    }
-    if (diffSeconds < 30 * 24 * 60 * 60) {
-      // Less than 30 days
-      return "30d";
-    }
-    // Default to 90d if older than 30 days
-    return "90d";
-  };
 
   const calculatedMaxRange = calculateMaxRange(assetDetails.deployedOn);
 

--- a/kit/dapp/src/components/blocks/charts/assets/total-supply-changed.tsx
+++ b/kit/dapp/src/components/blocks/charts/assets/total-supply-changed.tsx
@@ -6,6 +6,7 @@ import {
   TimeSeriesChart,
   TimeSeriesRoot,
   TimeSeriesTitle,
+  type TimeRange,
 } from "@/components/blocks/charts/time-series";
 import { ChartColumnIncreasingIcon } from "@/components/ui/animated-icons/chart-column-increasing";
 import type { ChartConfig } from "@/components/ui/chart";
@@ -18,9 +19,14 @@ import { useTranslations, type Locale } from "next-intl";
 interface TotalSupplyChangedProps {
   data: AssetStats[];
   locale: Locale;
+  maxRange?: TimeRange;
 }
 
-export function TotalSupplyChanged({ data, locale }: TotalSupplyChangedProps) {
+export function TotalSupplyChanged({
+  data,
+  locale,
+  maxRange = "30d",
+}: TotalSupplyChangedProps) {
   const t = useTranslations("components.charts.assets");
 
   const chartConfig = {
@@ -46,7 +52,7 @@ export function TotalSupplyChanged({ data, locale }: TotalSupplyChangedProps) {
   }
 
   return (
-    <TimeSeriesRoot locale={locale}>
+    <TimeSeriesRoot locale={locale} maxRange={maxRange}>
       <TimeSeriesTitle
         title={t("total-supply-changed.title")}
         description={t("total-supply-changed.description")}

--- a/kit/dapp/src/components/blocks/charts/assets/total-supply.tsx
+++ b/kit/dapp/src/components/blocks/charts/assets/total-supply.tsx
@@ -5,6 +5,7 @@ import {
   TimeSeriesChart,
   TimeSeriesRoot,
   TimeSeriesTitle,
+  type TimeRange,
 } from "@/components/blocks/charts/time-series";
 import { TIME_RANGE_CONFIG } from "@/components/blocks/charts/time-series/index";
 import { ChartColumnIncreasingIcon } from "@/components/ui/animated-icons/chart-column-increasing";
@@ -22,12 +23,14 @@ interface TotalSupplyProps {
   locale: Locale;
   interval?: "day" | "week" | "month" | "year";
   size?: "small" | "large";
+  maxRange?: TimeRange;
 }
 
 export function TotalSupply({
   data,
   locale,
   size = "small",
+  maxRange = "30d",
 }: TotalSupplyProps) {
   const t = useTranslations("components.charts.assets");
 
@@ -60,7 +63,11 @@ export function TotalSupply({
   } satisfies ChartConfig;
 
   return (
-    <TimeSeriesRoot locale={locale} className={cn(size === "large" && "mb-4")}>
+    <TimeSeriesRoot
+      locale={locale}
+      className={cn(size === "large" && "mb-4")}
+      maxRange={maxRange}
+    >
       <TimeSeriesTitle
         title={t("total-supply.title")}
         description={t("total-supply.description")}

--- a/kit/dapp/src/components/blocks/charts/assets/total-transfers.tsx
+++ b/kit/dapp/src/components/blocks/charts/assets/total-transfers.tsx
@@ -13,14 +13,20 @@ import {
   TimeSeriesChart,
   TimeSeriesRoot,
   TimeSeriesTitle,
+  type TimeRange,
 } from "../time-series";
 
 interface TotalTransfersProps {
   data: AssetStats[];
   locale: Locale;
+  maxRange?: TimeRange;
 }
 
-export function TotalTransfers({ data, locale }: TotalTransfersProps) {
+export function TotalTransfers({
+  data,
+  locale,
+  maxRange = "30d",
+}: TotalTransfersProps) {
   const t = useTranslations("components.charts.assets");
 
   const chartConfig = {
@@ -42,7 +48,7 @@ export function TotalTransfers({ data, locale }: TotalTransfersProps) {
   }
 
   return (
-    <TimeSeriesRoot locale={locale}>
+    <TimeSeriesRoot locale={locale} maxRange={maxRange}>
       <TimeSeriesTitle
         title={t("total-transfers.title")}
         description={t("total-transfers.description")}

--- a/kit/dapp/src/components/blocks/charts/assets/total-volume.tsx
+++ b/kit/dapp/src/components/blocks/charts/assets/total-volume.tsx
@@ -5,6 +5,7 @@ import {
   TimeSeriesChart,
   TimeSeriesRoot,
   TimeSeriesTitle,
+  type TimeRange,
 } from "@/components/blocks/charts/time-series";
 import { ChartColumnIncreasingIcon } from "@/components/ui/animated-icons/chart-column-increasing";
 import type { ChartConfig } from "@/components/ui/chart";
@@ -16,9 +17,14 @@ import { useTranslations, type Locale } from "next-intl";
 interface TotalVolumeProps {
   data: AssetStats[];
   locale: Locale;
+  maxRange?: TimeRange;
 }
 
-export function TotalVolume({ data, locale }: TotalVolumeProps) {
+export function TotalVolume({
+  data,
+  locale,
+  maxRange = "30d",
+}: TotalVolumeProps) {
   const t = useTranslations("components.charts.assets");
 
   const chartConfig = {
@@ -40,7 +46,7 @@ export function TotalVolume({ data, locale }: TotalVolumeProps) {
   }
 
   return (
-    <TimeSeriesRoot locale={locale}>
+    <TimeSeriesRoot locale={locale} maxRange={maxRange}>
       <TimeSeriesTitle
         title={t("total-volume.title")}
         description={t("total-volume.description")}

--- a/kit/dapp/src/components/blocks/charts/portfolio/portfolio-value.tsx
+++ b/kit/dapp/src/components/blocks/charts/portfolio/portfolio-value.tsx
@@ -28,6 +28,7 @@ interface PortfolioValueProps {
   portfolioStats: PortfolioStatsCollection;
   assetPriceMap: Map<string, Price>;
   locale: Locale;
+  maxRange?: TimeRange;
 }
 
 type AggregationType = "total" | "stackByType" | "compareTypes";
@@ -36,6 +37,7 @@ export function PortfolioValue({
   portfolioStats,
   assetPriceMap,
   locale,
+  maxRange = "30d",
 }: PortfolioValueProps) {
   const t = useTranslations("components.charts.portfolio");
   const [aggregationType, setAggregationType] =
@@ -171,7 +173,7 @@ export function PortfolioValue({
   };
 
   return (
-    <TimeSeriesRoot locale={locale}>
+    <TimeSeriesRoot locale={locale} maxRange={maxRange}>
       <TimeSeriesTitle
         title={t("portfolio-value-title")}
         description={t("portfolio-value-description")}

--- a/kit/dapp/src/components/blocks/charts/time-series/index.tsx
+++ b/kit/dapp/src/components/blocks/charts/time-series/index.tsx
@@ -83,6 +83,7 @@ interface TimeSeriesState {
   chartType: ChartType;
   setChartType: (type: ChartType) => void;
   locale: Locale;
+  maxRange: TimeRange;
 }
 
 const TimeSeriesContext = createContext<TimeSeriesState | null>(null);
@@ -100,13 +101,15 @@ interface TimeSeriesRootProps {
   locale: Locale;
   defaultTimeRange?: TimeRange;
   defaultChartType?: ChartType;
+  maxRange?: TimeRange;
   className?: string;
 }
 
 export function TimeSeriesRoot({
   children,
   locale,
-  defaultTimeRange = "30d",
+  defaultTimeRange = "7d",
+  maxRange = "30d",
   defaultChartType = "area",
   className,
 }: TimeSeriesRootProps) {
@@ -121,6 +124,7 @@ export function TimeSeriesRoot({
         chartType,
         setChartType,
         locale,
+        maxRange,
       }}
     >
       <Card className={cn(className)}>{children}</Card>
@@ -140,7 +144,15 @@ export function TimeSeriesTitle({
   lastUpdated,
 }: TimeSeriesTitleProps) {
   const t = useTranslations("components.chart");
-  const { chartType, setChartType, timeRange, setTimeRange } = useTimeSeries();
+  const { chartType, setChartType, timeRange, setTimeRange, maxRange } =
+    useTimeSeries();
+
+  const availableTimeRanges: TimeRange[] = ["24h", "7d", "30d", "90d"];
+  const maxRangeIndex = availableTimeRanges.indexOf(maxRange);
+  const filteredTimeRanges =
+    maxRangeIndex !== -1
+      ? availableTimeRanges.slice(0, maxRangeIndex + 1)
+      : availableTimeRanges;
 
   return (
     <CardHeader>
@@ -176,10 +188,11 @@ export function TimeSeriesTitle({
               <SelectValue placeholder={t("select-time-range")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="24h">{t("time-range.24h")}</SelectItem>
-              <SelectItem value="7d">{t("time-range.7d")}</SelectItem>
-              <SelectItem value="30d">{t("time-range.30d")}</SelectItem>
-              <SelectItem value="90d">{t("time-range.90d")}</SelectItem>
+              {filteredTimeRanges.map((range) => (
+                <SelectItem key={range} value={range}>
+                  {t(`time-range.${range}`)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
 

--- a/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-fragment.ts
+++ b/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-fragment.ts
@@ -20,6 +20,7 @@ export const CryptoCurrencyFragment = theGraphGraphqlKit(`
       id
     }
     concentration
+    deployedOn
   }
 `);
 

--- a/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-schema.ts
+++ b/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-schema.ts
@@ -47,7 +47,7 @@ export const OnChainCryptoCurrencySchema = t.Object(
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
     deployedOn: t.StringifiedBigInt({
-      description: "The timestamp when the bond was deployed",
+      description: "The timestamp when the cryptocurrency was deployed",
     }),
   },
   {

--- a/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-schema.ts
+++ b/kit/dapp/src/lib/queries/cryptocurrency/cryptocurrency-schema.ts
@@ -46,6 +46,9 @@ export const OnChainCryptoCurrencySchema = t.Object(
       description:
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
+    deployedOn: t.StringifiedBigInt({
+      description: "The timestamp when the bond was deployed",
+    }),
   },
   {
     description:

--- a/kit/dapp/src/lib/queries/deposit/deposit-fragment.ts
+++ b/kit/dapp/src/lib/queries/deposit/deposit-fragment.ts
@@ -28,6 +28,7 @@ export const DepositFragment = theGraphGraphqlKit(`
       id
     }
     concentration
+    deployedOn
   }
 `);
 

--- a/kit/dapp/src/lib/queries/deposit/deposit-schema.ts
+++ b/kit/dapp/src/lib/queries/deposit/deposit-schema.ts
@@ -77,6 +77,9 @@ export const OnChainDepositSchema = t.Object(
       description:
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
+    deployedOn: t.StringifiedBigInt({
+      description: "The timestamp when the bond was deployed",
+    }),
   },
   {
     description:

--- a/kit/dapp/src/lib/queries/deposit/deposit-schema.ts
+++ b/kit/dapp/src/lib/queries/deposit/deposit-schema.ts
@@ -78,7 +78,7 @@ export const OnChainDepositSchema = t.Object(
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
     deployedOn: t.StringifiedBigInt({
-      description: "The timestamp when the bond was deployed",
+      description: "The timestamp when the deposit was deployed",
     }),
   },
   {

--- a/kit/dapp/src/lib/queries/equity/equity-fragment.ts
+++ b/kit/dapp/src/lib/queries/equity/equity-fragment.ts
@@ -25,6 +25,7 @@ export const EquityFragment = theGraphGraphqlKit(`
       id
     }
     concentration
+    deployedOn
   }
 `);
 

--- a/kit/dapp/src/lib/queries/equity/equity-schema.ts
+++ b/kit/dapp/src/lib/queries/equity/equity-schema.ts
@@ -64,7 +64,7 @@ export const OnChainEquitySchema = t.Object(
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
     deployedOn: t.StringifiedBigInt({
-      description: "The timestamp when the bond was deployed",
+      description: "The timestamp when the equity was deployed",
     }),
   },
   {

--- a/kit/dapp/src/lib/queries/equity/equity-schema.ts
+++ b/kit/dapp/src/lib/queries/equity/equity-schema.ts
@@ -63,6 +63,9 @@ export const OnChainEquitySchema = t.Object(
       description:
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
+    deployedOn: t.StringifiedBigInt({
+      description: "The timestamp when the bond was deployed",
+    }),
   },
   {
     description:

--- a/kit/dapp/src/lib/queries/fund/fund-fragment.ts
+++ b/kit/dapp/src/lib/queries/fund/fund-fragment.ts
@@ -31,6 +31,7 @@ export const FundFragment = theGraphGraphqlKit(`
         value
       }
     }
+    deployedOn
   }
 `);
 

--- a/kit/dapp/src/lib/queries/fund/fund-schema.ts
+++ b/kit/dapp/src/lib/queries/fund/fund-schema.ts
@@ -88,6 +88,9 @@ export const OnChainFundSchema = t.Object(
         description: "Information about fund's own holdings as an account",
       }
     ),
+    deployedOn: t.StringifiedBigInt({
+      description: "The timestamp when the bond was deployed",
+    }),
   },
   {
     description:

--- a/kit/dapp/src/lib/queries/fund/fund-schema.ts
+++ b/kit/dapp/src/lib/queries/fund/fund-schema.ts
@@ -89,7 +89,7 @@ export const OnChainFundSchema = t.Object(
       }
     ),
     deployedOn: t.StringifiedBigInt({
-      description: "The timestamp when the bond was deployed",
+      description: "The timestamp when the fund was deployed",
     }),
   },
   {

--- a/kit/dapp/src/lib/queries/stablecoin/stablecoin-fragment.ts
+++ b/kit/dapp/src/lib/queries/stablecoin/stablecoin-fragment.ts
@@ -28,6 +28,7 @@ export const StableCoinFragment = theGraphGraphqlKit(`
       id
     }
     concentration
+    deployedOn
   }
 `);
 

--- a/kit/dapp/src/lib/queries/stablecoin/stablecoin-schema.ts
+++ b/kit/dapp/src/lib/queries/stablecoin/stablecoin-schema.ts
@@ -77,7 +77,7 @@ export const OnChainStableCoinSchema = t.Object(
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
     deployedOn: t.StringifiedBigInt({
-      description: "The timestamp when the bond was deployed",
+      description: "The timestamp when the stablecoin was deployed",
     }),
   },
   {

--- a/kit/dapp/src/lib/queries/stablecoin/stablecoin-schema.ts
+++ b/kit/dapp/src/lib/queries/stablecoin/stablecoin-schema.ts
@@ -76,6 +76,9 @@ export const OnChainStableCoinSchema = t.Object(
       description:
         "The percentage of total supply held by the top holders, indicating ownership concentration",
     }),
+    deployedOn: t.StringifiedBigInt({
+      description: "The timestamp when the bond was deployed",
+    }),
   },
   {
     description:

--- a/kit/dapp/src/utils/timeRange.ts
+++ b/kit/dapp/src/utils/timeRange.ts
@@ -1,0 +1,31 @@
+import type { TimeRange } from "@/components/blocks/charts/time-series";
+import { differenceInSeconds } from "date-fns";
+
+/**
+ * Calculates the maximum time range for charts based on the deployment date of an asset.
+ *
+ * @param deployedOn - The deployment timestamp of the asset (in seconds as a bigint).
+ * @returns The appropriate TimeRange ("24h", "7d", "30d", "90d").
+ */
+export const calculateMaxRange = (deployedOn: bigint): TimeRange => {
+  const now = new Date();
+  // Convert bigint seconds to milliseconds for Date constructor
+  const deployedDate = new Date(Number(deployedOn) * 1000);
+  const diffSeconds = differenceInSeconds(now, deployedDate);
+
+  // Determine the appropriate range based on the age of the asset
+  if (diffSeconds < 24 * 60 * 60) {
+    // Less than 24 hours
+    return "24h";
+  }
+  if (diffSeconds < 7 * 24 * 60 * 60) {
+    // Less than 7 days
+    return "7d";
+  }
+  if (diffSeconds < 30 * 24 * 60 * 60) {
+    // Less than 30 days
+    return "30d";
+  }
+  // Default to 90d if older than 30 days
+  return "90d";
+};


### PR DESCRIPTION
## Summary by Sourcery

Modify time series charts to dynamically adjust the maximum time range based on the asset's age

New Features:
- Introduce a flexible time range selection that limits chart views based on asset age

Enhancements:
- Implement a dynamic time range calculation that adapts to the asset's deployment date
- Add a new 'deployedOn' field to asset schemas to track asset creation timestamp