### PR TITLE
fix: weird date for collateral proof expiration

### DIFF
--- a/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
@@ -90,7 +90,6 @@ export const createDepositFunction = withAccessControl(
       currency: price.currency,
     });
 
-    // Calculate collateralLivenessSeconds using the refactored central function
     const collateralLivenessSeconds = getTimeUnitSeconds(
       collateralLivenessValue,
       collateralLivenessTimeUnit

--- a/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
@@ -90,8 +90,11 @@ export const createDepositFunction = withAccessControl(
       currency: price.currency,
     });
 
-    const collateralLivenessSeconds =
-      collateralLivenessValue * getTimeUnitSeconds(collateralLivenessTimeUnit);
+    // Calculate collateralLivenessSeconds using the refactored central function
+    const collateralLivenessSeconds = getTimeUnitSeconds(
+      collateralLivenessValue,
+      collateralLivenessTimeUnit
+    );
 
     const createDepositResult = await portalClient.request(
       DepositFactoryCreate,

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-function.ts
@@ -103,6 +103,11 @@ export const createStablecoinFunction = withAccessControl(
       currency: price.currency,
     });
 
+    const collateralLivenessSeconds = getTimeUnitSeconds(
+      collateralLivenessValue,
+      collateralLivenessTimeUnit
+    );
+
     const createStablecoinResult = await portalClient.request(
       StableCoinFactoryCreate,
       {
@@ -112,9 +117,7 @@ export const createStablecoinFunction = withAccessControl(
           name: assetName,
           symbol: symbol.toString(),
           decimals: decimals || 6,
-          collateralLivenessSeconds:
-            (collateralLivenessValue || 12) *
-            getTimeUnitSeconds(collateralLivenessTimeUnit || "months"),
+          collateralLivenessSeconds,
         },
         ...(await handleChallenge(
           user,

--- a/kit/dapp/src/lib/queries/deposit-factory/deposit-factory-predict-address.tsx
+++ b/kit/dapp/src/lib/queries/deposit-factory/deposit-factory-predict-address.tsx
@@ -51,9 +51,10 @@ export const getPredictedAddress = withTracing(
     } = input;
     const user = await getUser();
 
-    const collateralLivenessSeconds =
-      collateralLivenessValue * getTimeUnitSeconds(collateralLivenessTimeUnit);
-
+    const collateralLivenessSeconds = getTimeUnitSeconds(
+      collateralLivenessValue,
+      collateralLivenessTimeUnit
+    );
     const data = await portalClient.request(CreateDepositPredictAddress, {
       address: DEPOSIT_FACTORY_ADDRESS,
       sender: user.wallet,

--- a/kit/dapp/src/lib/queries/deposit/deposit-calculated.ts
+++ b/kit/dapp/src/lib/queries/deposit/deposit-calculated.ts
@@ -24,10 +24,7 @@ export async function depositsCalculateFields(
     // Calculate collateral proof validity date
     const collateralProofValidity =
       Number(deposit.lastCollateralUpdate) > 0
-        ? addSeconds(
-            new Date(Number(deposit.lastCollateralUpdate) * 1000),
-            Number(deposit.liveness)
-          )
+        ? addSeconds(deposit.lastCollateralUpdate, Number(deposit.liveness))
         : undefined;
 
     const price = prices.get(deposit.id);

--- a/kit/dapp/src/lib/queries/stablecoin-factory/stablecoin-factory-predict-address.tsx
+++ b/kit/dapp/src/lib/queries/stablecoin-factory/stablecoin-factory-predict-address.tsx
@@ -51,8 +51,10 @@ export const getPredictedAddress = withTracing(
     } = input;
     const user = await getUser();
 
-    const collateralLivenessSeconds =
-      collateralLivenessValue * getTimeUnitSeconds(collateralLivenessTimeUnit);
+    const collateralLivenessSeconds = getTimeUnitSeconds(
+      collateralLivenessValue,
+      collateralLivenessTimeUnit
+    );
 
     const data = await portalClient.request(CreateStablecoinPredictAddress, {
       address: STABLE_COIN_FACTORY_ADDRESS,

--- a/kit/dapp/src/lib/utils/date.ts
+++ b/kit/dapp/src/lib/utils/date.ts
@@ -1,6 +1,10 @@
 import {
   addDays,
   addHours,
+  addMonths,
+  addSeconds,
+  addWeeks,
+  differenceInSeconds,
   formatDistance,
   formatDuration as formatDurationFns,
   formatRelative,
@@ -165,21 +169,39 @@ export function getDateFromTimestamp(timestamp: string | number | Date): Date {
   return new Date(numericTimestamp * 1000);
 }
 
-export function getTimeUnitSeconds(unit: TimeUnit): number {
+/**
+ * Calculates the total number of seconds for a given value and time unit.
+ *
+ * @param value - The numeric value of the time unit (e.g., 12)
+ * @param unit - The time unit (e.g., 'months')
+ * @returns The total number of seconds, calculated accurately using date-fns.
+ */
+export function getTimeUnitSeconds(value: number, unit: TimeUnit): number {
+  const now = new Date();
+  let futureDate: Date;
+
   switch (unit) {
     case "seconds":
-      return 1;
+      futureDate = addSeconds(now, value);
+      break;
     case "hours":
-      return 3600;
+      futureDate = addHours(now, value);
+      break;
     case "days":
-      return 86400;
+      futureDate = addDays(now, value);
+      break;
     case "weeks":
-      return 604800;
+      futureDate = addWeeks(now, value);
+      break;
     case "months":
-      return 2592000; // 30 days
+      futureDate = addMonths(now, value);
+      break;
     default:
-      throw new Error("Unsupported time unit");
+      // Should not happen due to validation, but handle defensively
+      throw new Error(`Unsupported time unit: ${unit}`);
   }
+
+  return differenceInSeconds(futureDate, now);
 }
 
 /**

--- a/kit/dapp/src/lib/utils/date.ts
+++ b/kit/dapp/src/lib/utils/date.ts
@@ -197,8 +197,8 @@ export function getTimeUnitSeconds(value: number, unit: TimeUnit): number {
       futureDate = addMonths(now, value);
       break;
     default:
-      // Should not happen due to validation, but handle defensively
-      throw new Error(`Unsupported time unit: ${unit}`);
+      const _exhaustiveCheck: never = unit;
+      throw new Error("Unsupported time unit");
   }
 
   return differenceInSeconds(futureDate, now);


### PR DESCRIPTION
- multiplying extra 1000 to last collateral updated date in deposit calculated which was giving an incorrect value
- 12 months was not being converted to seconds properly, because we were assuming all months to have 30 days, which is incorrect

![CleanShot 2025-04-24 at 14 15 51@2x](https://github.com/user-attachments/assets/23327b6d-3662-4248-96c4-b11779ef0e81)


## Summary by Sourcery

Fix incorrect date calculations for collateral proof expiration by improving time unit conversion and timestamp handling

Bug Fixes:
- Corrected the calculation of time unit seconds to accurately convert months, avoiding the previous assumption of 30 days per month
- Fixed incorrect timestamp multiplication when calculating collateral proof validity

Enhancements:
- Refactored getTimeUnitSeconds function to use date-fns for more accurate time unit conversions
- Updated multiple functions to use the improved time calculation method

## Summary by Sourcery

Fix incorrect date calculations for collateral proof expiration by improving time unit conversion and timestamp handling

Bug Fixes:
- Corrected the calculation of time unit seconds to accurately convert months instead of using a fixed 30-day assumption
- Fixed incorrect timestamp multiplication when calculating collateral proof validity

Enhancements:
- Refactored getTimeUnitSeconds function to use date-fns for more accurate time unit conversions
- Updated multiple functions to use improved time calculation method