### PR TITLE
fix: create mint burn and transfer fund test

### DIFF
--- a/kit/e2e/pages/admin-page.ts
+++ b/kit/e2e/pages/admin-page.ts
@@ -631,12 +631,7 @@ export class AdminPage extends BasePage {
     await expect(formattedActual).toBe(formattedExpected);
   }
 
-  async mintAsset(options: {
-    sidebarAssetTypes: string;
-    user: string;
-    amount: string;
-    pincode: string;
-  }) {
+  async mintAsset(options: { user: string; amount: string; pincode: string }) {
     await this.page.reload();
     await this.page.getByRole("button", { name: "Manage" }).click();
     const mintTokensOption = this.page.getByRole("menuitem", {
@@ -680,6 +675,16 @@ export class AdminPage extends BasePage {
     await this.page.locator("#amount").fill(options.amount);
     await this.page.getByRole("button", { name: "Next" }).click();
     await this.completeAssetCreation("Top up", options.pincode);
+  }
+
+  async redeemBurnAsset(options: { amount: string; pincode: string }) {
+    await this.page
+      .locator('button[data-slot="sheet-trigger"]')
+      .filter({ hasText: "Burn" })
+      .click();
+    await this.page.locator("#amount").fill(options.amount);
+    await this.page.getByRole("button", { name: "Next" }).click();
+    await this.completeAssetCreation("Burn", options.pincode);
   }
 
   async verifyTotalSupply(expectedAmount: string) {

--- a/kit/e2e/test-data/asset-data.ts
+++ b/kit/e2e/test-data/asset-data.ts
@@ -328,6 +328,21 @@ export const fundData = {
   initialSupply: "0",
 };
 
+export const fundMintTokenData = {
+  amount: "10000",
+  pincode: pincode,
+};
+
+export const fundTransferData = {
+  transferAmount: "1000",
+  pincode: pincode,
+};
+
+export const fundBurnData = {
+  amount: "1000",
+  pincode: pincode,
+};
+
 export const stablecoinData = {
   assetType: "Stablecoin",
   name: generateStablecoinName(),

--- a/kit/e2e/tests/create-mint-burn-transfer-fund.spec.ts
+++ b/kit/e2e/tests/create-mint-burn-transfer-fund.spec.ts
@@ -1,9 +1,10 @@
 import { type BrowserContext, test } from "@playwright/test";
 import { Pages } from "../pages/pages";
 import {
-  equityData,
-  equityMintTokenData,
-  equityTransferData,
+  fundBurnData,
+  fundData,
+  fundMintTokenData,
+  fundTransferData,
 } from "../test-data/asset-data";
 import { assetMessage } from "../test-data/success-msg-data";
 import { adminUser, signUpTransferUserData } from "../test-data/user-data";
@@ -13,10 +14,15 @@ const testData = {
   transferUserEmail: "",
   transferUserWalletAddress: "",
   transferUserName: "",
-  equityName: "",
+  fundName: "",
+  currentTotalSupply: 0,
 };
 
-test.describe("Create, mint and transfer equity", () => {
+const supplyTracking = {
+  currentTotalSupply: "",
+};
+
+test.describe("Create, mint, transfer and burn fund", () => {
   test.describe.configure({ mode: "serial" });
   let userContext: BrowserContext | undefined;
   let transferUserContext: BrowserContext | undefined;
@@ -70,54 +76,63 @@ test.describe("Create, mint and transfer equity", () => {
       await adminContext.close();
     }
   });
-  test("Admin user creates and mint equity", async ({ browser }) => {
-    await adminPages.adminPage.createEquity(equityData);
-    testData.equityName = equityData.name;
+  test("Admin user creates, mint and burn fund", async ({ browser }) => {
+    await adminPages.adminPage.createFund(fundData);
+    testData.fundName = fundData.name;
     await adminPages.adminPage.verifySuccessMessage(
       assetMessage.successMessage
     );
     await adminPages.adminPage.checkIfAssetExists({
-      sidebarAssetTypes: equityData.sidebarAssetTypes,
-      name: testData.equityName,
-      totalSupply: equityData.initialSupply,
+      sidebarAssetTypes: fundData.sidebarAssetTypes,
+      name: testData.fundName,
+      totalSupply: fundData.initialSupply,
     });
-    await adminPages.adminPage.clickAssetDetails(testData.equityName);
+    await adminPages.adminPage.clickAssetDetails(testData.fundName);
     await adminPages.adminPage.mintAsset({
       user: adminUser.name,
-      ...equityMintTokenData,
+      ...fundMintTokenData,
     });
     await adminPages.adminPage.verifySuccessMessage(
       assetMessage.successMessage
     );
-    await adminPages.adminPage.verifyTotalSupply(equityMintTokenData.amount);
+    await adminPages.adminPage.verifyTotalSupply(fundMintTokenData.amount);
+    await adminPages.adminPage.redeemBurnAsset({
+      ...fundBurnData,
+    });
+    const mintAmount = Number.parseFloat(fundMintTokenData.amount);
+    const burnAmount = Number.parseFloat(fundBurnData.amount);
+    const newTotal = mintAmount - burnAmount;
+    testData.currentTotalSupply = newTotal;
+    await adminPages.adminPage.verifyTotalSupply(newTotal.toString());
   });
-  test("Admin user transfer equity to regular transfer user", async () => {
+  test("Admin user transfer, burn  to regular transfer user and verify balance", async () => {
     await adminPages.portfolioPage.transferAsset({
-      asset: testData.equityName,
+      asset: testData.fundName,
       walletAddress: testData.transferUserWalletAddress,
       user: testData.transferUserName,
-      ...equityTransferData,
+      ...fundTransferData,
     });
     await adminPages.adminPage.verifySuccessMessage(
       assetMessage.successMessage
     );
 
-    const mintAmount = Number.parseFloat(equityMintTokenData.amount);
-    const transferAmount = Number.parseFloat(equityTransferData.transferAmount);
-    const expectedBalance = (mintAmount - transferAmount).toString();
+    const transferAmount = Number.parseFloat(fundTransferData.transferAmount);
+    const expectedBalance = (
+      testData.currentTotalSupply - transferAmount
+    ).toString();
     await adminPages.adminPage.clickSidebarMenuItem("My assets");
 
     await adminPages.adminPage.filterAssetByName({
-      name: testData.equityName,
+      name: testData.fundName,
       totalSupply: expectedBalance,
     });
   });
 
-  test("Verify regular transfer user received equity", async () => {
+  test("Verify regular transfer user received fund", async () => {
     await transferUserPages.portfolioPage.goto();
     await transferUserPages.portfolioPage.verifyPortfolioAssetAmount({
-      expectedAmount: equityTransferData.transferAmount,
-      price: equityData.price,
+      expectedAmount: fundTransferData.transferAmount,
+      price: fundData.price,
     });
   });
 });

--- a/kit/e2e/tests/create-mint-transfer-cryptocurrency.spec.ts
+++ b/kit/e2e/tests/create-mint-transfer-cryptocurrency.spec.ts
@@ -71,9 +71,7 @@ test.describe("Create, mint and transfer cryptocurrency", () => {
       await adminContext.close();
     }
   });
-  test("Admin user creates, mint cryptocurrency and transfer to user", async ({
-    browser,
-  }) => {
+  test("Admin user creates and mint cryptocurrency", async ({ browser }) => {
     await adminPages.adminPage.createCryptocurrency(cryptocurrencyData);
     testData.cryptocurrencyName = cryptocurrencyData.name;
     await adminPages.adminPage.verifySuccessMessage(
@@ -86,7 +84,6 @@ test.describe("Create, mint and transfer cryptocurrency", () => {
     });
     await adminPages.adminPage.clickAssetDetails(testData.cryptocurrencyName);
     await adminPages.adminPage.mintAsset({
-      sidebarAssetTypes: cryptocurrencyData.sidebarAssetTypes,
       user: adminUser.name,
       ...cryptocurrencyMintTokenData,
     });
@@ -97,7 +94,7 @@ test.describe("Create, mint and transfer cryptocurrency", () => {
       cryptocurrencyDataAmountAfterMint.amount
     );
   });
-  test("Admin user transfer cryptocurrency to regular tranfer user and verify balance", async () => {
+  test("Admin user transfer cryptocurrency to regular transfer user", async () => {
     await adminPages.portfolioPage.transferAsset({
       asset: testData.cryptocurrencyName,
       walletAddress: testData.transferUserWalletAddress,

--- a/kit/e2e/tests/create-top-up-mint-transfer-bond.spec.ts
+++ b/kit/e2e/tests/create-top-up-mint-transfer-bond.spec.ts
@@ -127,7 +127,6 @@ test.describe("Create, top up, mint and transfer bonds", () => {
     );
 
     await adminPages.adminPage.mintAsset({
-      sidebarAssetTypes: stablecoinData.sidebarAssetTypes,
       user: adminUser.name,
       ...stableCoinMintTokenData,
     });
@@ -156,7 +155,6 @@ test.describe("Create, top up, mint and transfer bonds", () => {
       assetMessage.successMessage
     );
     await adminPages.adminPage.mintAsset({
-      sidebarAssetTypes: bondData.sidebarAssetTypes,
       user: adminUser.name,
       ...bondMintTokenData,
     });
@@ -166,7 +164,7 @@ test.describe("Create, top up, mint and transfer bonds", () => {
     await adminPages.adminPage.verifyTotalSupply(topUpData.amount);
   });
 
-  test("Admin user transfer bonds to user and verify balance", async () => {
+  test("Admin user transfer bonds to regular transfer user", async () => {
     await adminPages.portfolioPage.transferAsset({
       asset: testData.bondName,
       walletAddress: testData.transferUserWalletAddress,

--- a/kit/e2e/tests/create-update-mint-transfer-stablecoin.spec.ts
+++ b/kit/e2e/tests/create-update-mint-transfer-stablecoin.spec.ts
@@ -22,7 +22,7 @@ const testData = {
   stablecoinName: "",
 };
 
-test.describe("Update collateral, mint and transfer assets", () => {
+test.describe("Create, update collateral, mint and transfer stablecoin", () => {
   test.describe.configure({ mode: "serial" });
   let userContext: BrowserContext | undefined;
   let transferUserContext: BrowserContext | undefined;
@@ -99,7 +99,6 @@ test.describe("Update collateral, mint and transfer assets", () => {
         stableCoinUpdateCollateralData.amount
       );
       await adminPages.adminPage.mintAsset({
-        sidebarAssetTypes: stablecoinData.sidebarAssetTypes,
         user: testData.userName,
         ...stableCoinMintTokenData,
       });
@@ -113,7 +112,7 @@ test.describe("Update collateral, mint and transfer assets", () => {
       await adminContext.close();
     }
   });
-  test("Transfer assets to user and verify balance", async () => {
+  test("Transfer stablecoin to regular transfer user", async () => {
     const [firstName, lastName] = testData.transferUserName
       .split(" ")
       .slice(0, 2);
@@ -155,7 +154,7 @@ test.describe("Update collateral, mint and transfer assets", () => {
       stablecoinData.price
     );
   });
-  test("Verify transfer user received the assets", async () => {
+  test("Verify transfer user received stablecoins", async () => {
     await transferUserPages.portfolioPage.goto();
     await transferUserPages.portfolioPage.verifyPortfolioAssetAmount({
       expectedAmount: stableCoinTransferData.transferAmount,


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end tests for creating, minting, transferring, and burning a fund asset

New Features:
- Implement a new end-to-end test scenario for fund assets covering creation, minting, transfer, and burning operations

Enhancements:
- Refactor existing admin page methods to simplify asset minting by removing unnecessary parameters
- Update test descriptions to be more precise about the actions being performed

Tests:
- Add comprehensive test suite for fund asset lifecycle
- Create new test spec for fund asset operations
- Implement test steps for creating, minting, transferring, and burning a fund