### PR TITLE
fix: run graph random-delay container only for prod setup

### DIFF
--- a/kit/charts/atk/charts/thegraph/values.yaml
+++ b/kit/charts/atk/charts/thegraph/values.yaml
@@ -13,17 +13,6 @@ graph-node:
       - name: wait-for-postgresql
         image: ghcr.io/settlemint/btp-waitforit:v7.7.3
         command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
-      # Random delay init container for Graph Node pods
-      - name: random-delay
-        image: busybox:latest # Using busybox as it has sh and sleep
-        imagePullPolicy: IfNotPresent
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            SLEEP_DURATION=$((RANDOM % 61)) # Generates random number 0-60
-            echo "Graph Node pod initiating random delay of ${SLEEP_DURATION} seconds..."
-            sleep ${SLEEP_DURATION}
-            echo "Graph Node random delay complete."
     affinityPresets:
       # -- Create anti-affinity rule to deter scheduling replicas on the same host
       antiAffinityByHostname: false

--- a/kit/charts/atk/values-prod.yaml
+++ b/kit/charts/atk/values-prod.yaml
@@ -183,6 +183,20 @@ thegraph:
         labels:
           app.kubernetes.io/part-of: thegraph
           environment: production
+      extraInitContainers:
+        - name: wait-for-postgresql
+          image: ghcr.io/settlemint/btp-waitforit:v7.7.3
+          command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
+        - name: random-delay
+          image: busybox:latest # Using busybox as it has sh and sleep
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              SLEEP_DURATION=$((RANDOM % 61)) # Generates random number 0-60
+              echo "Graph Node pod initiating random delay of ${SLEEP_DURATION} seconds..."
+              sleep ${SLEEP_DURATION}
+              echo "Graph Node random delay complete."
     graphNodeGroups:
       query:
         replicaCount: 2


### PR DESCRIPTION
We don't need to run random delay init container for dev setup, as we run combined node there(which means - 1 migration at the time)

## Summary by Sourcery

Enhancements:
- Conditionally apply random delay init container only for production Kubernetes deployments