### PR TITLE
fix: use StringifiedBigInt for event counts

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/(dashboard)/_components/charts/asset-activity.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/(dashboard)/_components/charts/asset-activity.tsx
@@ -29,10 +29,10 @@ export async function AssetActivity() {
 
   const isEmpty = data.every(
     (asset) =>
-      asset.mintEventCount === 0 &&
-      asset.burnEventCount === 0 &&
-      asset.transferEventCount === 0 &&
-      asset.clawbackEventCount === 0
+      asset.mintEventCount === BigInt(0) &&
+      asset.burnEventCount === BigInt(0) &&
+      asset.transferEventCount === BigInt(0) &&
+      asset.clawbackEventCount === BigInt(0)
   );
 
   if (isEmpty) {
@@ -43,12 +43,12 @@ export async function AssetActivity() {
   const chartData = data.map((asset) => ({
     id: asset.id,
     assetType: asset.assetType,
-    mintEventCount: asset.mintEventCount,
-    burnEventCount: asset.burnEventCount,
-    transferEventCount: asset.transferEventCount,
-    frozenEventCount: asset.frozenEventCount,
-    unfrozenEventCount: asset.unfrozenEventCount,
-    clawbackEventCount: asset.clawbackEventCount,
+    mintEventCount: Number(asset.mintEventCount),
+    burnEventCount: Number(asset.burnEventCount),
+    transferEventCount: Number(asset.transferEventCount),
+    frozenEventCount: Number(asset.frozenEventCount),
+    unfrozenEventCount: Number(asset.unfrozenEventCount),
+    clawbackEventCount: Number(asset.clawbackEventCount),
   }));
 
   return (

--- a/kit/dapp/src/lib/queries/asset-activity/asset-activity-schema.ts
+++ b/kit/dapp/src/lib/queries/asset-activity/asset-activity-schema.ts
@@ -14,22 +14,22 @@ export const AssetActivitySchema = t.Object(
     totalSupply: t.BigDecimal({
       description: "Total supply of the asset",
     }),
-    burnEventCount: t.Number({
+    burnEventCount: t.StringifiedBigInt({
       description: "Number of burn events",
     }),
-    mintEventCount: t.Number({
+    mintEventCount: t.StringifiedBigInt({
       description: "Number of mint events",
     }),
-    transferEventCount: t.Number({
+    transferEventCount: t.StringifiedBigInt({
       description: "Number of transfer events",
     }),
-    frozenEventCount: t.Number({
+    frozenEventCount: t.StringifiedBigInt({
       description: "Number of token freezing events",
     }),
-    unfrozenEventCount: t.Number({
+    unfrozenEventCount: t.StringifiedBigInt({
       description: "Number of token unfreezing events",
     }),
-    clawbackEventCount: t.Number({
+    clawbackEventCount: t.StringifiedBigInt({
       description: "Number of token clawback events",
     }),
   },


### PR DESCRIPTION
## Summary by Sourcery

Update event count types to use StringifiedBigInt and handle BigInt comparisons

Bug Fixes:
- Fixed type handling for event counts by converting between BigInt and Number

Enhancements:
- Updated schema to use StringifiedBigInt for more precise event count representation