### PR TITLE
fix: updating platform settings default currency does not work 

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/table.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/(table)/_components/table.tsx
@@ -20,7 +20,7 @@ interface TableProps {
 }
 
 export async function AssetsTable({ assettype }: TableProps) {
-  const baseCurrency = await getSetting(SETTING_KEYS.BASE_CURRENCY);
+  const baseCurrency = await getSetting({ key: SETTING_KEYS.BASE_CURRENCY });
 
   switch (assettype) {
     case "bond":

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/base-currency-settings-form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/base-currency-settings-form.tsx
@@ -109,17 +109,21 @@ export function BaseCurrencySettingsForm({
             <FormField
               name="baseCurrency"
               render={({ field }) => (
-                <FormItem className="grid grid-cols-[200px_1fr] items-center gap-4">
-                  <FormLabel className="text-right">
-                    {t("base-currency-label")}
-                  </FormLabel>
+                <FormItem className="flex items-center gap-4">
+                  <FormLabel>{t("base-currency-label")}</FormLabel>
                   <Select
                     onValueChange={field.onChange}
                     defaultValue={field.value}
                   >
                     <FormControl>
                       <SelectTrigger>
-                        <SelectValue placeholder={t("select-base-currency")} />
+                        <SelectValue>
+                          {t(
+                            currencyKeys[
+                              field.value as keyof typeof currencyKeys
+                            ]
+                          )}
+                        </SelectValue>
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/base-currency-settings-form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/_components/base-currency-settings-form.tsx
@@ -108,6 +108,7 @@ export function BaseCurrencySettingsForm({
           >
             <FormField
               name="baseCurrency"
+              control={form.control}
               render={({ field }) => (
                 <FormItem className="flex items-center gap-4">
                   <FormLabel>{t("base-currency-label")}</FormLabel>
@@ -118,11 +119,7 @@ export function BaseCurrencySettingsForm({
                     <FormControl>
                       <SelectTrigger>
                         <SelectValue>
-                          {t(
-                            currencyKeys[
-                              field.value as keyof typeof currencyKeys
-                            ]
-                          )}
+                          {t(currencyKeys[field.value])}
                         </SelectValue>
                       </SelectTrigger>
                     </FormControl>

--- a/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/settings/(home)/page.tsx
@@ -6,7 +6,7 @@ import { BaseCurrencySettingsForm } from "./_components/base-currency-settings-f
 
 export default async function SettingsPage() {
   const t = await getTranslations("admin.platform.settings");
-  const baseCurrency = await getSetting(SETTING_KEYS.BASE_CURRENCY);
+  const baseCurrency = await getSetting({ key: SETTING_KEYS.BASE_CURRENCY });
 
   return (
     <>

--- a/kit/dapp/src/lib/config/settings.ts
+++ b/kit/dapp/src/lib/config/settings.ts
@@ -22,16 +22,18 @@ export const getSetting = withAccessControl(
   withTracing(
     "queries",
     "getSetting",
-    async <K extends SettingKey>(
-      key: K
-    ): Promise<(typeof DEFAULT_SETTINGS)[K]> => {
+    async ({
+      key,
+    }: {
+      key: SettingKey;
+    }): Promise<(typeof DEFAULT_SETTINGS)[SettingKey]> => {
       "use cache";
       cacheTag("setting");
       const setting = await db.query.settings.findFirst({
         where: eq(settings.key, key),
       });
       return (
-        (setting?.value as (typeof DEFAULT_SETTINGS)[K]) ??
+        (setting?.value as (typeof DEFAULT_SETTINGS)[SettingKey]) ??
         DEFAULT_SETTINGS[key]
       );
     }

--- a/kit/dapp/src/lib/config/settings.ts
+++ b/kit/dapp/src/lib/config/settings.ts
@@ -13,15 +13,15 @@ import { withTracing } from "../utils/tracing";
 /**
  * Get a setting value by key, falling back to the default value if not set
  */
-export const getSetting = withAccessControl(
-  {
-    requiredPermissions: {
-      setting: ["read"],
+export const getSetting = withTracing(
+  "queries",
+  "getSetting",
+  withAccessControl(
+    {
+      requiredPermissions: {
+        setting: ["read"],
+      },
     },
-  },
-  withTracing(
-    "queries",
-    "getSetting",
     async ({
       key,
     }: {


### PR DESCRIPTION
## Summary by Sourcery

Fix issues with platform settings base currency configuration and retrieval

Bug Fixes:
- Corrected the getSetting function to accept an object parameter instead of a direct key
- Fixed base currency selection and display in settings form

Enhancements:
- Updated getSetting function signature to improve type safety and flexibility
- Improved base currency selection UI with more explicit value rendering