### PR TITLE
fix: wrong bond underlying asset balance decimals

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/(details)/_components/details/bonds.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/(details)/_components/details/bonds.tsx
@@ -66,12 +66,14 @@ export async function BondsDetails({
         <DetailGridItem label={t("total-supply")} info={t("total-supply-info")}>
           {formatNumber(bond.cap, {
             token: bond.symbol,
+            decimals: bond.decimals,
             locale: locale,
           })}
         </DetailGridItem>
         <DetailGridItem label={t("total-issued")} info={t("total-issued-info")}>
           {formatNumber(bond.totalSupply, {
             token: bond.symbol,
+            decimals: bond.decimals,
             locale: locale,
           })}
         </DetailGridItem>
@@ -80,6 +82,7 @@ export async function BondsDetails({
           <DetailGridItem label={t("balance")}>
             {formatNumber(balanceData.value, {
               token: bond.symbol,
+              decimals: bond.decimals,
               locale: locale,
             })}
           </DetailGridItem>

--- a/kit/dapp/src/lib/queries/bond/bond-fragment.ts
+++ b/kit/dapp/src/lib/queries/bond/bond-fragment.ts
@@ -78,6 +78,7 @@ export const BondFragment = theGraphGraphqlKit(
     redeemedAmount
     faceValue
     underlyingBalance
+    underlyingBalanceExact
     totalUnderlyingNeeded
     totalUnderlyingNeededExact
     cap

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -71,7 +71,8 @@ type Bond implements Asset @entity(immutable: false) {
   faceValue: BigInt!
   underlyingAsset: Asset!
   redeemedAmount: BigInt!
-  underlyingBalance: BigInt!
+  underlyingBalance: BigDecimal!
+  underlyingBalanceExact: BigInt!
   yieldSchedule: FixedYield
   totalUnderlyingNeeded: BigDecimal!
   totalUnderlyingNeededExact: BigInt!

--- a/kit/subgraph/src/assets/fetch/asset.ts
+++ b/kit/subgraph/src/assets/fetch/asset.ts
@@ -1,0 +1,45 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { Bond, CryptoCurrency, Deposit, Equity, Fund, StableCoin } from "../../../generated/schema";
+
+/**
+ * Fetches any asset entity by its address and returns its decimals
+ * This function tries to load the asset by each possible type since Asset is an interface, not a concrete type.
+ * @param address The address of the asset
+ * @returns The decimals of the asset or 18 as default
+ */
+export function fetchAssetDecimals(address: Address): i32 {
+  // Try each asset type and return the decimals of the first one found
+
+  let bond = Bond.load(address);
+  if (bond != null) {
+    return bond.decimals;
+  }
+
+  let equity = Equity.load(address);
+  if (equity != null) {
+    return equity.decimals;
+  }
+
+  let fund = Fund.load(address);
+  if (fund != null) {
+    return fund.decimals;
+  }
+
+  let stableCoin = StableCoin.load(address);
+  if (stableCoin != null) {
+    return stableCoin.decimals;
+  }
+
+  let crypto = CryptoCurrency.load(address);
+  if (crypto != null) {
+    return crypto.decimals;
+  }
+
+  let deposit = Deposit.load(address);
+  if (deposit != null) {
+    return deposit.decimals;
+  }
+
+  // Default to 18 if asset not found (most common decimals value)
+  return 18;
+}

--- a/kit/subgraph/src/assets/fetch/bond.ts
+++ b/kit/subgraph/src/assets/fetch/bond.ts
@@ -54,7 +54,8 @@ export function fetchBond(address: Address, timestamp: BigInt = BigInt.zero()): 
 
     bond.underlyingAsset = underlyingAsset.reverted ? Address.zero() : underlyingAsset.value;
     bond.redeemedAmount = BigInt.zero();
-    bond.underlyingBalance = BigInt.zero();
+    bond.underlyingBalanceExact = BigInt.zero();
+    bond.underlyingBalance = BigDecimal.zero();
     bond.yieldSchedule = yieldSchedule.reverted ? null : yieldSchedule.value;
     bond.totalUnderlyingNeededExact = BigInt.zero();
     bond.totalUnderlyingNeeded = BigDecimal.zero();


### PR DESCRIPTION
## Summary by Sourcery

Fix underlying asset balance decimal handling in bond-related subgraph entities

Bug Fixes:
- Correct the handling of underlying asset balance by introducing an exact balance field and a converted decimal balance field
- Add proper decimal conversion for underlying asset balances to ensure accurate representation

Enhancements:
- Implement a utility function to fetch asset decimals across different asset types
- Improve balance tracking by separating exact and decimal representations

Chores:
- Update GraphQL schema to support new balance tracking approach
- Modify bond-related functions to use new balance fields