### PR TITLE
fix: cf lint failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: namespacelabs/nscloud-checkout-action@v7
+        with:
+          fetch-depth: 0
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v5


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure checkout action to fetch full git history by setting fetch-depth to 0