### PR TITLE
fix: setting initial state in useLocalStorage

### DIFF
--- a/kit/dapp/src/hooks/use-local-storage.ts
+++ b/kit/dapp/src/hooks/use-local-storage.ts
@@ -6,43 +6,43 @@ export function useLocalStorage<T>(
   key: string,
   initialValue: T
 ): [T, (value: T | ((val: T) => T)) => void] {
-  // Get from local storage then
-  // parse stored json or return initialValue
-  const [storedValue, setStoredValue] = useState<T>(initialValue);
-
-  useEffect(() => {
+  const [storedValue, setStoredValue] = useState<T>(() => {
     // Server-side rendering does not have `window`
     if (typeof window === "undefined") {
-      return;
+      return initialValue;
     }
 
     try {
-      // Get from local storage by key
       const item = window.localStorage.getItem(key);
-      // Parse stored json or if none return initialValue
-      setStoredValue(item ? JSON.parse(item) : initialValue);
+      return item ? JSON.parse(item) : initialValue;
     } catch (error) {
-      // If error also return initialValue
-      console.error(error);
-      setStoredValue(initialValue);
+      // If error reading or parsing, return initialValue
+      console.error(`Error reading localStorage key “${key}”:`, error);
+      return initialValue;
     }
-  }, [key, initialValue]);
+  });
 
-  // Return a wrapped version of useState's setter function that
-  // persists the new value to localStorage.
+  // Persist state changes back to localStorage
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(storedValue));
+      } catch (error) {
+        console.error(`Error setting localStorage key “${key}”:`, error);
+      }
+    }
+  }, [key, storedValue]);
+
+  // Return a wrapped version of useState's setter function
   const setValue = (value: T | ((val: T) => T)) => {
     try {
-      // Allow value to be a function so we have same API as useState
+      // Allow value to be a function for useState-like API
       const valueToStore =
         value instanceof Function ? value(storedValue) : value;
-      // Save state
       setStoredValue(valueToStore);
-      // Save to local storage
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem(key, JSON.stringify(valueToStore));
-      }
+      // Persistence is handled by the useEffect above
     } catch (error) {
-      // A more advanced implementation would handle the error case
+      // Optional: More robust error handling
       console.error(error);
     }
   };


### PR DESCRIPTION
## Summary by Sourcery

Refactor the useLocalStorage hook to improve initial state handling and localStorage synchronization

Bug Fixes:
- Fix the initial state setting in useLocalStorage to correctly handle server-side rendering and localStorage retrieval

Enhancements:
- Optimize the hook's state initialization by using a lazy initial state
- Improve error logging for localStorage operations
- Separate localStorage persistence logic into a dedicated useEffect