### PR TITLE
fix: create right besu configmap when dev mode used

### DIFF
--- a/kit/charts/atk/charts/besu-network/charts/besu-genesis/values.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-genesis/values.yaml
@@ -61,7 +61,7 @@ rawGenesisConfig:
   blockchain:
     nodes:
       generate: true
-      count: 4
+      count: 1
     accountPassword: "password"
 
 image:

--- a/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
+++ b/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.job.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -140,3 +141,4 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "thegraph.fullname" . }}-workspace
   backoffLimit: 0
+{{- end }}

--- a/kit/charts/atk/charts/thegraph/values.yaml
+++ b/kit/charts/atk/charts/thegraph/values.yaml
@@ -100,6 +100,7 @@ graph-node:
 
 job:
   fullnameOverride: graph
+  enabled: true
 
   # Pod Security Context
   podSecurityContext: {}

--- a/kit/charts/atk/values-prod.yaml
+++ b/kit/charts/atk/values-prod.yaml
@@ -110,6 +110,10 @@ besu-network:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
+  rawGenesisConfig:
+    blockchain:
+      nodes:
+        count: 4
 
 erpc:
   enabled: true

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -110,6 +110,10 @@ besu-network:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
+  rawGenesisConfig:
+    blockchain:
+      nodes:
+        count: 1
 
 erpc:
   enabled: true
@@ -225,6 +229,7 @@ thegraph:
               port: 8050
               serviceName: graph-node-index
   job:
+    enabled: true
     fullnameOverride: graph
     image:
       repository: node


### PR DESCRIPTION
## Summary by Sourcery

Configure Besu and The Graph chart values for development and production environments, adjusting node counts and enabling specific deployments

New Features:
- Add configuration to enable The Graph job deployment conditionally

Enhancements:
- Modify Besu network configuration to support different node counts in dev and prod environments

Chores:
- Update Helm chart values to provide more flexible configuration options