### PR TITLE
feat: setup ia factory

### DIFF
--- a/kit/contracts/ignition/modules/smart.ts
+++ b/kit/contracts/ignition/modules/smart.ts
@@ -97,6 +97,21 @@ const SmartModule = buildModule("SmartModule", (m) => {
     }
   );
 
+  m.call(tokenImplementationAuthority, "setTREXFactory", [factory], {
+    id: "setTREXFactory",
+    from: deployer,
+  });
+
+  const tokenImplementationAuthorityFactory = m.contract("IAFactory", [factory], {
+    id: "tokenImplementationAuthorityFactory",
+    from: deployer,
+  });
+
+  m.call(tokenImplementationAuthority, "setIAFactory", [tokenImplementationAuthorityFactory], {
+    id: "setIAFactory",
+    from: deployer,
+  });
+
   m.call(identityFactory, "addTokenFactory", [factory], {
     id: "addTokenFactory",
     from: deployer,

--- a/kit/contracts/test/ERC3643.t.sol
+++ b/kit/contracts/test/ERC3643.t.sol
@@ -26,6 +26,8 @@ import { Test, console, Vm } from "forge-std/Test.sol";
 import { TREXGateway } from "../contracts/shared/erc3643/factory/TREXGateway.sol";
 import { TREXImplementationAuthority } from
     "../contracts/shared/erc3643/proxy/authority/TREXImplementationAuthority.sol";
+import { IAFactory } from
+    "../contracts/shared/erc3643/proxy/authority/IAFactory.sol";
 import { ClaimTopicsRegistry } from "../contracts/shared/erc3643/registry/implementation/ClaimTopicsRegistry.sol";
 import { TrustedIssuersRegistry } from "../contracts/shared/erc3643/registry/implementation/TrustedIssuersRegistry.sol";
 import { IdentityRegistryStorage } from
@@ -102,13 +104,21 @@ contract GatewayTest is Test {
             })
         );
 
+
         Identity identity = new Identity(address(0), true);
         ImplementationAuthority identityImplementationAuthority = new ImplementationAuthority(address(identity));
         IdFactory identityFactory = new IdFactory(address(identityImplementationAuthority));
+
         // Factory
         TREXFactory factory = new TREXFactory(address(tokenImplementationAuthority), address(identityFactory));
         identityFactory.addTokenFactory(address(factory));
         identityGateway = address(new Gateway(address(identityFactory), new address[](0)));
+
+        tokenImplementationAuthority.setTREXFactory(address(factory));
+
+        // IA Factory i used to use different proxy versions for the token
+        IAFactory iaFactory = new IAFactory(address(factory));
+        tokenImplementationAuthority.setIAFactory(address(iaFactory));
 
         // Gateway
         gateway = address(new TREXGateway(address(factory), true));


### PR DESCRIPTION
## Summary by Sourcery

Set up an Implementation Authority (IA) Factory for managing token implementation proxies in the ERC3643 token system

New Features:
- Introduce IAFactory to support different proxy versions for tokens

Enhancements:
- Extend token implementation authority configuration to include a dedicated factory for managing implementation proxies