### PR TITLE
fix: token registry to use AccessControl + fix events to include initiator

### DIFF
--- a/kit/contracts/contracts/SMARTDeploymentRegistry.sol
+++ b/kit/contracts/contracts/SMARTDeploymentRegistry.sol
@@ -68,6 +68,12 @@ contract SMARTDeploymentRegistry is AccessControl, ERC2771Context {
     bytes32[] private allRegistryTypeHashes;
 
     // --- Events ---
+    /// @notice Emitted when a SMART deployment is registered.
+    /// @param registrar The address of the registrar.
+    /// @param timestamp The timestamp of the registration.
+    /// @param complianceAddress The address of the SMARTCompliance contract.
+    /// @param identityRegistryStorageAddress The address of the SMARTIdentityRegistryStorage contract.
+    /// @param identityFactoryAddress The address of the SMARTIdentityFactory contract.
     event SMARTDeploymentRegistered(
         address indexed registrar,
         uint256 timestamp,
@@ -78,13 +84,28 @@ contract SMARTDeploymentRegistry is AccessControl, ERC2771Context {
         address trustedIssuersRegistryAddress
     );
 
-    event SMARTComplianceModuleRegistered(address indexed moduleAddress, address indexed registrar, uint256 timestamp);
+    /// @notice Emitted when a compliance module is registered.
+    /// @param registrar The address of the registrar.
+    /// @param moduleAddress The address of the compliance module.
+    /// @param timestamp The timestamp of the registration.
+    event SMARTComplianceModuleRegistered(address indexed registrar, address indexed moduleAddress, uint256 timestamp);
+
+    /// @notice Emitted when a deployment is reset.
+    /// @param resetBy The address of the resetter.
+    /// @param timestamp The timestamp of the reset.
     event SMARTDeploymentReset(address indexed resetBy, uint256 timestamp);
+
+    /// @notice Emitted when a token registry is registered.
+    /// @param registrar The address of the registrar.
+    /// @param typeName The type name of the token registry.
+    /// @param registryTypeHash The type hash of the token registry.
+    /// @param registryAddress The address of the token registry.
+    /// @param timestamp The timestamp of the registration.
     event SMARTTokenRegistryRegistered(
+        address indexed registrar,
         string typeName,
         bytes32 indexed registryTypeHash,
         address indexed registryAddress,
-        address indexed registrar,
         uint256 timestamp
     );
 
@@ -171,7 +192,7 @@ contract SMARTDeploymentRegistry is AccessControl, ERC2771Context {
         isComplianceModuleRegistered[address(_module)] = true;
         complianceModules.push(_module);
 
-        emit SMARTComplianceModuleRegistered(address(_module), _msgSender(), block.timestamp);
+        emit SMARTComplianceModuleRegistered(_msgSender(), address(_module), block.timestamp);
     }
 
     /**
@@ -207,7 +228,7 @@ contract SMARTDeploymentRegistry is AccessControl, ERC2771Context {
         allRegistryTypeHashes.push(registryTypeHash);
 
         emit SMARTTokenRegistryRegistered(
-            _typeName, registryTypeHash, address(_registryAddress), _msgSender(), block.timestamp
+            _msgSender(), _typeName, registryTypeHash, address(_registryAddress), block.timestamp
         );
     }
 

--- a/kit/contracts/contracts/SMARTTokenRegistry.sol
+++ b/kit/contracts/contracts/SMARTTokenRegistry.sol
@@ -1,17 +1,20 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 pragma solidity ^0.8.28;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
-/// @title SMARTRegistry - Base contract for managing token registries
-/// @notice This contract provides a base implementation for managing token registries.
-/// It includes functionality for registering tokens and checking their registration status.
-/// @dev Inherits from Ownable and ERC2771Context for ownership management and meta-transaction support.
+/// @title SMARTTokenRegistry - Contract for managing token registries with role-based access control
+/// @notice This contract provides functionality for registering tokens and checking their registration status,
+/// managed by roles defined in AccessControl.
+/// @dev Inherits from AccessControl and ERC2771Context for role management and meta-transaction support.
 /// @custom:security-contact support@settlemint.com
 
-contract SMARTTokenRegistry is ERC2771Context, Ownable {
+contract SMARTTokenRegistry is ERC2771Context, AccessControl {
+    /// @notice Role identifier for accounts permitted to register and unregister tokens.
+    bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
+
     /// @notice Custom errors for the registry contract
     error InvalidTokenAddress(); // Error for when the provided token address is the zero address
     error TokenAlreadyRegistered(address token); // Error for attempting to register an already registered token
@@ -21,41 +24,60 @@ contract SMARTTokenRegistry is ERC2771Context, Ownable {
     mapping(address => bool) public isTokenRegistered;
 
     /// @notice Emitted when a token is registered.
+    /// @param initiator The address of the initiator of the registration.
     /// @param token The address of the registered token.
-    event TokenRegistered(address indexed token);
+    event TokenRegistered(address indexed initiator, address indexed token);
 
     /// @notice Emitted when a token is unregistered.
+    /// @param initiator The address of the initiator of the unregistration.
     /// @param token The address of the unregistered token.
-    event TokenUnregistered(address indexed token);
+    event TokenUnregistered(address indexed initiator, address indexed token);
 
     /// @notice Deploys the registry contract.
-    /// @dev Sets the initial owner who can register and unregister tokens.
+    /// @dev Sets up the initial admin and registrar roles using AccessControl's _grantRole.
     /// @param forwarder The address of the trusted forwarder for meta-transactions.
-    /// @param initialOwner The address of the initial owner.
-    constructor(address forwarder, address initialOwner) Ownable(initialOwner) ERC2771Context(forwarder) { }
+    /// @param initialAdmin The address of the initial admin and registrar.
+    constructor(address forwarder, address initialAdmin) ERC2771Context(forwarder) {
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+        _grantRole(REGISTRAR_ROLE, initialAdmin);
+    }
 
     /// @notice Registers a token.
-    /// @dev Can only be called by the owner.
+    /// @dev Can only be called by an account with REGISTRAR_ROLE, enforced by onlyRole modifier.
     /// Reverts if the token address is invalid or if the token is already registered.
     /// @param token The address of the token to register.
-    function registerToken(address token) external onlyOwner {
+    function registerToken(address token) external onlyRole(REGISTRAR_ROLE) {
         if (token == address(0)) revert InvalidTokenAddress();
         if (isTokenRegistered[token]) revert TokenAlreadyRegistered(token);
 
         isTokenRegistered[token] = true;
-        emit TokenRegistered(token);
+        emit TokenRegistered(_msgSender(), token);
     }
 
     /// @notice Unregisters a token.
-    /// @dev Can only be called by the owner.
+    /// @dev Can only be called by an account with REGISTRAR_ROLE, enforced by onlyRole modifier.
     /// Reverts if the token address is invalid or if the token is not registered.
     /// @param token The address of the token to unregister.
-    function unregisterToken(address token) external onlyOwner {
+    function unregisterToken(address token) external onlyRole(REGISTRAR_ROLE) {
         if (token == address(0)) revert InvalidTokenAddress();
         if (!isTokenRegistered[token]) revert TokenNotRegistered(token);
 
         isTokenRegistered[token] = false;
-        emit TokenUnregistered(token);
+        emit TokenUnregistered(_msgSender(), token);
+    }
+
+    /// @notice Grants the REGISTRAR_ROLE to an account.
+    /// @dev Can only be called by an account with DEFAULT_ADMIN_ROLE, enforced by onlyRole modifier.
+    /// @param account The address to grant the role to.
+    function grantRegistrarRole(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _grantRole(REGISTRAR_ROLE, account);
+    }
+
+    /// @notice Revokes the REGISTRAR_ROLE from an account.
+    /// @dev Can only be called by an account with DEFAULT_ADMIN_ROLE, enforced by onlyRole modifier.
+    /// @param account The address to revoke the role from.
+    function revokeRegistrarRole(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _revokeRole(REGISTRAR_ROLE, account);
     }
 
     // --- ERC2771Context Overrides ---

--- a/kit/contracts/test/SMARTDeploymentRegistry.t.sol
+++ b/kit/contracts/test/SMARTDeploymentRegistry.t.sol
@@ -195,7 +195,7 @@ contract SMARTDeploymentRegistryTest is SMARTUtils {
         _registerDeploymentAsUser(user1);
 
         vm.expectEmit(true, true, true, true);
-        emit SMARTDeploymentRegistry.SMARTComplianceModuleRegistered(address(mockModule1), user1, block.timestamp);
+        emit SMARTDeploymentRegistry.SMARTComplianceModuleRegistered(user1, address(mockModule1), block.timestamp);
         vm.prank(user1);
         registry.registerComplianceModule(mockModule1);
     }
@@ -251,7 +251,7 @@ contract SMARTDeploymentRegistryTest is SMARTUtils {
 
         vm.expectEmit(true, true, true, true);
         emit SMARTDeploymentRegistry.SMARTTokenRegistryRegistered(
-            typeName, typeHash, address(mockTokenRegistry1), user1, block.timestamp
+            user1, typeName, typeHash, address(mockTokenRegistry1), block.timestamp
         );
         vm.prank(user1);
         registry.registerTokenRegistry(typeName, mockTokenRegistry1);

--- a/kit/contracts/test/SMARTTokenRegistry.t.sol
+++ b/kit/contracts/test/SMARTTokenRegistry.t.sol
@@ -3,61 +3,67 @@ pragma solidity ^0.8.28;
 
 import { Test, console2 } from "forge-std/Test.sol";
 import { SMARTTokenRegistry } from "../contracts/SMARTTokenRegistry.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol"; // Corrected import path
+// No need to import AccessControl just for the error if we declare it locally for testing
 
 contract SMARTTokenRegistryTest is Test {
     SMARTTokenRegistry registry;
-    address owner;
+    address admin; // Changed from owner to admin for clarity
     address user1;
+    address user2; // Added for role management tests
     address mockToken;
     address mockForwarder;
 
-    event TokenRegistered(address indexed token);
-    event TokenUnregistered(address indexed token);
+    // Declare external error for testing
+    error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
 
     function setUp() public {
-        owner = makeAddr("owner");
+        admin = makeAddr("admin");
         user1 = makeAddr("user1");
+        user2 = makeAddr("user2");
         mockToken = makeAddr("mockToken");
         mockForwarder = makeAddr("mockForwarder");
 
-        vm.prank(owner);
-        registry = new SMARTTokenRegistry(mockForwarder, owner);
+        vm.prank(admin); // Deployer is admin
+        registry = new SMARTTokenRegistry(mockForwarder, admin);
     }
 
     // --- Test Constructor ---
 
-    function test_Constructor_SetsOwnerCorrectly() public view {
-        assertEq(registry.owner(), owner, "Owner should be set correctly");
+    function test_Constructor_SetsInitialRolesCorrectly() public view {
+        assertTrue(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), admin), "Admin should have DEFAULT_ADMIN_ROLE");
+        assertTrue(registry.hasRole(registry.REGISTRAR_ROLE(), admin), "Admin should have REGISTRAR_ROLE");
     }
 
     // --- Test registerToken ---
 
     function test_RegisterToken_Success() public {
-        vm.prank(owner);
+        vm.prank(admin); // Admin has REGISTRAR_ROLE by default
         vm.expectEmit(true, true, true, true, address(registry));
-        emit TokenRegistered(mockToken);
+        emit SMARTTokenRegistry.TokenRegistered(admin, mockToken); // Emit with initiator
         registry.registerToken(mockToken);
         assertTrue(registry.isTokenRegistered(mockToken), "Token should be registered");
     }
 
-    function test_RegisterToken_Fail_NotOwner() public {
-        vm.prank(user1);
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user1));
+    function test_RegisterToken_Fail_NotRegistrar() public {
+        vm.startPrank(user1); // user1 does not have REGISTRAR_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user1, registry.REGISTRAR_ROLE())
+        );
         registry.registerToken(mockToken);
+        vm.stopPrank();
     }
 
     function test_RegisterToken_Fail_InvalidTokenAddress() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectRevert(SMARTTokenRegistry.InvalidTokenAddress.selector);
         registry.registerToken(address(0));
     }
 
     function test_RegisterToken_Fail_TokenAlreadyRegistered() public {
-        vm.prank(owner);
+        vm.prank(admin);
         registry.registerToken(mockToken); // First registration
 
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(SMARTTokenRegistry.TokenAlreadyRegistered.selector, mockToken));
         registry.registerToken(mockToken); // Attempt to register again
     }
@@ -65,52 +71,129 @@ contract SMARTTokenRegistryTest is Test {
     // --- Test unregisterToken ---
 
     function test_UnregisterToken_Success() public {
-        // First, register the token
-        vm.prank(owner);
+        vm.prank(admin);
         registry.registerToken(mockToken);
         assertTrue(registry.isTokenRegistered(mockToken), "Token should be registered initially");
 
-        // Now, unregister
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectEmit(true, true, true, true, address(registry));
-        emit TokenUnregistered(mockToken);
+        emit SMARTTokenRegistry.TokenUnregistered(admin, mockToken); // Emit with initiator
         registry.unregisterToken(mockToken);
         assertFalse(registry.isTokenRegistered(mockToken), "Token should be unregistered");
     }
 
-    function test_UnregisterToken_Fail_NotOwner() public {
-        vm.prank(owner);
-        registry.registerToken(mockToken); // Register token first
+    function test_UnregisterToken_Fail_NotRegistrar() public {
+        vm.prank(admin);
+        registry.registerToken(mockToken);
 
-        vm.prank(user1);
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user1));
+        vm.startPrank(user1); // user1 does not have REGISTRAR_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user1, registry.REGISTRAR_ROLE())
+        );
         registry.unregisterToken(mockToken);
+        vm.stopPrank();
     }
 
     function test_UnregisterToken_Fail_InvalidTokenAddress() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectRevert(SMARTTokenRegistry.InvalidTokenAddress.selector);
         registry.unregisterToken(address(0));
     }
 
     function test_UnregisterToken_Fail_TokenNotRegistered() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(SMARTTokenRegistry.TokenNotRegistered.selector, mockToken));
-        registry.unregisterToken(mockToken); // Attempt to unregister a token that was never registered
+        registry.unregisterToken(mockToken);
+    }
+
+    // --- Test Role Management (grantRegistrarRole) ---
+
+    function test_GrantRegistrarRole_Success_ByAdmin() public {
+        vm.prank(admin); // Admin has DEFAULT_ADMIN_ROLE
+        registry.grantRegistrarRole(user1);
+        assertTrue(registry.hasRole(registry.REGISTRAR_ROLE(), user1), "user1 should have REGISTRAR_ROLE after grant");
+    }
+
+    function test_GrantRegistrarRole_Fail_ByNonAdmin() public {
+        vm.startPrank(user1); // user1 does not have DEFAULT_ADMIN_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user1, registry.DEFAULT_ADMIN_ROLE())
+        );
+        registry.grantRegistrarRole(user2);
+        vm.stopPrank();
+    }
+
+    function test_GrantRegistrarRole_Fail_ByRegistrarNotAdmin() public {
+        // Grant user1 REGISTRAR_ROLE but not ADMIN_ROLE
+        vm.prank(admin);
+        registry.grantRegistrarRole(user1);
+        // Revoke admin role from user1 if it had it (though it doesn't by default setup for user1)
+        // This step is more for robust testing in complex scenarios; here admin is distinct.
+
+        vm.startPrank(user1); // user1 has REGISTRAR_ROLE, but not DEFAULT_ADMIN_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user1, registry.DEFAULT_ADMIN_ROLE())
+        );
+        registry.grantRegistrarRole(user2);
+        vm.stopPrank();
+    }
+
+    // --- Test Role Management (revokeRegistrarRole) ---
+
+    function test_RevokeRegistrarRole_Success_ByAdmin() public {
+        // Grant role first
+        vm.prank(admin);
+        registry.grantRegistrarRole(user1);
+        assertTrue(registry.hasRole(registry.REGISTRAR_ROLE(), user1), "user1 should have REGISTRAR_ROLE initially");
+
+        // Revoke role
+        vm.prank(admin);
+        registry.revokeRegistrarRole(user1);
+        assertFalse(
+            registry.hasRole(registry.REGISTRAR_ROLE(), user1), "user1 should not have REGISTRAR_ROLE after revoke"
+        );
+    }
+
+    function test_RevokeRegistrarRole_Fail_ByNonAdmin() public {
+        // Grant role first by admin
+        vm.prank(admin);
+        registry.grantRegistrarRole(user1);
+
+        vm.startPrank(user2); // user2 does not have DEFAULT_ADMIN_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user2, registry.DEFAULT_ADMIN_ROLE())
+        );
+        registry.revokeRegistrarRole(user1);
+        vm.stopPrank();
+    }
+
+    function test_RevokeRegistrarRole_Fail_ByRegistrarNotAdmin() public {
+        // Grant user1 REGISTRAR_ROLE
+        vm.prank(admin);
+        registry.grantRegistrarRole(user1);
+
+        // user1 (Registrar, not Admin) tries to revoke from user2 (who doesn't have it, but action should fail on auth)
+        vm.startPrank(user1);
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user1, registry.DEFAULT_ADMIN_ROLE())
+        );
+        registry.revokeRegistrarRole(user2); // Attempting to revoke from another user
+        vm.stopPrank();
     }
 
     // --- Test ERC2771Context Overrides ---
-    // Note: Testing _msgSender and _msgData thoroughly requires a more complex setup
-    // with a real or mock ERC2771 forwarder.
-    // For now, we rely on OpenZeppelin's tested implementation.
-    // A basic check can ensure the functions don't revert.
+    // Basic check to ensure internal _msgSender usage doesn't break.
+    // Thorough testing of ERC2771 requires a mock forwarder.
 
-    function test_MsgSender_ReturnsNonZero() public {
-        // This test is basic and doesn't validate ERC2771 functionality deeply
-        // It just checks that calling it (which happens internally) doesn't break.
-        // When called directly by an EOA (not via forwarder), _msgSender should return msg.sender.
-        vm.prank(owner);
-        registry.registerToken(mockToken); // A function that uses _msgSender()
-        assertTrue(registry.isTokenRegistered(mockToken), "Token registration using internal _msgSender should succeed");
+    function test_Internal_MsgSender_WorksForRegistrar() public {
+        // Grant user1 REGISTRAR_ROLE
+        vm.prank(admin);
+        registry.grantRegistrarRole(user1);
+
+        vm.prank(user1); // user1 is now a registrar
+        vm.expectEmit(true, true, true, true, address(registry));
+        emit SMARTTokenRegistry.TokenRegistered(user1, mockToken);
+        registry.registerToken(mockToken);
+        assertTrue(registry.isTokenRegistered(mockToken), "Token registration by new registrar should succeed");
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor SMARTTokenRegistry to use AccessControl for role-based access and enhance event logging to include initiators

New Features:
- Introduced role-based access control for token registration
- Added methods to grant and revoke registrar roles

Bug Fixes:
- Fixed token registration and unregistration to use role-based access instead of owner-only

Enhancements:
- Updated events to include initiator addresses
- Replaced Ownable with more flexible AccessControl
- Improved role management for token registry