### PR TITLE
feat: drizzle helm

### DIFF
--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
@@ -1,13 +1,9 @@
-# This Job runs Drizzle migrations before Hasura starts.
-# It mimics the structure of the subgraph deployment job where applicable.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # Naming convention similar to subgraph job, but indicating drizzle
   name: {{ printf "%s-drizzle-migrate-%d" .Release.Name (.Release.Revision | int) }}
   namespace: {{ .Release.Namespace }}
   labels:
-    # Use parent chart's labels helper
     {{- include "atk.labels" . | nindent 4 }}
     app.kubernetes.io/component: drizzle-migrate
     helm.sh/revision: "{{ .Release.Revision }}"
@@ -22,20 +18,18 @@ spec:
     metadata:
       name: {{ printf "%s-drizzle-migrate-%d" .Release.Name (.Release.Revision | int) }}
       labels:
-        # Use parent chart's selector labels helper
         {{- include "atk.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: drizzle-migrate
         helm.sh/revision: "{{ .Release.Revision }}"
     spec:
       restartPolicy: Never
-      # Use global pull secrets if defined in parent chart values
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
       - name: wait-for-postgres
-        image: busybox # Use busybox image like the subgraph job
+        image: busybox
         imagePullPolicy: IfNotPresent
         command:
           - /bin/sh
@@ -49,7 +43,7 @@ spec:
               sleep 2
             done
             echo "Service ${SERVICE_HOST}:${SERVICE_PORT} is available."
-      - name: clone-repo # Clone repo like subgraph job
+      - name: clone-repo
         image: alpine/git:latest
         imagePullPolicy: IfNotPresent
         command:
@@ -57,16 +51,15 @@ spec:
           - -c
           - |
             set -ex
-            # Consider making repo URL configurable via values?
             git clone https://github.com/settlemint/asset-tokenization-kit.git /workspace
         volumeMounts:
           - name: workspace
             mountPath: /workspace
       containers:
       - name: drizzle-migrate
-        image: "oven/bun:1" # Standard Bun image
+        image: "oven/bun:1"
         imagePullPolicy: IfNotPresent
-        workingDir: /workspace/kit/dapp # Dapp dir within cloned repo
+        workingDir: /workspace/kit/dapp
         command: ["/bin/sh", "-c"]
         args:
         - |
@@ -82,13 +75,11 @@ spec:
           bunx drizzle-kit push --force
           echo "Drizzle migrations finished."
         env:
-        # Retrieve the password from the secret first
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgresql-postgresql # Use the observed secret name
-              key: password # Use the observed key name
-        # Construct DATABASE_URL using known/assumed values and the password
+              name: postgresql-postgresql
+              key: password
         - name: SETTLEMINT_HASURA_DATABASE_URL
           value: "postgresql://postgres:$(PGPASSWORD)@postgresql-pgpool:5432/postgres"
         volumeMounts:
@@ -98,4 +89,4 @@ spec:
         - name: workspace
           emptyDir: {}
       terminationGracePeriodSeconds: 30
-  backoffLimit: 1 # Try only once per hook execution
+  backoffLimit: 1

--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
@@ -4,25 +4,28 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   # Naming convention similar to subgraph job, but indicating drizzle
-  name: {{ printf "%s-drizzle-migrate" .Release.Name }}
+  name: {{ printf "%s-drizzle-migrate-%d" .Release.Name (.Release.Revision | int) }}
   namespace: {{ .Release.Namespace }}
   labels:
     # Use parent chart's labels helper
     {{- include "atk.labels" . | nindent 4 }}
     app.kubernetes.io/component: drizzle-migrate
+    helm.sh/revision: "{{ .Release.Revision }}"
   annotations:
-    # Run before install/upgrade, delete before creating new one
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5" # Ensure it runs before Hasura deployment
-    "helm.sh/hook-delete-policy": before-hook-creation
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
 spec:
   template:
     metadata:
-      name: {{ printf "%s-drizzle-migrate" .Release.Name }}
+      name: {{ printf "%s-drizzle-migrate-%d" .Release.Name (.Release.Revision | int) }}
       labels:
         # Use parent chart's selector labels helper
         {{- include "atk.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: drizzle-migrate
+        helm.sh/revision: "{{ .Release.Revision }}"
     spec:
       restartPolicy: Never
       # Use global pull secrets if defined in parent chart values
@@ -68,14 +71,10 @@ spec:
         args:
         - |
           set -ex
-          echo "Updating package list and installing build tools..."
-          apt-get update && apt-get install -y --no-install-recommends build-essential python3 make g++
-          echo "Build tools installed."
-          
-          echo "Installing Dapp dependencies..."
-          bun install --frozen-lockfile
+          echo "Installing dependencies..."
+          bun install
           echo "Running Drizzle migrations..."
-          # PG* env vars sourced from secret below
+          export SETTLEMINT_HASURA_DATABASE_URL="postgresql://postgres:${PGPASSWORD}@postgresql-pgpool:5432/postgres"
           bunx drizzle-kit push --force
           echo "Drizzle migrations finished."
         env:
@@ -86,7 +85,7 @@ spec:
               name: postgresql-postgresql # Use the observed secret name
               key: password # Use the observed key name
         # Construct DATABASE_URL using known/assumed values and the password
-        - name: DATABASE_URL
+        - name: SETTLEMINT_HASURA_DATABASE_URL
           value: "postgresql://postgres:$(PGPASSWORD)@postgresql-pgpool:5432/postgres"
         volumeMounts:
           - name: workspace
@@ -95,4 +94,4 @@ spec:
         - name: workspace
           emptyDir: {}
       terminationGracePeriodSeconds: 30
-  backoffLimit: 1 # Try only once per hook execution 
+  backoffLimit: 1 # Try only once per hook execution

--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
@@ -71,6 +71,10 @@ spec:
         args:
         - |
           set -ex
+          echo "Installing Python and required build tools..."
+          apt-get update
+          apt-get install -y python3 python3-pip build-essential
+          ln -sf /usr/bin/python3 /usr/bin/python
           echo "Installing dependencies..."
           bun install
           echo "Running Drizzle migrations..."

--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
@@ -1,0 +1,101 @@
+# This Job runs Drizzle migrations before Hasura starts.
+# It mimics the structure of the subgraph deployment job where applicable.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Naming convention similar to subgraph job, but indicating drizzle
+  name: {{ printf "%s-drizzle-migrate" .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # Use parent chart's labels helper
+    {{- include "atk.labels" . | nindent 4 }}
+    app.kubernetes.io/component: drizzle-migrate
+  annotations:
+    # Run before install/upgrade, delete before creating new one
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5" # Ensure it runs before Hasura deployment
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: {{ printf "%s-drizzle-migrate" .Release.Name }}
+      labels:
+        # Use parent chart's selector labels helper
+        {{- include "atk.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: drizzle-migrate
+    spec:
+      restartPolicy: Never
+      # Use global pull secrets if defined in parent chart values
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox # Use busybox image like the subgraph job
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - -c
+          - |
+            SERVICE_HOST="postgresql-pgpool"
+            SERVICE_PORT="5432"
+            echo "Waiting for ${SERVICE_HOST}:${SERVICE_PORT}..."
+            until nc -z -w 2 ${SERVICE_HOST} ${SERVICE_PORT}; do
+              echo "Service ${SERVICE_HOST}:${SERVICE_PORT} not ready yet, waiting 2s..."
+              sleep 2
+            done
+            echo "Service ${SERVICE_HOST}:${SERVICE_PORT} is available."
+      - name: clone-repo # Clone repo like subgraph job
+        image: alpine/git:latest
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - -c
+          - |
+            set -ex
+            # Consider making repo URL configurable via values?
+            git clone https://github.com/settlemint/asset-tokenization-kit.git /workspace
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+      containers:
+      - name: drizzle-migrate
+        image: "oven/bun:1" # Standard Bun image
+        imagePullPolicy: IfNotPresent
+        workingDir: /workspace/kit/dapp # Dapp dir within cloned repo
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          set -ex
+          echo "Installing Dapp dependencies..."
+          bun install --frozen-lockfile
+          echo "Running Drizzle migrations..."
+          # PG* env vars sourced from secret below
+          bunx drizzle-kit push --force
+          echo "Drizzle migrations finished."
+        env:
+        # Define PGHOST using the stable service name
+        - name: PGHOST
+          value: "postgresql-pgpool"
+        - name: PGPORT
+          value: "5432"
+        # Assume default username and database name based on likely Bitnami defaults
+        - name: PGUSER
+          value: "postgres"
+        - name: PGDATABASE
+          value: "postgres"
+        # Source password from the observed secret and key
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-postgresql # Use the observed secret name
+              key: password # Use the observed key name
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+      volumes:
+        - name: workspace
+          emptyDir: {}
+      terminationGracePeriodSeconds: 30
+  backoffLimit: 1 # Try only once per hook execution 

--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
@@ -68,6 +68,10 @@ spec:
         args:
         - |
           set -ex
+          echo "Updating package list and installing build tools..."
+          apt-get update && apt-get install -y --no-install-recommends build-essential python3 make g++
+          echo "Build tools installed."
+          
           echo "Installing Dapp dependencies..."
           bun install --frozen-lockfile
           echo "Running Drizzle migrations..."
@@ -75,22 +79,15 @@ spec:
           bunx drizzle-kit push --force
           echo "Drizzle migrations finished."
         env:
-        # Define PGHOST using the stable service name
-        - name: PGHOST
-          value: "postgresql-pgpool"
-        - name: PGPORT
-          value: "5432"
-        # Assume default username and database name based on likely Bitnami defaults
-        - name: PGUSER
-          value: "postgres"
-        - name: PGDATABASE
-          value: "postgres"
-        # Source password from the observed secret and key
+        # Retrieve the password from the secret first
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
               name: postgresql-postgresql # Use the observed secret name
               key: password # Use the observed key name
+        # Construct DATABASE_URL using known/assumed values and the password
+        - name: DATABASE_URL
+          value: "postgresql://postgres:$(PGPASSWORD)@postgresql-pgpool:5432/postgres"
         volumeMounts:
           - name: workspace
             mountPath: /workspace

--- a/kit/contracts/genesis-output.sh
+++ b/kit/contracts/genesis-output.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env zsh -e
 
 # Get the absolute path of the script's directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 ALL_ALLOCATIONS_FILE="${SCRIPT_DIR}/genesis-output.json"
 
 # Check if anvil is running, if not start it

--- a/kit/contracts/genesis-output.sh
+++ b/kit/contracts/genesis-output.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env zsh -e
+#!/usr/bin/env bash -e
 
 # Get the absolute path of the script's directory
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ALL_ALLOCATIONS_FILE="${SCRIPT_DIR}/genesis-output.json"
 
 # Check if anvil is running, if not start it

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -15,7 +15,7 @@
     "compile:forge": "settlemint scs foundry build --sizes",
     "compile:hardhat": "settlemint scs hardhat build",
     "test": "settlemint scs foundry test -vvv",
-    "genesis": "chmod +x ./genesis-output.sh && ./genesis-output.sh",
+    "genesis": "./genesis-output.sh && ./genesis-output.sh",
     "abi-output": "bash -ex abi-output.sh",
     "deploy:remote": "settlemint scs hardhat deploy remote --deployment-id asset-tokenization",
     "deploy:local": "settlemint scs hardhat deploy local --deployment-id asset-tokenization-local --reset"

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -15,7 +15,7 @@
     "compile:forge": "settlemint scs foundry build --sizes",
     "compile:hardhat": "settlemint scs hardhat build",
     "test": "settlemint scs foundry test -vvv",
-    "genesis": "./genesis-output.sh && ./genesis-output.sh",
+    "genesis": "./genesis-output.sh",
     "abi-output": "bash -ex abi-output.sh",
     "deploy:remote": "settlemint scs hardhat deploy remote --deployment-id asset-tokenization",
     "deploy:local": "settlemint scs hardhat deploy local --deployment-id asset-tokenization-local --reset"

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -15,7 +15,7 @@
     "compile:forge": "settlemint scs foundry build --sizes",
     "compile:hardhat": "settlemint scs hardhat build",
     "test": "settlemint scs foundry test -vvv",
-    "genesis": "./genesis-output.sh",
+    "genesis": "bash -ex genesis-output.sh",
     "abi-output": "bash -ex abi-output.sh",
     "deploy:remote": "settlemint scs hardhat deploy remote --deployment-id asset-tokenization",
     "deploy:local": "settlemint scs hardhat deploy local --deployment-id asset-tokenization-local --reset"

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -15,7 +15,7 @@
     "compile:forge": "settlemint scs foundry build --sizes",
     "compile:hardhat": "settlemint scs hardhat build",
     "test": "settlemint scs foundry test -vvv",
-    "genesis": "bash -ex genesis-output.sh",
+    "genesis": "chmod +x ./genesis-output.sh && ./genesis-output.sh",
     "abi-output": "bash -ex abi-output.sh",
     "deploy:remote": "settlemint scs hardhat deploy remote --deployment-id asset-tokenization",
     "deploy:local": "settlemint scs hardhat deploy local --deployment-id asset-tokenization-local --reset"


### PR DESCRIPTION
## Summary by Sourcery

Add Drizzle migration Helm job for database schema management in Kubernetes deployments

New Features:
- Introduce a Kubernetes Job for running Drizzle database migrations during Helm chart deployment

Enhancements:
- Update genesis-output script to use zsh and simplify script directory detection
- Modify package.json genesis script to run twice

Deployment:
- Create a Helm job template for running Drizzle database migrations with init containers to ensure PostgreSQL readiness