### PR TITLE
fix: missing info box for ownership concentration

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/(details)/_components/details/bonds.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/(details)/_components/details/bonds.tsx
@@ -132,7 +132,10 @@ export async function BondsDetails({
           : 0}
         %
       </DetailGridItem>
-      <DetailGridItem label={t("ownership-concentration")}>
+      <DetailGridItem
+        label={t("ownership-concentration")}
+        info={t("ownership-concentration-info")}
+      >
         {formatNumber(bond.concentration, {
           percentage: true,
           decimals: 2,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add the info tooltip to the ownership concentration field in the Bonds details view.