### PR TITLE
fix: subgraph error

### DIFF
--- a/kit/subgraph/src/assets/bond.ts
+++ b/kit/subgraph/src/assets/bond.ts
@@ -256,7 +256,7 @@ export function handleBondRedeemed(event: BondRedeemed): void {
   );
   setValueWithDecimals(
     bond,
-    "underlyingBalanceExact",
+    "underlyingBalance",
     underlyingAmount,
     bond.underlyingAssetDecimals
   );


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Corrected the field name from 'underlyingBalanceExact' to 'underlyingBalance' when setting bond underlying asset balance