### PR TITLE
fix: missing margins for sheet forms

### DIFF
--- a/kit/dapp/src/components/blocks/form/form.tsx
+++ b/kit/dapp/src/components/blocks/form/form.tsx
@@ -494,7 +494,7 @@ export function Form<
                 />
               )}
             </div>
-            <div className="mt-auto pt-6">
+            <div className="mt-auto pt-6 mb-6">
               <FormButton
                 hideButtons={
                   typeof hideButtons === "function"

--- a/kit/dapp/src/components/blocks/form/form.tsx
+++ b/kit/dapp/src/components/blocks/form/form.tsx
@@ -494,7 +494,7 @@ export function Form<
                 />
               )}
             </div>
-            <div className="mt-auto pt-6 mb-6">
+            <div className="mt-auto pt-6 mb-5">
               <FormButton
                 hideButtons={
                   typeof hideButtons === "function"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed missing bottom margin for sheet form, which was causing insufficient spacing at the bottom of the form