### PR TITLE
fix: run ct utility only on changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,7 +58,16 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs kit/charts --target-branch main)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --chart-dirs kit/charts --check-version-increment=false --target-branch main
 
       - name: Install Bun dependencies


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a step to list changed charts and conditionally run chart-testing lint only for modified charts