### PR TITLE
feat: add EASModule in Hardhat ignition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "kit/contracts/kit/contracts/lib/forge-std"]
-	path = kit/contracts/kit/contracts/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
-[submodule "kit/contracts/kit/contracts/lib/eas-contracts"]
-	path = kit/contracts/kit/contracts/lib/eas-contracts
-	url = https://github.com/ethereum-attestation-service/eas-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "kit/contracts/kit/contracts/lib/forge-std"]
+	path = kit/contracts/kit/contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "kit/contracts/kit/contracts/lib/eas-contracts"]
+	path = kit/contracts/kit/contracts/lib/eas-contracts
+	url = https://github.com/ethereum-attestation-service/eas-contracts

--- a/kit/contracts/contracts/AirdropFactory.sol
+++ b/kit/contracts/contracts/AirdropFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { StandardAirdrop } from "./StandardAirdrop.sol";
 import { VestingAirdrop } from "./VestingAirdrop.sol";

--- a/kit/contracts/contracts/Bond.sol
+++ b/kit/contracts/contracts/Bond.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/kit/contracts/contracts/BondFactory.sol
+++ b/kit/contracts/contracts/BondFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Bond } from "./Bond.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/CryptoCurrency.sol
+++ b/kit/contracts/contracts/CryptoCurrency.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";

--- a/kit/contracts/contracts/CryptoCurrencyFactory.sol
+++ b/kit/contracts/contracts/CryptoCurrencyFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { CryptoCurrency } from "./CryptoCurrency.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/CustomEAS.args
+++ b/kit/contracts/contracts/CustomEAS.args
@@ -1,0 +1,1 @@
+$CustomSchemaRegistry 

--- a/kit/contracts/contracts/CustomEAS.args
+++ b/kit/contracts/contracts/CustomEAS.args
@@ -1,1 +1,0 @@
-$CustomSchemaRegistry 

--- a/kit/contracts/contracts/CustomEAS.sol
+++ b/kit/contracts/contracts/CustomEAS.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+pragma solidity 0.8.29;
+
+import { EAS, ISchemaRegistry } from "@ethereum-attestation-service/eas-contracts/EAS.sol";
+
+contract CustomEAS is EAS {
+    constructor(ISchemaRegistry registry) EAS(registry) { }
+} 

--- a/kit/contracts/contracts/CustomEAS.sol
+++ b/kit/contracts/contracts/CustomEAS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.28;
 
 import { EAS, ISchemaRegistry } from "@ethereum-attestation-service/eas-contracts/EAS.sol";
 

--- a/kit/contracts/contracts/CustomEAS.sol
+++ b/kit/contracts/contracts/CustomEAS.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.28;
-
-import { EAS, ISchemaRegistry } from "@ethereum-attestation-service/eas-contracts/EAS.sol";
-
-contract CustomEAS is EAS {
-    constructor(ISchemaRegistry registry) EAS(registry) { }
-} 

--- a/kit/contracts/contracts/CustomSchemaRegistry.sol
+++ b/kit/contracts/contracts/CustomSchemaRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.28;
 
 import { SchemaRegistry } from "@ethereum-attestation-service/eas-contracts/SchemaRegistry.sol";
 

--- a/kit/contracts/contracts/CustomSchemaRegistry.sol
+++ b/kit/contracts/contracts/CustomSchemaRegistry.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+pragma solidity 0.8.29;
+
+import { SchemaRegistry } from "@ethereum-attestation-service/eas-contracts/SchemaRegistry.sol";
+
+contract CustomSchemaRegistry is SchemaRegistry { } 

--- a/kit/contracts/contracts/Deposit.sol
+++ b/kit/contracts/contracts/Deposit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/kit/contracts/contracts/DepositFactory.sol
+++ b/kit/contracts/contracts/DepositFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Deposit } from "./Deposit.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/DvPSwap.sol
+++ b/kit/contracts/contracts/DvPSwap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/kit/contracts/contracts/DvPSwapFactory.sol
+++ b/kit/contracts/contracts/DvPSwapFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { DvPSwap } from "./DvPSwap.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/EAS.md
+++ b/kit/contracts/contracts/EAS.md
@@ -1,0 +1,50 @@
+# Ethereum Attestation Service (EAS) – Enterprise-Grade Attestation Management
+
+## Introduction
+
+The EAS implementation provides a robust, standardized way to create and manage on-chain attestations. Tailored for enterprise use, these contracts enable secure, transparent attestation management with support for custom schemas and flexible attestation structures.
+
+---
+
+## Why On-Chain Attestations?
+
+On-chain attestations provide immutable, verifiable records of claims or statements. They enable transparent verification while maintaining the flexibility to support various use cases from identity verification to credential management.
+
+### Enterprise Applications:
+
+- **Identity & Credentials:** Manage verifiable credentials and identity attestations securely.
+- **Compliance & Auditing:** Create immutable audit trails of verifications and certifications.
+- **Supply Chain:** Track and verify product authenticity and certifications.
+- **Governance:** Enable transparent verification of voting rights and permissions.
+
+---
+
+## Contract Features and Capabilities
+
+### Schema Management
+
+- Flexible schema registry for defining and managing attestation structures.
+- Support for complex data types and nested schemas.
+- Immutable schema records ensuring consistency.
+
+### Attestation Creation and Management
+
+- **Secure Attestations:** Create and verify attestations with cryptographic security.
+- **Revocation Support:** Built-in mechanisms for revoking or updating attestations.
+- **Multi-Party Attestations:** Support for attestations involving multiple parties.
+
+### Security and Compliance
+
+- **Immutable Records:** All attestations are permanently recorded on-chain.
+- **Verifiable History:** Complete audit trail of attestations and schema changes.
+- **Access Control:** Fine-grained control over who can create and manage attestations.
+
+### Extensibility
+
+- Custom implementations can extend base functionality.
+- Support for additional features through inheritance.
+- Integration with existing systems through standard interfaces.
+
+---
+
+EAS empowers enterprises with robust attestation management capabilities, enhancing transparency and trust while maintaining security and compliance standards. 

--- a/kit/contracts/contracts/EAS.sol
+++ b/kit/contracts/contracts/EAS.sol
@@ -3,32 +3,18 @@ pragma solidity ^0.8.28;
 
 import { EAS as BaseEAS, ISchemaRegistry } from "@ethereum-attestation-service/eas-contracts/EAS.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
-import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
 contract EAS is BaseEAS, ERC2771Context {
     constructor(
         ISchemaRegistry registry,
         address forwarder
-    ) BaseEAS(registry) ERC2771Context(forwarder) { }
+    ) BaseEAS(registry) ERC2771Context(forwarder) {}
 
-    /// @notice Returns the message sender in the context of meta-transactions
-    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
-    /// @return The address of the message sender
-    function _msgSender() internal view override(Context, ERC2771Context) returns (address) {
+    function _msgSender() internal view virtual override(ERC2771Context) returns (address) {
         return super._msgSender();
     }
 
-    /// @notice Returns the message data in the context of meta-transactions
-    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
-    /// @return The message data
-    function _msgData() internal view override(Context, ERC2771Context) returns (bytes calldata) {
+    function _msgData() internal view virtual override(ERC2771Context) returns (bytes calldata) {
         return super._msgData();
     }
-
-    /// @notice Returns the length of the context suffix for meta-transactions
-    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
-    /// @return The length of the context suffix
-    function _contextSuffixLength() internal view override(Context, ERC2771Context) returns (uint256) {
-        return super._contextSuffixLength();
-    }
-}
+} 

--- a/kit/contracts/contracts/EAS.sol
+++ b/kit/contracts/contracts/EAS.sol
@@ -2,7 +2,33 @@
 pragma solidity ^0.8.28;
 
 import { EAS as BaseEAS, ISchemaRegistry } from "@ethereum-attestation-service/eas-contracts/EAS.sol";
+import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
-contract EAS is BaseEAS {
-    constructor(ISchemaRegistry registry) BaseEAS(registry) { }
+contract EAS is BaseEAS, ERC2771Context {
+    constructor(
+        ISchemaRegistry registry,
+        address forwarder
+    ) BaseEAS(registry) ERC2771Context(forwarder) { }
+
+    /// @notice Returns the message sender in the context of meta-transactions
+    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
+    /// @return The address of the message sender
+    function _msgSender() internal view override(Context, ERC2771Context) returns (address) {
+        return super._msgSender();
+    }
+
+    /// @notice Returns the message data in the context of meta-transactions
+    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
+    /// @return The message data
+    function _msgData() internal view override(Context, ERC2771Context) returns (bytes calldata) {
+        return super._msgData();
+    }
+
+    /// @notice Returns the length of the context suffix for meta-transactions
+    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
+    /// @return The length of the context suffix
+    function _contextSuffixLength() internal view override(Context, ERC2771Context) returns (uint256) {
+        return super._contextSuffixLength();
+    }
 }

--- a/kit/contracts/contracts/EAS.sol
+++ b/kit/contracts/contracts/EAS.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+pragma solidity ^0.8.28;
+
+import { EAS as BaseEAS, ISchemaRegistry } from "@ethereum-attestation-service/eas-contracts/EAS.sol";
+
+contract EAS is BaseEAS {
+    constructor(ISchemaRegistry registry) BaseEAS(registry) { }
+}

--- a/kit/contracts/contracts/EASSchemaRegistry.sol
+++ b/kit/contracts/contracts/EASSchemaRegistry.sol
@@ -3,4 +3,4 @@ pragma solidity ^0.8.28;
 
 import { SchemaRegistry } from "@ethereum-attestation-service/eas-contracts/SchemaRegistry.sol";
 
-contract CustomSchemaRegistry is SchemaRegistry { } 
+contract EASSchemaRegistry is SchemaRegistry { }

--- a/kit/contracts/contracts/EASSchemaRegistry.sol
+++ b/kit/contracts/contracts/EASSchemaRegistry.sol
@@ -3,29 +3,15 @@ pragma solidity ^0.8.28;
 
 import { SchemaRegistry } from "@ethereum-attestation-service/eas-contracts/SchemaRegistry.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
-import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
 contract EASSchemaRegistry is SchemaRegistry, ERC2771Context {
-    constructor(address forwarder) ERC2771Context(forwarder) { }
+    constructor(address forwarder) ERC2771Context(forwarder) {}
 
-    /// @notice Returns the message sender in the context of meta-transactions
-    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
-    /// @return The address of the message sender
-    function _msgSender() internal view override(Context, ERC2771Context) returns (address) {
+    function _msgSender() internal view virtual override(ERC2771Context) returns (address) {
         return super._msgSender();
     }
 
-    /// @notice Returns the message data in the context of meta-transactions
-    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
-    /// @return The message data
-    function _msgData() internal view override(Context, ERC2771Context) returns (bytes calldata) {
+    function _msgData() internal view virtual override(ERC2771Context) returns (bytes calldata) {
         return super._msgData();
-    }
-
-    /// @notice Returns the length of the context suffix for meta-transactions
-    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
-    /// @return The length of the context suffix
-    function _contextSuffixLength() internal view override(Context, ERC2771Context) returns (uint256) {
-        return super._contextSuffixLength();
     }
 }

--- a/kit/contracts/contracts/EASSchemaRegistry.sol
+++ b/kit/contracts/contracts/EASSchemaRegistry.sol
@@ -2,5 +2,30 @@
 pragma solidity ^0.8.28;
 
 import { SchemaRegistry } from "@ethereum-attestation-service/eas-contracts/SchemaRegistry.sol";
+import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
-contract EASSchemaRegistry is SchemaRegistry { }
+contract EASSchemaRegistry is SchemaRegistry, ERC2771Context {
+    constructor(address forwarder) ERC2771Context(forwarder) { }
+
+    /// @notice Returns the message sender in the context of meta-transactions
+    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
+    /// @return The address of the message sender
+    function _msgSender() internal view override(Context, ERC2771Context) returns (address) {
+        return super._msgSender();
+    }
+
+    /// @notice Returns the message data in the context of meta-transactions
+    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
+    /// @return The message data
+    function _msgData() internal view override(Context, ERC2771Context) returns (bytes calldata) {
+        return super._msgData();
+    }
+
+    /// @notice Returns the length of the context suffix for meta-transactions
+    /// @dev Overrides both Context and ERC2771Context to support meta-transactions
+    /// @return The length of the context suffix
+    function _contextSuffixLength() internal view override(Context, ERC2771Context) returns (uint256) {
+        return super._contextSuffixLength();
+    }
+}

--- a/kit/contracts/contracts/Equity.sol
+++ b/kit/contracts/contracts/Equity.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/kit/contracts/contracts/EquityFactory.sol
+++ b/kit/contracts/contracts/EquityFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Equity } from "./Equity.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/FixedYield.sol
+++ b/kit/contracts/contracts/FixedYield.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";

--- a/kit/contracts/contracts/FixedYieldFactory.sol
+++ b/kit/contracts/contracts/FixedYieldFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { FixedYield } from "./FixedYield.sol";
 import { ERC20Yield } from "./extensions/ERC20Yield.sol";

--- a/kit/contracts/contracts/Forwarder.sol
+++ b/kit/contracts/contracts/Forwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC2771Forwarder } from "@openzeppelin/contracts/metatx/ERC2771Forwarder.sol";
 

--- a/kit/contracts/contracts/Fund.sol
+++ b/kit/contracts/contracts/Fund.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/kit/contracts/contracts/FundFactory.sol
+++ b/kit/contracts/contracts/FundFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Fund } from "./Fund.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/PushAirdrop.sol
+++ b/kit/contracts/contracts/PushAirdrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/kit/contracts/contracts/StableCoin.sol
+++ b/kit/contracts/contracts/StableCoin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/kit/contracts/contracts/StableCoinFactory.sol
+++ b/kit/contracts/contracts/StableCoinFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { StableCoin } from "./StableCoin.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/kit/contracts/contracts/StandardAirdrop.sol
+++ b/kit/contracts/contracts/StandardAirdrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { AirdropBase } from "./airdrop/AirdropBase.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/kit/contracts/contracts/VestingAirdrop.sol
+++ b/kit/contracts/contracts/VestingAirdrop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { AirdropBase } from "./airdrop/AirdropBase.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/kit/contracts/contracts/airdrop/AirdropBase.sol
+++ b/kit/contracts/contracts/airdrop/AirdropBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/kit/contracts/contracts/airdrop/interfaces/IClaimStrategy.sol
+++ b/kit/contracts/contracts/airdrop/interfaces/IClaimStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 /**
  * @title IClaimStrategy

--- a/kit/contracts/contracts/airdrop/strategies/LinearVestingStrategy.sol
+++ b/kit/contracts/contracts/airdrop/strategies/LinearVestingStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IClaimStrategy } from "../interfaces/IClaimStrategy.sol";

--- a/kit/contracts/contracts/extensions/ERC20HistoricalBalances.sol
+++ b/kit/contracts/contracts/extensions/ERC20HistoricalBalances.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Checkpoints } from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";

--- a/kit/contracts/contracts/extensions/ERC20Yield.sol
+++ b/kit/contracts/contracts/extensions/ERC20Yield.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";

--- a/kit/contracts/contracts/interfaces/IFixedYield.sol
+++ b/kit/contracts/contracts/interfaces/IFixedYield.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20Yield } from "../extensions/ERC20Yield.sol";

--- a/kit/contracts/foundry.toml
+++ b/kit/contracts/foundry.toml
@@ -20,6 +20,7 @@
 forge-std = "1.9.5"
 "@openzeppelin-contracts" = "5.2.0"
 openzeppelin-community-contracts = { version = "0.0.1", git = "https://github.com/OpenZeppelin/openzeppelin-community-contracts.git", rev = "e33f73d1957e46b9ed17c319ed607bb3c7137944" }
+eas-contracts = { version = "1.4.0", git = "https://github.com/ethereum-attestation-service/eas-contracts.git", rev = "v1.4.0" }
 
 [profile.default]
   src = 'contracts'

--- a/kit/contracts/foundry.toml
+++ b/kit/contracts/foundry.toml
@@ -28,7 +28,7 @@ eas-contracts = { version = "1.4.0", git = "https://github.com/ethereum-attestat
   libs = ["dependencies"]
   test = 'test'
   cache_path  = 'cache_forge'
-  solc = "0.8.27"
+  solc = "0.8.28"
   optimizer = true
   optimizer_runs = 200
   gas_reports = ["*"]

--- a/kit/contracts/hardhat.config.ts
+++ b/kit/contracts/hardhat.config.ts
@@ -5,7 +5,7 @@ import type { HardhatUserConfig } from "hardhat/config";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.27",
+    version: "0.8.28",
     settings: {
       evmVersion: "paris",
       viaIR: true,

--- a/kit/contracts/hardhat.config.ts
+++ b/kit/contracts/hardhat.config.ts
@@ -5,15 +5,19 @@ import type { HardhatUserConfig } from "hardhat/config";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.28",
-    settings: {
-      evmVersion: "paris",
-      viaIR: true,
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.28",
+        settings: {
+          evmVersion: "paris",
+          viaIR: true,
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+    ],
   },
   networks: {
     hardhat: {},

--- a/kit/contracts/ignition/modules/eas.ts
+++ b/kit/contracts/ignition/modules/eas.ts
@@ -6,10 +6,10 @@ const EASModule = buildModule("EASModule", (m) => {
   const { forwarder } = m.useModule(ForwarderModule);
 
   // Deploy the EASSchemaRegistry first since EAS depends on it
-  const schemaRegistry = m.contract("EASSchemaRegistry", [forwarder]);
+  const schemaRegistry = m.contract("contracts/EASSchemaRegistry.sol:EASSchemaRegistry", [forwarder]);
 
   // Deploy the EAS contract with the schema registry address and forwarder
-  const eas = m.contract("EAS", [schemaRegistry, forwarder]);
+  const eas = m.contract("contracts/EAS.sol:EAS", [schemaRegistry, forwarder]);
 
   return { schemaRegistry, eas };
 });

--- a/kit/contracts/ignition/modules/eas.ts
+++ b/kit/contracts/ignition/modules/eas.ts
@@ -1,0 +1,17 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+import ForwarderModule from "./forwarder";
+
+const EASModule = buildModule("EASModule", (m) => {
+  // Get the forwarder from the ForwarderModule
+  const { forwarder } = m.useModule(ForwarderModule);
+
+  // Deploy the EASSchemaRegistry first since EAS depends on it
+  const schemaRegistry = m.contract("EASSchemaRegistry", [forwarder]);
+
+  // Deploy the EAS contract with the schema registry address and forwarder
+  const eas = m.contract("EAS", [schemaRegistry, forwarder]);
+
+  return { schemaRegistry, eas };
+});
+
+export default EASModule;

--- a/kit/contracts/ignition/modules/main.ts
+++ b/kit/contracts/ignition/modules/main.ts
@@ -5,6 +5,7 @@ import CryptoCurrenciesModule from "./crypto-currencies";
 import DepositsModule from "./deposits";
 import DvPSwapModule from "./dvpswap";
 import DvPSwapFactoryModule from "./dvpswap-factory";
+import EASModule from "./eas";
 import EquitiesModule from "./equities";
 import FixedYieldFactoryModule from "./fixed-yield-factory";
 import ForwarderModule from "./forwarder";
@@ -23,6 +24,7 @@ const AssetTokenizationModule = buildModule("AssetTokenizationModule", (m) => {
   const { dvpSwapFactory } = m.useModule(DvPSwapFactoryModule);
   const { dvpSwap } = m.useModule(DvPSwapModule);
   const { airdropFactory } = m.useModule(AirdropFactoryModule);
+  const { schemaRegistry, eas } = m.useModule(EASModule);
 
   return {
     ustb,
@@ -35,6 +37,8 @@ const AssetTokenizationModule = buildModule("AssetTokenizationModule", (m) => {
     dvpSwap,
     dvpSwapFactory,
     airdropFactory,
+    schemaRegistry,
+    eas,
   };
 });
 

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -9,7 +9,7 @@
     "url": "https://settlemint.com"
   },
   "scripts": {
-    "dependencies": "forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} +",
+    "dependencies": "forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} + && find ./dependencies/ -name '*.sol' -type f -exec bash -c 'if [[ \"$(uname)\" == \"Darwin\" ]]; then sed -i \"\" \"s/pragma solidity 0.8/pragma solidity ^0.8/g\" \"$1\"; else sed -i \"s/pragma solidity 0.8/pragma solidity ^0.8/g\" \"$1\"; fi' _ {} \\;",
     "lint": "solhint --config .solhint.json ./contracts/**/*.sol",
     "format": "settlemint scs foundry format && prettier --write .",
     "compile:forge": "settlemint scs foundry build --sizes",

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -9,7 +9,7 @@
     "url": "https://settlemint.com"
   },
   "scripts": {
-    "dependencies": "forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} + && find ./dependencies/eas-contracts-1.4.0/ -name '*.sol' -type f -exec bash -c 'if [[ \"$(uname)\" == \"Darwin\" ]]; then sed -i \"\" \"s/pragma solidity 0.8.28/pragma solidity ^0.8.28/g\" \"$1\"; else sed -i \"s/pragma solidity 0.8.28/pragma solidity ^0.8.28/g\" \"$1\"; fi' _ {} \\; && find ./contracts/ -name '*.sol' -type f -exec bash -c 'if [[ \"$(uname)\" == \"Darwin\" ]]; then sed -i \"\" \"s/pragma solidity 0.8.29/pragma solidity ^0.8.28/g\" \"$1\"; else sed -i \"s/pragma solidity 0.8.29/pragma solidity ^0.8.28/g\" \"$1\"; fi' _ {} \\;",
+    "dependencies": "forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} +",
     "lint": "solhint --config .solhint.json ./contracts/**/*.sol",
     "format": "settlemint scs foundry format && prettier --write .",
     "compile:forge": "settlemint scs foundry build --sizes",

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -9,7 +9,7 @@
     "url": "https://settlemint.com"
   },
   "scripts": {
-    "dependencies": "forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} + && find ./dependencies/ -name '*.sol' -type f -exec bash -c 'if [[ \"$(uname)\" == \"Darwin\" ]]; then sed -i \"\" \"s/pragma solidity 0.8/pragma solidity ^0.8/g\" \"$1\"; else sed -i \"s/pragma solidity 0.8/pragma solidity ^0.8/g\" \"$1\"; fi' _ {} \\;",
+    "dependencies": "forge soldeer install && find dependencies -name .git -type d -exec rm -rf {} + && find ./dependencies/eas-contracts-1.4.0/ -name '*.sol' -type f -exec bash -c 'if [[ \"$(uname)\" == \"Darwin\" ]]; then sed -i \"\" \"s/pragma solidity 0.8.28/pragma solidity ^0.8.28/g\" \"$1\"; else sed -i \"s/pragma solidity 0.8.28/pragma solidity ^0.8.28/g\" \"$1\"; fi' _ {} \\; && find ./contracts/ -name '*.sol' -type f -exec bash -c 'if [[ \"$(uname)\" == \"Darwin\" ]]; then sed -i \"\" \"s/pragma solidity 0.8.29/pragma solidity ^0.8.28/g\" \"$1\"; else sed -i \"s/pragma solidity 0.8.29/pragma solidity ^0.8.28/g\" \"$1\"; fi' _ {} \\;",
     "lint": "solhint --config .solhint.json ./contracts/**/*.sol",
     "format": "settlemint scs foundry format && prettier --write .",
     "compile:forge": "settlemint scs foundry build --sizes",

--- a/kit/contracts/remappings.txt
+++ b/kit/contracts/remappings.txt
@@ -1,3 +1,5 @@
+@ethereum-attestation-service/eas-contracts/=dependencies/eas-contracts/contracts/
 @openzeppelin/community-contracts/=dependencies/openzeppelin-community-contracts-0.0.1/contracts/
 @openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.2.0/
+eas-contracts/=dependencies/eas-contracts-1.4.0/
 forge-std/=dependencies/forge-std-1.9.5/src/

--- a/kit/contracts/remappings.txt
+++ b/kit/contracts/remappings.txt
@@ -1,5 +1,4 @@
-@ethereum-attestation-service/eas-contracts/=dependencies/eas-contracts/contracts/
+@ethereum-attestation-service/eas-contracts/=dependencies/eas-contracts-1.4.0/contracts/
 @openzeppelin/community-contracts/=dependencies/openzeppelin-community-contracts-0.0.1/contracts/
 @openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.2.0/
-eas-contracts/=dependencies/eas-contracts-1.4.0/
 forge-std/=dependencies/forge-std-1.9.5/src/

--- a/kit/contracts/soldeer.lock
+++ b/kit/contracts/soldeer.lock
@@ -17,3 +17,9 @@ name = "openzeppelin-community-contracts"
 version = "0.0.1"
 source = "https://github.com/OpenZeppelin/openzeppelin-community-contracts.git"
 checksum = "e33f73d1957e46b9ed17c319ed607bb3c7137944"
+
+[[dependencies]]
+name = "eas-contracts"
+version = "1.4.1"
+url = "https://github.com/ethereum-attestation-service/eas-contracts.git"
+tag = "v1.4.1"

--- a/kit/contracts/soldeer.lock
+++ b/kit/contracts/soldeer.lock
@@ -1,25 +1,25 @@
 [[dependencies]]
 name = "@openzeppelin-contracts"
 version = "5.2.0"
-source = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_2_0_11-01-2025_09:30:20_contracts.zip"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_2_0_11-01-2025_09:30:20_contracts.zip"
 checksum = "6dbd0440446b2ed16ca25e9f1af08fc0c5c1e73e71fee86ae8a00daa774e3817"
-integrity = "a54240487b1b3c8f6b9a8d2655015c9acd325d753e765db53151693536ce6eb4"
+integrity = "4cb7f3777f67fdf4b7d0e2f94d2f93f198b2e5dce718b7062ac7c2c83e1183bd"
+
+[[dependencies]]
+name = "eas-contracts"
+version = "1.4.0"
+git = "https://github.com/ethereum-attestation-service/eas-contracts.git"
+rev = "v1.4.0"
 
 [[dependencies]]
 name = "forge-std"
 version = "1.9.5"
-source = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_5_21-12-2024_15:04:05_forge-std-1.9.zip"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_5_21-12-2024_15:04:05_forge-std-1.9.zip"
 checksum = "57ada736f383289db77fac4472d48f820e7c98172cf9b01681b0c37065ce043f"
 integrity = "4753ffdfa0dde40878372b6a4d8e8fd1648b190b33996896c8b92f6f1680850f"
 
 [[dependencies]]
 name = "openzeppelin-community-contracts"
 version = "0.0.1"
-source = "https://github.com/OpenZeppelin/openzeppelin-community-contracts.git"
-checksum = "e33f73d1957e46b9ed17c319ed607bb3c7137944"
-
-[[dependencies]]
-name = "eas-contracts"
-version = "1.4.1"
-url = "https://github.com/ethereum-attestation-service/eas-contracts.git"
-tag = "v1.4.1"
+git = "https://github.com/OpenZeppelin/openzeppelin-community-contracts.git"
+rev = "e33f73d1957e46b9ed17c319ed607bb3c7137944"

--- a/kit/contracts/test/AirdropFactory.t.sol
+++ b/kit/contracts/test/AirdropFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test, console, Vm } from "forge-std/Test.sol";
 import { AirdropFactory } from "../contracts/AirdropFactory.sol";

--- a/kit/contracts/test/Bond.t.sol
+++ b/kit/contracts/test/Bond.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { Bond } from "../contracts/Bond.sol";

--- a/kit/contracts/test/BondFactory.t.sol
+++ b/kit/contracts/test/BondFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";

--- a/kit/contracts/test/CryptoCurrency.t.sol
+++ b/kit/contracts/test/CryptoCurrency.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { CryptoCurrency } from "../contracts/CryptoCurrency.sol";

--- a/kit/contracts/test/CryptoCurrencyFactory.t.sol
+++ b/kit/contracts/test/CryptoCurrencyFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/kit/contracts/test/Deposit.t.sol
+++ b/kit/contracts/test/Deposit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { Deposit } from "../contracts/Deposit.sol";

--- a/kit/contracts/test/DepositFactory.t.sol
+++ b/kit/contracts/test/DepositFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/kit/contracts/test/DvPSwap.t.sol
+++ b/kit/contracts/test/DvPSwap.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { DvPSwap } from "../contracts/DvPSwap.sol";

--- a/kit/contracts/test/DvPSwapFactory.t.sol
+++ b/kit/contracts/test/DvPSwapFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { DvPSwapFactory } from "../contracts/DvPSwapFactory.sol";

--- a/kit/contracts/test/Equity.t.sol
+++ b/kit/contracts/test/Equity.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { Equity } from "../contracts/Equity.sol";

--- a/kit/contracts/test/EquityFactory.t.sol
+++ b/kit/contracts/test/EquityFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/kit/contracts/test/FixedYield.t.sol
+++ b/kit/contracts/test/FixedYield.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { FixedYield } from "../contracts/FixedYield.sol";

--- a/kit/contracts/test/FixedYieldFactory.t.sol
+++ b/kit/contracts/test/FixedYieldFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test, Vm } from "forge-std/Test.sol";
 import { FixedYieldFactory } from "../contracts/FixedYieldFactory.sol";

--- a/kit/contracts/test/Fund.t.sol
+++ b/kit/contracts/test/Fund.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { Fund } from "../contracts/Fund.sol";

--- a/kit/contracts/test/FundFactory.t.sol
+++ b/kit/contracts/test/FundFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/kit/contracts/test/LinearVestingAirdrop.t.sol
+++ b/kit/contracts/test/LinearVestingAirdrop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test, console } from "forge-std/Test.sol";
 import { VestingAirdrop } from "../contracts/VestingAirdrop.sol";

--- a/kit/contracts/test/PushAirdrop.t.sol
+++ b/kit/contracts/test/PushAirdrop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test, console } from "forge-std/Test.sol";
 import { PushAirdrop } from "../contracts/PushAirdrop.sol";

--- a/kit/contracts/test/StableCoin.t.sol
+++ b/kit/contracts/test/StableCoin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { StableCoin } from "../contracts/StableCoin.sol";

--- a/kit/contracts/test/StableCoinFactory.t.sol
+++ b/kit/contracts/test/StableCoinFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { VmSafe } from "forge-std/Vm.sol";

--- a/kit/contracts/test/StandardAirdrop.t.sol
+++ b/kit/contracts/test/StandardAirdrop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test, console } from "forge-std/Test.sol";
 import { StandardAirdrop } from "../contracts/StandardAirdrop.sol";

--- a/kit/contracts/test/VestingAirdrop.t.sol
+++ b/kit/contracts/test/VestingAirdrop.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { Test, console } from "forge-std/Test.sol";
 import { VestingAirdrop } from "../contracts/VestingAirdrop.sol";

--- a/kit/contracts/test/mocks/ERC20Mock.sol
+++ b/kit/contracts/test/mocks/ERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/kit/contracts/test/mocks/ERC20YieldMock.sol
+++ b/kit/contracts/test/mocks/ERC20YieldMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Yield } from "../../contracts/extensions/ERC20Yield.sol";


### PR DESCRIPTION
## Summary by Sourcery

Add support for Ethereum Attestation Service (EAS) with deployment modules and meta-transaction compatibility

New Features:
- Integrate EAS and EASSchemaRegistry contracts
- Add EAS deployment module in Hardhat Ignition
- Implement meta-transaction support for EAS contracts

Enhancements:
- Upgrade Solidity compiler version from 0.8.27 to 0.8.28
- Update Hardhat and Foundry configurations to support new compiler version