### PR TITLE
fix: add random timeout to job setup to not overlap migration

### DIFF
--- a/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
+++ b/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
@@ -34,12 +34,23 @@ spec:
             - -c
             - |
               set -e
-              echo "Waiting for {{ index .Values "graph-node" "fullnameOverride" }}-query:8020 to be available..."
-              until nc -z -w 2 {{ index .Values "graph-node" "fullnameOverride" }}-query 8020; do
-                echo "Service not ready yet, waiting..."
+              # Determine service suffix using Helm within shell variable assignment
+              SERVICE_SUFFIX="{{- if index .Values "graph-node" "graphNodeGroups" "combined" "enabled" | default false -}}-combined{{- else -}}-query{{- end -}}"
+              # Construct full service name
+              SERVICE_NAME="{{ index .Values "graph-node" "fullnameOverride" | default (printf "%s-%s" .Release.Name "graph-node") }}${SERVICE_SUFFIX}"
+              PORT="8020"
+              SECONDS_WAITED=0
+
+              echo "Waiting for graph-node service ${SERVICE_NAME}:${PORT} to be available..."
+
+              until nc -z -w 2 "${SERVICE_NAME}" "${PORT}"; do
+                # Optional: Add timeout check here if WAIT_TIMEOUT is used
+                echo "Service ${SERVICE_NAME}:${PORT} not ready yet, waiting 5s..."
                 sleep 5
+                # Optional: Increment SECONDS_WAITED here if timeout is used
               done
-              echo "Service is available, proceeding..."
+
+              echo "Service ${SERVICE_NAME}:${PORT} is available, proceeding..."
         - name: clone-repo
           image: alpine/git:latest
           command:
@@ -102,8 +113,14 @@ spec:
               echo "Dependencies installed"
               bunx turbo dependencies
 
-              # Replace localhost with graph-node-query for subgraph deployment
-              sed -i 's|http://localhost:8020|http://{{ index .Values "graph-node" "fullnameOverride" }}-query:8020|g' /workspace/kit/subgraph/graph-local-deploy.sh
+              # Determine service suffix using Helm within shell variable assignment
+              SERVICE_SUFFIX="{{- if index .Values "graph-node" "graphNodeGroups" "combined" "enabled" | default false -}}-combined{{- else -}}-query{{- end -}}"
+              # Construct full service name
+              SERVICE_NAME="{{ index .Values "graph-node" "fullnameOverride" | default (printf "%s-%s" .Release.Name "graph-node") }}${SERVICE_SUFFIX}"
+
+              # Replace localhost with dynamically determined graph-node service
+              echo "Configuring subgraph deployment to use service: http://${SERVICE_NAME}:8020"
+              sed -i "s|http://localhost:8020|http://${SERVICE_NAME}:8020|g" /workspace/kit/subgraph/graph-local-deploy.sh
               sed -i 's/yq -i/yq -i -y/g' /workspace/kit/subgraph/graph-local-deploy.sh
 
               echo "Build forge contracts..."

--- a/kit/charts/atk/charts/thegraph/values.yaml
+++ b/kit/charts/atk/charts/thegraph/values.yaml
@@ -13,6 +13,17 @@ graph-node:
       - name: wait-for-postgresql
         image: ghcr.io/settlemint/btp-waitforit:v7.7.3
         command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
+      # Random delay init container for Graph Node pods
+      - name: random-delay
+        image: busybox:latest # Using busybox as it has sh and sleep
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            SLEEP_DURATION=$((RANDOM % 61)) # Generates random number 0-60
+            echo "Graph Node pod initiating random delay of ${SLEEP_DURATION} seconds..."
+            sleep ${SLEEP_DURATION}
+            echo "Graph Node random delay complete."
     affinityPresets:
       # -- Create anti-affinity rule to deter scheduling replicas on the same host
       antiAffinityByHostname: false
@@ -119,6 +130,18 @@ job:
 
   # Image pull secrets
   imagePullSecrets: []
+
+  # Custom Init Containers (add definitions here if needed, e.g., for dependencies)
+  # extraInitContainers: []
+
+  # Random Delay Init Container Configuration
+  # randomDelayInitContainer:
+  #   enabled: false # Set to true to enable the random delay
+  #   maxSeconds: 31 # Max random sleep duration (exclusive, e.g., 31 means 0-30 seconds)
+  #   image:
+  #     repository: busybox
+  #     tag: latest
+  #     pullPolicy: IfNotPresent
 
   # Resource configuration
   resources:

--- a/kit/charts/atk/values-prod.yaml
+++ b/kit/charts/atk/values-prod.yaml
@@ -190,21 +190,21 @@ thegraph:
         podMetadata:
           labels:
             role: query-node
-            custom-label: custom-value
       index:
         enabled: true
         replicaCount: 2
         podMetadata:
           labels:
             role: index-node
-            custom-label: custom-value
       block-ingestor:
         enabled: true
         replicaCount: 2
         podMetadata:
           labels:
             role: block-ingestor
-            custom-label: custom-value
+      combined:
+        enabled: false
+    blockIngestorGroupName: block-ingestor
     ingress:
       hosts:
         - host: graph.k8s.orb.local

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -173,6 +173,8 @@ blockscout:
 thegraph:
   enabled: true
   graph-node:
+    image:
+      tag: v0.37.0
     graphNodeDefaults:
       imagePullSecrets:
         - name: image-pull-secret-docker
@@ -181,29 +183,37 @@ thegraph:
       podMetadata:
         labels:
           app.kubernetes.io/part-of: thegraph
-          environment: production
+          environment: development
     graphNodeGroups:
       query:
-        enabled: true
+        enabled: false
         replicaCount: 1
         podMetadata:
           labels:
             role: query-node
             custom-label: custom-value
       index:
-        enabled: true
+        enabled: false
         replicaCount: 1
         podMetadata:
           labels:
             role: index-node
             custom-label: custom-value
       block-ingestor:
-        enabled: true
+        enabled: false
         replicaCount: 1
         podMetadata:
           labels:
             role: block-ingestor
             custom-label: custom-value
+      combined:
+        enabled: true
+        replicaCount: 1
+        includeInIndexPools:
+          - default
+        env:
+          node_role: combined-mode
+    blockIngestorGroupName: combined
     ingress:
       hosts:
         - host: graph.k8s.orb.local
@@ -211,23 +221,23 @@ thegraph:
             - path: /(.*)
               pathType: ImplementationSpecific
               port: 8000
-              serviceName: graph-node-query
+              serviceName: graph-node-combined
             - path: /ws/?(.*)
               pathType: ImplementationSpecific
               port: 8001
-              serviceName: graph-node-query
+              serviceName: graph-node-combined
             - path: /admin/?(.*)
               pathType: ImplementationSpecific
               port: 8020
-              serviceName: graph-node-query
+              serviceName: graph-node-combined
             - path: /indexer/?(.*)
               pathType: ImplementationSpecific
               port: 8030
-              serviceName: graph-node-index
+              serviceName: graph-node-combined
             - path: /graphman/?(.*)
               pathType: ImplementationSpecific
               port: 8050
-              serviceName: graph-node-index
+              serviceName: graph-node-combined
   job:
     enabled: true
     fullnameOverride: graph

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "helm:check-context": "[ \"$(kubectl config current-context)\" = \"orbstack\" ] || (echo \"Error: Not in orbstack context. Current context: $(kubectl config current-context)\" && exit 1)",
     "helm:full": "bun run helm:check-context && bun run secrets && bun run abis && bunx turbo genesis && cp kit/contracts/genesis-output.json kit/charts/atk/charts/besu-network/charts/besu-genesis/files/genesis-output.json && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
     "helm:dependency": "helm dependency update kit/charts/atk",
-    "helm:install": "bun run helm:check-context && bun run helm:dependency && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
+    "helm:install": "bun run helm:check-context && bun run helm:dependency && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace --timeout 15m",
     "helm:delete": "bun run helm:check-context && helm uninstall atk -n atk --wait && kubectl delete pvc --all -n atk && kubectl delete namespace atk",
     "helm:reset": "bun run helm:delete && bun run helm:install"
   },


### PR DESCRIPTION
## Summary by Sourcery

Modify The Graph deployment configuration to use a combined node mode and add a random startup delay to prevent migration overlaps

New Features:
- Introduce a random delay init container for Graph Node pods to mitigate potential startup conflicts

Enhancements:
- Implement dynamic service name resolution for Graph Node deployments
- Add a random initialization delay to prevent potential race conditions during pod startup

Chores:
- Update Helm chart configurations to support combined Graph Node mode
- Modify Helm install script to increase timeout