### PR TITLE
fix: adjust alloy configuration

### DIFF
--- a/kit/charts/atk/charts/dapp/values.yaml
+++ b/kit/charts/atk/charts/dapp/values.yaml
@@ -31,11 +31,7 @@ serviceAccount:
 annotations: {}
 # Additional labels for the deployment pod metadata
 podLabels: {}
-podAnnotations:
-  # Example annotations (adjust as needed)
-  loki.io/scrape: "true"
-  prometheus.io/scrape: "false"
-  # backup.velero.io/backup-volumes: ""
+podAnnotations: {}
 
 podSecurityContext:
   fsGroup: 2016

--- a/kit/charts/atk/charts/hasura/values.yaml
+++ b/kit/charts/atk/charts/hasura/values.yaml
@@ -6,6 +6,7 @@ graphql-engine:
     kots.io/app-slug: settlemint-atk
     app.kubernetes.io/part-of: settlemint-atk
     app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/component: hasura
   ingress:
     enabled: true
     ingressClassName: "settlemint-nginx"

--- a/kit/charts/atk/charts/observability/values.yaml
+++ b/kit/charts/atk/charts/observability/values.yaml
@@ -293,10 +293,6 @@ alloy:
           role = "node"
         }
 
-        discovery.kubernetes "kubernetes_service_endpoints" {
-          role = "endpoints"
-        }
-
         discovery.relabel "kubernetes_nodes_cadvisor" {
           targets = discovery.kubernetes.kubernetes_nodes.targets
 
@@ -364,70 +360,6 @@ alloy:
           }
         }
 
-        discovery.relabel "kubernetes_service_endpoints" {
-          targets = discovery.kubernetes.kubernetes_service_endpoints.targets
-
-          rule {
-            source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_scrape"]
-            regex         = "true"
-            action        = "keep"
-          }
-
-          rule {
-            source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_scheme"]
-            regex         = "(https?)"
-            target_label  = "__scheme__"
-          }
-
-          rule {
-            source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_path"]
-            regex         = "(.+)"
-            target_label  = "__metrics_path__"
-          }
-
-          rule {
-            source_labels = ["__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"]
-            regex         = "(.+?)(?::\\d+)?;(\\d+)"
-            target_label  = "__address__"
-            replacement   = "$1:$2"
-          }
-
-          rule {
-            regex       = "__meta_kubernetes_service_annotation_prometheus_io_param_(.+)"
-            replacement = "__param_$1"
-            action      = "labelmap"
-          }
-
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
-
-          rule {
-            source_labels = ["__meta_kubernetes_service_name"]
-            target_label  = "service"
-          }
-
-          rule {
-            regex       = "__meta_kubernetes_pod_label_uid"
-            action      = "labeldrop"
-          }
-
-          rule {
-            regex       = "__meta_kubernetes_pod_label_id"
-            action      = "labeldrop"
-          }
-
-          rule {
-            regex       = "__meta_kubernetes_pod_label_name"
-            action      = "labeldrop"
-          }
-
-          rule {
-            replacement  = "{{ .Values.clustername | default "settlemint" }}"
-            target_label = "cluster_name"
-          }
-        }
 
         prometheus.scrape "kubernetes_nodes_cadvisor" {
           targets         = discovery.relabel.kubernetes_nodes_cadvisor.output
@@ -501,18 +433,6 @@ alloy:
           targets = discovery.kubernetes.kubernetes_pods.targets
 
           rule {
-            source_labels = ["__meta_kubernetes_pod_label_name"]
-            regex         = "node-agent"
-            action        = "drop"
-          }
-
-          rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape", "__meta_kubernetes_pod_annotation_loki_io_scrape"]
-            regex         = "true;.*|.*;true"
-            action        = "keep"
-          }
-
-          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scheme"]
             regex         = "(https?)"
             target_label  = "__scheme__"
@@ -540,11 +460,6 @@ alloy:
           rule {
             source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
             target_label  = "component"
-          }
-
-          rule {
-            source_labels = ["__meta_kubernetes_pod_label_settlemint_com_service_type"]
-            target_label  = "service_type"
           }
 
           rule {

--- a/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
+++ b/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "thegraph.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -304,6 +304,12 @@ portal:
     - name: wait-for-postgres
       image: ghcr.io/settlemint/btp-waitforit:v7.7.3
       command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
+  podLabels:
+    app.kubernetes.io/component: portal
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3000"
+    prometheus.io/path: "/portal-metrics"
 
 support:
   enabled: true
@@ -543,4 +549,7 @@ dapp:
       timeoutSeconds: 10 # Max time per curl attempt
       connectTimeoutSeconds: 5 # Max time to connect
       retries: 24
+  podLabels:
+    app.kubernetes.io/component: dapp
+    kots.io/app-slug: settlemint-atk
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust Alloy configuration and Kubernetes metadata for improved observability and monitoring

Enhancements:
- Simplify Alloy configuration by removing redundant service endpoint and pod discovery rules

CI:
- Modify Helm chart deployment job for The Graph to run only on post-install

Chores:
- Update Kubernetes pod labels and annotations for better component identification and monitoring