### PR TITLE
fix: link to your activity when no pending txns

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -607,7 +607,8 @@
       "contract": "Contract",
       "hash": "Hash",
       "function": "Function",
-      "created": "Created"
+      "created": "Created",
+      "view-activity": "View your activity"
     }
   },
   "creator-owner": "Creator / Owner",

--- a/kit/dapp/src/components/blocks/pending-transactions-dropdown/pending-transactions-dropdown.tsx
+++ b/kit/dapp/src/components/blocks/pending-transactions-dropdown/pending-transactions-dropdown.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Link } from "@/i18n/routing";
 import { usePendingTransactions } from "@/lib/hooks/use-pending-transactions";
 import { formatDate } from "@/lib/utils/date";
 import { useLocale, useTranslations } from "next-intl";
@@ -60,9 +61,18 @@ export function PendingTransactionsDropdown() {
         className="w-[350px] rounded-lg shadow-dropdown"
       >
         {pendingTransactions.length === 0 ? (
-          <div className="p-4 text-center text-sm text-muted-foreground">
-            {t("no-pending")}
-          </div>
+          <>
+            <div className="pt-4 text-center text-sm text-muted-foreground">
+              {t("no-pending")}
+            </div>
+            <Link
+              prefetch
+              href="/portfolio/my-activity"
+              className="pb-4 text-center mt-2 block text-muted-foreground text-sm hover:text-primary"
+            >
+              {t("view-activity")}
+            </Link>
+          </>
         ) : (
           <ScrollArea className="h-[400px]">
             <div className="space-y-2 p-2">


### PR DESCRIPTION

![CleanShot 2025-04-17 at 18 12 35@2x](https://github.com/user-attachments/assets/ad1c8797-1a85-442c-874a-7c167071e396)


## Summary by Sourcery

Add a link to view user activity when there are no pending transactions

Bug Fixes:
- Resolve user navigation friction when no pending transactions exist

Enhancements:
- Improve user experience by providing a direct link to view activity when no pending transactions are present