### PR TITLE
feat: use access control enumerable

### DIFF
--- a/kit/contracts/contracts/SMARTBond.sol
+++ b/kit/contracts/contracts/SMARTBond.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 // OpenZeppelin imports
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20, IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
@@ -40,7 +40,7 @@ import { ERC20Yield } from "./extensions/ERC20Yield.sol";
 ///      burning, custodian actions, and collateral tracking. Access control uses custom roles.
 contract SMARTBond is
     SMART,
-    AccessControl,
+    AccessControlEnumerable,
     SMARTCustodian,
     SMARTPausable,
     SMARTBurnable,
@@ -589,7 +589,13 @@ contract SMARTBond is
     }
 
     /// @dev Overrides ERC165 to ensure that the SMART implementation is used.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(SMART, AccessControl) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SMART, AccessControlEnumerable)
+        returns (bool)
+    {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/kit/contracts/contracts/SMARTDeploymentRegistry.sol
+++ b/kit/contracts/contracts/SMARTDeploymentRegistry.sol
@@ -13,7 +13,7 @@ import { ISMARTComplianceModule } from "smart-protocol/contracts/interface/ISMAR
 import { SMARTTokenRegistry } from "./SMARTTokenRegistry.sol";
 
 // OpenZeppelin Contracts
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
@@ -39,10 +39,10 @@ error TokenRegistryAddressAlreadyUsed(address registryAddress);
  *         The deployer of this contract receives DEFAULT_ADMIN_ROLE for overall contract administration.
  *         The first address to successfully call `registerDeployment` receives DEPLOYMENT_OWNER_ROLE.
  *         DEPLOYMENT_OWNER_ROLE is self-administering, meaning holders of this role can grant/revoke it to others.
- * @dev Utilizes AccessControl for permissioning and ERC2771Context for meta-transaction support.
+ * @dev Utilizes AccessControlEnumerable for permissioning and ERC2771Context for meta-transaction support.
  *      Core dependency addresses are stored upon registration.
  */
-contract SMARTDeploymentRegistry is AccessControl, ERC2771Context {
+contract SMARTDeploymentRegistry is AccessControlEnumerable, ERC2771Context {
     // --- Roles ---
     bytes32 public constant DEPLOYMENT_OWNER_ROLE = keccak256("DEPLOYMENT_OWNER_ROLE");
 

--- a/kit/contracts/contracts/SMARTDeposit.sol
+++ b/kit/contracts/contracts/SMARTDeposit.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 // OpenZeppelin imports
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20, IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
@@ -34,7 +34,7 @@ import { SMARTCollateral } from "smart-protocol/contracts/extensions/collateral/
 ///      burning, custodian actions, and collateral tracking. Access control uses custom roles.
 contract SMARTDeposit is
     SMART,
-    AccessControl,
+    AccessControlEnumerable,
     SMARTCollateral,
     SMARTCustodian,
     SMARTPausable,
@@ -262,7 +262,13 @@ contract SMARTDeposit is
     }
 
     /// @dev Overrides ERC165 to ensure that the SMART implementation is used.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(SMART, AccessControl) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SMART, AccessControlEnumerable)
+        returns (bool)
+    {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/kit/contracts/contracts/SMARTEquity.sol
+++ b/kit/contracts/contracts/SMARTEquity.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20, IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
@@ -29,7 +29,7 @@ import { ERC20Votes } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20
 
 contract SMARTEquity is
     SMART,
-    AccessControl,
+    AccessControlEnumerable,
     SMARTCustodian,
     SMARTPausable,
     SMARTBurnable,
@@ -239,7 +239,13 @@ contract SMARTEquity is
     }
 
     /// @dev Overrides ERC165 to ensure that the SMART implementation is used.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(SMART, AccessControl) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SMART, AccessControlEnumerable)
+        returns (bool)
+    {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/kit/contracts/contracts/SMARTFund.sol
+++ b/kit/contracts/contracts/SMARTFund.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 // OpenZeppelin imports
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { ERC20Votes } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import { Nonces } from "@openzeppelin/contracts/utils/Nonces.sol";
@@ -43,7 +43,7 @@ contract SMARTFund is
     SMARTBurnable,
     SMARTPausable,
     SMARTCustodian,
-    AccessControl,
+    AccessControlEnumerable,
     ERC20Permit,
     ERC20Votes, // TODO: ??
     ERC2771Context
@@ -370,7 +370,13 @@ contract SMARTFund is
     }
 
     /// @dev Overrides ERC165 to ensure that the SMART implementation is used.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(SMART, AccessControl) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SMART, AccessControlEnumerable)
+        returns (bool)
+    {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/kit/contracts/contracts/SMARTStableCoin.sol
+++ b/kit/contracts/contracts/SMARTStableCoin.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 // OpenZeppelin imports
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20, IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
@@ -34,7 +34,7 @@ import { SMARTCollateral } from "smart-protocol/contracts/extensions/collateral/
 ///      burning, custodian actions, and collateral tracking. Access control uses custom roles.
 contract SMARTStableCoin is
     SMART,
-    AccessControl,
+    AccessControlEnumerable,
     SMARTCollateral,
     SMARTCustodian,
     SMARTPausable,
@@ -262,7 +262,13 @@ contract SMARTStableCoin is
     }
 
     /// @dev Overrides ERC165 to ensure that the SMART implementation is used.
-    function supportsInterface(bytes4 interfaceId) public view virtual override(SMART, AccessControl) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(SMART, AccessControlEnumerable)
+        returns (bool)
+    {
         return super.supportsInterface(interfaceId);
     }
 }

--- a/kit/contracts/contracts/SMARTTokenRegistry.sol
+++ b/kit/contracts/contracts/SMARTTokenRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 pragma solidity 0.8.28;
 
-import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
+import { AccessControlEnumerable } from "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
@@ -11,7 +11,7 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 /// @dev Inherits from AccessControl and ERC2771Context for role management and meta-transaction support.
 /// @custom:security-contact support@settlemint.com
 
-contract SMARTTokenRegistry is ERC2771Context, AccessControl {
+contract SMARTTokenRegistry is ERC2771Context, AccessControlEnumerable {
     /// @notice Role identifier for accounts permitted to register and unregister tokens.
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace AccessControl with AccessControlEnumerable in all relevant contracts to enable role enumeration.