### PR TITLE
feat: proxy image through harbor

### DIFF
--- a/kit/charts/atk/charts/besu-network/charts/besu-genesis/templates/genesis-job-cleanup.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-genesis/templates/genesis-job-cleanup.yaml
@@ -32,18 +32,20 @@ spec:
         app.kubernetes.io/namespace: {{ .Release.Namespace }}
         app.kubernetes.io/managed-by: helm
     spec:
-{{- if and (eq .Values.cluster.provider "azure") (.Values.cluster.cloudNativeServices) }}
-      serviceAccountName: {{ .Values.azure.serviceAccountName }}
-{{- else if and (eq .Values.cluster.provider "aws") (.Values.cluster.cloudNativeServices) }}
-      serviceAccountName: {{ .Values.aws.serviceAccountName }}
-{{- else }}
-      serviceAccountName: {{ include "besu-genesis.name" . }}-sa
-{{- end }}
-      restartPolicy: "Never"
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- with .Values.imagePullSecrets }}
-        {{- toYaml . | nindent 8 }}
+        {{- range . }}
+        - name: {{ . }}
         {{- end }}
+      {{- end }}
+      {{- if and (eq .Values.cluster.provider "azure") (.Values.cluster.cloudNativeServices) }}
+      serviceAccountName: {{ .Values.azure.serviceAccountName }}
+     {{- else if and (eq .Values.cluster.provider "aws") (.Values.cluster.cloudNativeServices) }}
+      serviceAccountName: {{ .Values.aws.serviceAccountName }}
+      {{- else }}
+      serviceAccountName: {{ include "besu-genesis.name" . }}-sa
+      {{- end }}
       containers:
         - name: delete-genesis
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/kit/charts/atk/charts/besu-network/charts/besu-genesis/templates/genesis-job-init.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-genesis/templates/genesis-job-init.yaml
@@ -33,12 +33,14 @@ spec:
         app.kubernetes.io/namespace: {{ .Release.Namespace }}
         app.kubernetes.io/managed-by: helm
     spec:
-      serviceAccountName: {{ include "besu-genesis.serviceAccountName" . }}
-      restartPolicy: "Never"
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- with .Values.imagePullSecrets }}
-        {{- toYaml . | nindent 8 }}
+        {{- range . }}
+        - name: {{ . }}
         {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "besu-genesis.serviceAccountName" . }}
       volumes:
         - name: generated-config
           emptyDir: {}

--- a/kit/charts/atk/charts/besu-network/charts/besu-genesis/values.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-genesis/values.yaml
@@ -69,4 +69,7 @@ image:
   tag: sha-49c40f5
   pullPolicy: IfNotPresent
 
-imagePullSecrets: []
+imagePullSecrets:
+  - image-pull-secret-harbor
+  - image-pull-secret-ghcr
+  - image-pull-secret-docker

--- a/kit/charts/atk/charts/besu-network/charts/besu-node/templates/node-statefulset.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-node/templates/node-statefulset.yaml
@@ -48,7 +48,8 @@ spec:
 {{- if has .Values.cluster.provider .Values.volumePermissionsFix }}
       # fix for minikube and PVC's only writable as root https://github.com/kubernetes/minikube/issues/1990
       - name: volume-permission-besu
-        image: busybox
+        image: "{{ .Values.busybox.registry }}/busybox:{{ .Values.busybox.tag }}"
+        imagePullPolicy: {{ .Values.busybox.pullPolicy }}
         command: ["sh", "-c", "chown -R 1000:1000 /data"]
         volumeMounts:
           - name: data

--- a/kit/charts/atk/charts/besu-network/charts/besu-node/values.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-node/values.yaml
@@ -196,17 +196,22 @@ node:
 
 image:
   besu:
-    repository: hyperledger/besu
+    repository: docker.io/hyperledger/besu
     tag: 25.3.0
     pullPolicy: IfNotPresent
   tessera:
-    repository: quorumengineering/tessera
+    repository: docker.io/quorumengineering/tessera
     tag: 24.4
     pullPolicy: IfNotPresent
   hooks:
     repository: ghcr.io/settlemint/quorum-genesis-tool
     tag: sha-49c40f5
     pullPolicy: IfNotPresent
+
+busybox:
+  registry: docker.io
+  tag: 1.37
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 

--- a/kit/charts/atk/charts/dapp/templates/deployment.yaml
+++ b/kit/charts/atk/charts/dapp/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         {{- /* Add GraphQL Check if enabled */}}
         {{- if .Values.initContainer.graphQLCheck.enabled }}
         - name: {{ .Values.initContainer.graphQLCheck.name | default "wait-for-graphql" }}
-          image: "{{ .Values.initContainer.graphQLCheck.image.repository }}:{{ .Values.initContainer.graphQLCheck.image.tag }}"
+          image: "{{ .Values.initContainer.graphQLCheck.image.registry }}/{{ .Values.initContainer.graphQLCheck.image.repository }}:{{ .Values.initContainer.graphQLCheck.image.tag }}"
           imagePullPolicy: {{ .Values.initContainer.graphQLCheck.image.pullPolicy }}
           command:
             - /bin/sh

--- a/kit/charts/atk/charts/dapp/values.yaml
+++ b/kit/charts/atk/charts/dapp/values.yaml
@@ -160,6 +160,7 @@ initContainer:
     enabled: true
     name: wait-for-graph-subgraph-kit # Name for the init container
     image:
+      registry: docker.io
       repository: curlimages/curl
       tag: latest # Or pin to a specific version like 8.7.1
       pullPolicy: IfNotPresent

--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-job.yaml
@@ -10,10 +10,11 @@ metadata:
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
-    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
 spec:
+  ttlSecondsAfterFinished: 300
   template:
     metadata:
       name: {{ printf "%s-drizzle-migrate-%d" .Release.Name (.Release.Revision | int) }}
@@ -23,14 +24,16 @@ spec:
         helm.sh/revision: "{{ .Release.Revision }}"
     spec:
       restartPolicy: Never
-      {{- with .Values.global.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
       {{- end }}
       initContainers:
-      - name: wait-for-postgres
-        image: busybox
-        imagePullPolicy: IfNotPresent
+      - name: wait-for-pgpool
+        image: "{{ .Values.busybox.registry }}/{{ .Values.busybox.repository }}:{{ .Values.busybox.tag }}"
+        imagePullPolicy: {{ .Values.busybox.pullPolicy }}
         command:
           - /bin/sh
           - -c
@@ -44,21 +47,31 @@ spec:
             done
             echo "Service ${SERVICE_HOST}:${SERVICE_PORT} is available."
       - name: clone-repo
-        image: alpine/git:latest
-        imagePullPolicy: IfNotPresent
+        image: "{{ .Values.git.image.registry }}/{{ .Values.git.image.repository }}:{{ .Values.git.image.tag }}"
+        imagePullPolicy: {{ .Values.git.image.pullPolicy }}
         command:
           - /bin/sh
           - -c
           - |
             set -ex
-            git clone https://github.com/settlemint/asset-tokenization-kit.git /workspace
+            # Check if the target directory exists and is a git repo, otherwise clone
+            if [ -d "/workspace/.git" ]; then
+              echo "Repository found in /workspace, pulling latest changes..."
+              cd /workspace
+              git pull
+            else
+              echo "Cloning repository into /workspace..."
+              # Ensure the workspace directory exists before cloning into it
+              mkdir -p /workspace
+              git clone https://github.com/settlemint/asset-tokenization-kit.git /workspace
+            fi
         volumeMounts:
           - name: workspace
             mountPath: /workspace
       containers:
       - name: drizzle-migrate
-        image: "oven/bun:1"
-        imagePullPolicy: IfNotPresent
+        image: "{{ .Values.drizzleMigrate.image.registry }}/{{ .Values.drizzleMigrate.image.repository }}:{{ .Values.drizzleMigrate.image.tag }}"
+        imagePullPolicy: {{ .Values.drizzleMigrate.image.pullPolicy }}
         workingDir: /workspace/kit/dapp
         command: ["/bin/sh", "-c"]
         args:
@@ -87,6 +100,11 @@ spec:
             mountPath: /workspace
       volumes:
         - name: workspace
+          {{- if .Values.job.workspace.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ printf "%s-drizzle-migrate-workspace" .Release.Name }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       terminationGracePeriodSeconds: 30
   backoffLimit: 1

--- a/kit/charts/atk/charts/hasura/templates/drizzle-migration-pvc.yaml
+++ b/kit/charts/atk/charts/hasura/templates/drizzle-migration-pvc.yaml
@@ -1,0 +1,28 @@
+{{- /* Template to define the PVC for the Drizzle migration job workspace */ -}}
+
+{{- if .Values.job.workspace.enabled  -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-drizzle-migrate-workspace" .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # It's better to use a defined helper template for labels if available
+    # Replicating common labels pattern as fallback
+    app.kubernetes.io/name: {{ printf "%s-drizzle-migrate-workspace" .Release.Name }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: drizzle-migrate-workspace
+spec:
+  accessModes:
+    - {{ .Values.job.workspace.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.job.workspace.size | default "1Gi" }}
+  {{- if .Values.job.workspace.storageClass }}
+  storageClassName: {{ .Values.job.workspace.storageClass }}
+  {{- else }}
+  # If no storageClass is specified, don't include the field to use the default
+  {{- end }}
+{{- end }}

--- a/kit/charts/atk/charts/hasura/values.yaml
+++ b/kit/charts/atk/charts/hasura/values.yaml
@@ -29,10 +29,46 @@ graphql-engine:
     - name: HASURA_GRAPHQL_DATABASE_URL
       value: "postgresql://hasura:atk@postgresql-pgpool:5432/hasura"
   global:
-    imagePullSecrets: []
+    imagePullSecrets:
+      - image-pull-secret-docker
+      - image-pull-secret-ghcr
+      - image-pull-secret-harbor
   postgres:
     enabled: false
   initContainers:
     - name: wait-for-postgresql
       image: ghcr.io/settlemint/btp-waitforit:v7.7.3
       command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
+
+busybox:
+  registry: docker.io
+  repository: busybox
+  tag: 1.37
+  pullPolicy: IfNotPresent
+
+drizzleMigrate:
+  image:
+    registry: docker.io
+    repository: oven/bun
+    tag: "1"
+    pullPolicy: IfNotPresent
+
+git:
+  image:
+    registry: docker.io
+    repository: alpine/git
+    tag: latest
+    pullPolicy: IfNotPresent
+
+job:
+  workspace:
+    # -- Configure the persistent volume claim for the job workspace
+    enabled: true # Set to false to use emptyDir instead of PVC
+    size: 1Gi
+    storageClass: "" # Optional: specify storage class, otherwise use default
+    accessMode: ReadWriteOnce
+
+imagePullSecrets:
+  - image-pull-secret-docker
+  - image-pull-secret-ghcr
+  - image-pull-secret-harbor

--- a/kit/charts/atk/charts/observability/values.yaml
+++ b/kit/charts/atk/charts/observability/values.yaml
@@ -701,15 +701,17 @@ prometheus-node-exporter:
   enabled: true
   image:
     registry: quay.io
+  imagePullSecrets:
+    - image-pull-secret-docker
+    - image-pull-secret-ghcr
+    - image-pull-secret-harbor
   kubeRBACProxy:
     image:
       registry: quay.io
   global:
     imageRegistry: quay.io
-    imagePullSecrets: []
   fullnameOverride: node-exporter
   nameOverride: node-exporter
-  imagePullSecrets: []
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9100"

--- a/kit/charts/atk/charts/support/values.yaml
+++ b/kit/charts/atk/charts/support/values.yaml
@@ -1,12 +1,20 @@
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql-ha/values.yaml
 postgresql-ha:
   enabled: true
+  global:
+    security:
+      allowInsecureImages: true
+    imagePullSecrets:
+      - image-pull-secret-docker
+      - image-pull-secret-ghcr
+      - image-pull-secret-harbor
   fullnameOverride: postgresql
   commonLabels:
     kots.io/app-slug: settlemint-atk
-
     app.kubernetes.io/managed-by: helm
   postgresql:
+    image:
+      registry: docker.io
     username: "postgres"
     password: "atk"
     repmgrUsername: repmgr
@@ -39,6 +47,8 @@ postgresql-ha:
         \c portal;
         GRANT ALL ON SCHEMA public TO portal;
   pgpool:
+    image:
+      registry: docker.io
     replicaCount: 1
     adminUsername: "pgpool"
     adminPassword: "atk"
@@ -54,6 +64,15 @@ postgresql-ha:
 # https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
 redis:
   enabled: true
+  global:
+    security:
+      allowInsecureImages: true
+    imagePullSecrets:
+      - image-pull-secret-docker
+      - image-pull-secret-ghcr
+      - image-pull-secret-harbor
+  image:
+    registry: docker.io
   fullnameOverride: redis
   commonLabels:
     kots.io/app-slug: settlemint-atk
@@ -66,14 +85,18 @@ redis:
   replica:
     replicaCount: 1
     resourcesPreset: "none"
-  global:
-    imagePullSecrets: []
 
 # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
 ingress-nginx:
   enabled: true
+  global:
+    image:
+      registry: registry.k8s.io
   fullnameOverride: 'ingress-nginx'
-  imagePullSecrets: []
+  imagePullSecrets:
+    - image-pull-secret-docker
+    - image-pull-secret-ghcr
+    - image-pull-secret-harbor
   defaultBackend:
     enabled: false
   controller:

--- a/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
+++ b/kit/charts/atk/charts/thegraph/templates/job-deploy-subgraph.yaml
@@ -10,6 +10,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 300
   template:
     metadata:
       {{- with .Values.job.podAnnotations }}
@@ -22,13 +23,18 @@ spec:
       restartPolicy: Never
       {{- with .Values.job.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
       {{- end }}
+      {{- if .Values.job.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.job.podSecurityContext | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: wait-for-graph-node
-          image: busybox
+          image: "{{ .Values.job.busyboxImage.registry }}/{{ .Values.job.busyboxImage.repository }}:{{ .Values.job.busyboxImage.tag }}"
+          imagePullPolicy: {{ .Values.job.busyboxImage.pullPolicy }}
           command:
             - /bin/sh
             - -c
@@ -52,7 +58,8 @@ spec:
 
               echo "Service ${SERVICE_NAME}:${PORT} is available, proceeding..."
         - name: clone-repo
-          image: alpine/git:latest
+          image: "{{ .Values.job.gitImage.registry }}/{{ .Values.job.gitImage.repository }}:{{ .Values.job.gitImage.tag }}"
+          imagePullPolicy: {{ .Values.job.gitImage.pullPolicy }}
           command:
             - /bin/sh
             - -c

--- a/kit/charts/atk/charts/thegraph/values.yaml
+++ b/kit/charts/atk/charts/thegraph/values.yaml
@@ -110,7 +110,7 @@ job:
 
   # Image configuration
   image:
-    repository: node
+    repository: docker.io/node
     tag: "23.11.0-slim"
     pullPolicy: IfNotPresent
 
@@ -118,7 +118,24 @@ job:
   podAnnotations: {}
 
   # Image pull secrets
-  imagePullSecrets: []
+  imagePullSecrets:
+    - image-pull-secret-docker
+    - image-pull-secret-ghcr
+    - image-pull-secret-harbor
+
+  # Image for the wait-for-graph-node init container
+  busyboxImage:
+    registry: docker.io
+    repository: busybox
+    tag: 1.36 # Use specific stable tag
+    pullPolicy: IfNotPresent
+
+  # Image for the clone-repo init container
+  gitImage:
+    registry: docker.io
+    repository: alpine/git
+    tag: latest # Or pin to a specific version
+    pullPolicy: IfNotPresent
 
   # Custom Init Containers (add definitions here if needed, e.g., for dependencies)
   # extraInitContainers: []
@@ -128,7 +145,7 @@ job:
   #   enabled: false # Set to true to enable the random delay
   #   maxSeconds: 31 # Max random sleep duration (exclusive, e.g., 31 means 0-30 seconds)
   #   image:
-  #     repository: busybox
+  #     repository: docker.io/busybox
   #     tag: latest
   #     pullPolicy: IfNotPresent
 

--- a/kit/charts/atk/templates/image-pull.secrets.yaml
+++ b/kit/charts/atk/templates/image-pull.secrets.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "atk.labels" $ | nindent 4 }}
   annotations:
+    # Ensure secrets are created before jobs/pods that might need them
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-15"
     {{- include "atk.annotations" $ | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:

--- a/kit/charts/atk/values-prod.yaml
+++ b/kit/charts/atk/values-prod.yaml
@@ -212,7 +212,7 @@ thegraph:
           image: ghcr.io/settlemint/btp-waitforit:v7.7.3
           command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
         - name: random-delay
-          image: busybox:latest # Using busybox as it has sh and sleep
+          image: docker.io/busybox:latest # Using busybox as it has sh and sleep
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
           args:
@@ -270,7 +270,7 @@ thegraph:
   job:
     fullnameOverride: graph
     image:
-      repository: node
+      repository: docker.io/node
       tag: "23.11.0-slim"
       pullPolicy: IfNotPresent
     workspace:
@@ -494,6 +494,7 @@ dapp:
       enabled: true
       name: wait-for-graph-subgraph-kit # Name for the init container
       image:
+        registry: docker.io
         repository: curlimages/curl
         tag: latest # Or pin to a specific version like 8.7.1
         pullPolicy: IfNotPresent

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -291,7 +291,7 @@ thegraph:
     enabled: true
     fullnameOverride: graph
     image:
-      repository: node
+      repository: docker.io/node
       tag: "23.11.0-slim"
       pullPolicy: IfNotPresent
     workspace:
@@ -548,6 +548,7 @@ dapp:
       enabled: true
       name: wait-for-graph-subgraph-kit  # Name for the init container
       image:
+        registry: docker.io
         repository: curlimages/curl
         tag: latest  # Or pin to a specific version like 8.7.1
         pullPolicy: IfNotPresent

--- a/kit/charts/configure-proxy.ts
+++ b/kit/charts/configure-proxy.ts
@@ -1,0 +1,263 @@
+import { join } from 'node:path';
+
+const HARBOR_PROXY = 'harbor.settlemint.com';
+
+async function processFile(filePath: string): Promise<void> {
+  try {
+    const content = await Bun.file(filePath).text();
+    const lines = content.split('\n');
+
+    // Check if there's a features.kits section
+    let inFeaturesSection = false;
+    let inKitsSection = false;
+    let inCustomDeployment = false;
+    let inCodeStudio = false;
+    let featuresSectionIndent = '';
+
+    const modifiedLines = lines.map((line) => {
+      // Track if we're entering or leaving the features section
+      if (line.trim() === 'features:') {
+        inFeaturesSection = true;
+        featuresSectionIndent = line.match(/^\s*/)?.[0] || '';
+      }
+      // If we're in features section and find a kits: entry
+      else if (inFeaturesSection && line.trim() === 'kits:') {
+        inKitsSection = true;
+      }
+      // Track customDeployment and codeStudio sections within kits
+      else if (inKitsSection && line.trim() === 'customDeployment:') {
+        inCustomDeployment = true;
+        inCodeStudio = false;
+      } else if (inKitsSection && line.trim() === 'codeStudio:') {
+        inCodeStudio = true;
+        inCustomDeployment = false;
+      }
+      // If we're in features section and find another top-level section
+      else if (
+        inFeaturesSection &&
+        !line.startsWith(`${featuresSectionIndent} `) &&
+        line.trim() !== ''
+      ) {
+        inFeaturesSection = false;
+        inKitsSection = false;
+        inCustomDeployment = false;
+        inCodeStudio = false;
+      }
+
+      // Skip modifying lines in the kits.customDeployment section
+      if (inKitsSection && inCustomDeployment) {
+        return line;
+      }
+
+      // Process registry: values
+      if (line.includes('registry:') && !line.includes(`${HARBOR_PROXY}/`)) {
+        const registryMatch = line.match(/(\s+registry:\s+)([^\s\n]+)/);
+        if (
+          registryMatch &&
+          registryMatch[2] !== HARBOR_PROXY &&
+          !registryMatch[2].startsWith(`${HARBOR_PROXY}/`)
+        ) {
+          console.log(
+            `Prefixing registry: ${registryMatch[2]} with ${HARBOR_PROXY}/`
+          );
+          return line.replace(
+            /(\s+registry:\s+)([^\s\n]+)/,
+            `$1${HARBOR_PROXY}/$2`
+          );
+        }
+      }
+
+      // Process imageRegistry: values
+      if (
+        line.includes('imageRegistry:') &&
+        !line.includes(`${HARBOR_PROXY}/`)
+      ) {
+        const registryMatch = line.match(/(\s+imageRegistry:\s+)([^\s\n]+)/);
+        if (
+          registryMatch &&
+          registryMatch[2] !== HARBOR_PROXY &&
+          !registryMatch[2].startsWith(`${HARBOR_PROXY}/`)
+        ) {
+          console.log(
+            `Prefixing imageRegistry: ${registryMatch[2]} with ${HARBOR_PROXY}/`
+          );
+          return line.replace(
+            /(\s+imageRegistry:\s+)([^\s\n]+)/,
+            `$1${HARBOR_PROXY}/$2`
+          );
+        }
+      }
+
+      // Replace name: ghcr.io with name: harbor.settlemint.com
+      if (line.includes('name:') && line.includes('ghcr.io')) {
+        console.log(`Replacing name: ghcr.io with ${HARBOR_PROXY}`);
+        return line.replace(/(\s+name:\s+)ghcr\.io/, `$1${HARBOR_PROXY}`);
+      }
+
+      // Process repository: values
+      if (line.includes('repository:')) {
+        const repoMatch = line.match(/(\s+repository:\s+)([^\s\n]+)/);
+        if (repoMatch) {
+          const repoValue = repoMatch[2];
+          let modifiedLine = line; // Store potential modification
+          let needsReplacing = false;
+
+          if (
+            repoValue.includes('registry.k8s.io') &&
+            !repoValue.includes(`${HARBOR_PROXY}/registry.k8s.io`)
+          ) {
+            const newValue = repoValue.replace(
+              'registry.k8s.io',
+              `${HARBOR_PROXY}/registry.k8s.io`
+            );
+            console.log(`Replacing repository: ${repoValue} with ${newValue}`);
+            modifiedLine = line.replace(repoValue, newValue);
+            needsReplacing = true;
+          } else if (
+            repoValue.includes('quay.io') &&
+            !repoValue.includes(`${HARBOR_PROXY}/quay.io`)
+          ) {
+            const newValue = repoValue.replace(
+              'quay.io',
+              `${HARBOR_PROXY}/quay.io`
+            );
+            console.log(`Replacing repository: ${repoValue} with ${newValue}`);
+            modifiedLine = line.replace(repoValue, newValue);
+            needsReplacing = true;
+          } else if (
+            repoValue.includes('ghcr.io') &&
+            !repoValue.includes(`${HARBOR_PROXY}/ghcr.io`)
+          ) {
+            const newValue = repoValue.replace(
+              'ghcr.io',
+              `${HARBOR_PROXY}/ghcr.io`
+            );
+            console.log(`Replacing repository: ${repoValue} with ${newValue}`);
+            modifiedLine = line.replace(repoValue, newValue);
+            needsReplacing = true;
+          } else if (
+            repoValue.includes('docker.io') &&
+            !repoValue.includes(`${HARBOR_PROXY}/docker.io`)
+          ) {
+            const newValue = repoValue.replace(
+              'docker.io',
+              `${HARBOR_PROXY}/docker.io`
+            );
+            console.log(`Replacing repository: ${repoValue} with ${newValue}`);
+            modifiedLine = line.replace(repoValue, newValue);
+            needsReplacing = true;
+          }
+
+          if (needsReplacing) {
+            return modifiedLine;
+          }
+        }
+      }
+
+      // Process image: values
+      if (line.includes('image:') && !line.includes('imageRegistry')) { // Avoid matching imageRegistry again
+        const imageMatch = line.match(/(\s+image:\s+)([^\s\n]+)/);
+        if (imageMatch) {
+          const imageValue = imageMatch[2];
+          let modifiedLine = line;
+          let needsReplacing = false;
+
+          if (
+            imageValue.includes('registry.k8s.io') &&
+            !imageValue.includes(`${HARBOR_PROXY}/registry.k8s.io`)
+          ) {
+            const newValue = imageValue.replace(
+              'registry.k8s.io',
+              `${HARBOR_PROXY}/registry.k8s.io`
+            );
+            console.log(`Replacing image: ${imageValue} with ${newValue}`);
+            modifiedLine = line.replace(imageValue, newValue);
+            needsReplacing = true;
+          } else if (
+            imageValue.includes('quay.io') &&
+            !imageValue.includes(`${HARBOR_PROXY}/quay.io`)
+          ) {
+            const newValue = imageValue.replace(
+              'quay.io',
+              `${HARBOR_PROXY}/quay.io`
+            );
+            console.log(`Replacing image: ${imageValue} with ${newValue}`);
+            modifiedLine = line.replace(imageValue, newValue);
+            needsReplacing = true;
+          } else if (
+            imageValue.includes('ghcr.io') &&
+            !imageValue.includes(`${HARBOR_PROXY}/ghcr.io`)
+          ) {
+            const newValue = imageValue.replace(
+              'ghcr.io',
+              `${HARBOR_PROXY}/ghcr.io`
+            );
+            console.log(`Replacing image: ${imageValue} with ${newValue}`);
+            modifiedLine = line.replace(imageValue, newValue);
+            needsReplacing = true;
+          } else if (
+            imageValue.includes('docker.io') &&
+            !imageValue.includes(`${HARBOR_PROXY}/docker.io`)
+          ) {
+            const newValue = imageValue.replace(
+              'docker.io',
+              `${HARBOR_PROXY}/docker.io`
+            );
+            console.log(`Replacing image: ${imageValue} with ${newValue}`);
+            modifiedLine = line.replace(imageValue, newValue);
+            needsReplacing = true;
+          }
+
+          if (needsReplacing) {
+            return modifiedLine;
+          }
+        }
+      }
+
+      return line;
+    });
+
+    const modifiedContent = modifiedLines.join('\n');
+
+    // Check if any changes were made
+    if (modifiedContent !== content) {
+      console.log(`Updated registry values in ${filePath}`);
+      await Bun.write(filePath, modifiedContent);
+    } else {
+      console.log(`No changes needed in ${filePath}`);
+    }
+  } catch (error) {
+    console.error(`Error processing ${filePath}:`, error);
+  }
+}
+
+const files = [
+  join(__dirname, 'atk', 'values.yaml'),
+  join(__dirname, 'atk', 'values-prod.yaml'),
+  join(__dirname, 'atk', 'values-example.yaml'),
+  join(__dirname, 'atk', 'charts', 'besu-network', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'besu-network', 'charts', 'besu-node', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'besu-network', 'charts', 'besu-genesis', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'blockscout', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'dapp', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'erpc', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'hasura', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'observability', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'portal', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'support', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'thegraph', 'values.yaml'),
+  join(__dirname, 'atk', 'charts', 'txsigner', 'values.yaml'),
+];
+
+async function main() {
+  try {
+    // Process files sequentially for clearer debugging
+    for (const file of files) {
+      await processFile(file);
+    }
+  } catch (error) {
+    console.error('Error processing files:', error);
+  }
+}
+
+await main();

--- a/kit/charts/package.json
+++ b/kit/charts/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "helm:deps": "bash -c 'set -eo pipefail; error_count=0; for d in ./{atk}; do if [ -d \"$d\" ]; then echo \"Updating dependencies for $d...\"; if ! helm dependency update \"$d\"; then echo \"Error updating dependencies for $d\"; error_count=$((error_count+1)); fi; fi; done; for d in ./atk/charts/*; do if [ -d \"$d\" ]; then echo \"Updating dependencies for $d...\"; if ! helm dependency update \"$d\"; then echo \"Error updating dependencies for $d\"; error_count=$((error_count+1)); fi; fi; done; if [ $error_count -gt 0 ]; then echo \"$error_count dependency update errors occurred\"; exit 1; fi'",
     "helm:package": "helm package atk --destination .",
-    "helm:push": "helm push atk-*.tgz oci://ghcr.io/settlemint && helm push ./atk-*.tgz oci://harbor.settlemint.com/atk"
+    "helm:push": "helm push atk-*.tgz oci://ghcr.io/settlemint && helm push ./atk-*.tgz oci://harbor.settlemint.com/atk",
+    "helm:proxy": "bun run configure-proxy.ts"
   },
   "dependencies": {},
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "helm:full": "bun run helm:check-context && bun run secrets && bun run abis && bunx turbo genesis && bunx turbo run helm:deps --force && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace",
     "helm:install": "bun run helm:check-context && bunx turbo run helm:deps && helm upgrade --install atk kit/charts/atk -f kit/charts/atk/values-example.yaml -n atk --create-namespace --timeout 15m",
     "helm:delete": "bun run helm:check-context && helm uninstall atk -n atk --wait && kubectl delete pvc --all -n atk && kubectl delete namespace atk",
-    "helm:reset": "bun run helm:delete && bun run helm:install"
+    "helm:reset": "bun run helm:delete && bun run helm:install",
+    "helm:proxy": "turbo run helm:proxy"
   },
   "dependencies": {},
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -100,8 +100,11 @@
       "cache": false,
       "persistent": true
     },
+    "helm:proxy": {
+      "cache": false
+    },
     "helm:package": {
-      "dependsOn": ["helm:deps"],
+      "dependsOn": ["helm:deps", "helm:proxy"],
       "cache": false
     },
     "helm:push": {


### PR DESCRIPTION
## Summary by Sourcery

Implement image proxying through Harbor registry for improved image management and consistency across Helm charts

New Features:
- Added a script to configure image registry proxying through Harbor
- Introduced persistent volume claim for Drizzle migration job workspace

Enhancements:
- Standardized image pull secrets across multiple Helm charts
- Updated image references to use explicit registry paths
- Added configuration for image pull policies and registries

Build:
- Added a TypeScript script (configure-proxy.ts) to automate image registry transformations

Chores:
- Updated package.json scripts to support Harbor image proxying
- Refactored image and registry configurations in multiple Helm chart values files