### PR TITLE
fix: asset creation  (#1951)

### DIFF
--- a/kit/dapp/src/components/blocks/create-forms/bond/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/form.tsx
@@ -6,6 +6,8 @@ import {
   type CreateBondInput,
 } from "@/lib/mutations/bond/create/create-schema";
 import type { SafeActionResult } from "@/lib/mutations/safe-action";
+import { isAddressAvailable } from "@/lib/queries/bond-factory/bond-factory-address-available";
+import { getPredictedAddress } from "@/lib/queries/bond-factory/bond-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
 import { getTomorrowMidnight } from "@/lib/utils/date";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
@@ -91,6 +93,8 @@ export function CreateBondForm({
             form={bondForm}
             onBack={onPrevStep}
             onSubmit={verificationWrapper(createBond)}
+            predictAddress={getPredictedAddress}
+            isAddressAvailable={isAddressAvailable}
           />
         );
       default:

--- a/kit/dapp/src/components/blocks/create-forms/common/summary/summary.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/common/summary/summary.tsx
@@ -22,10 +22,9 @@ interface SummaryProps {
   form: UseFormReturn<any>;
   configurationCard: React.ReactNode;
   onSubmit: (data: any) => Promise<SafeActionResult<string[]> | any>;
+  predictAddress: (values: any) => Promise<Address>;
+  isAddressAvailable: (address: Address) => Promise<boolean>;
   onBack?: () => void;
-  // Optional functions for address prediction - some asset types may not need these
-  predictAddress?: (values: any) => Promise<Address>;
-  isAddressAvailable?: (address: Address) => Promise<boolean>;
 }
 
 export function Summary({
@@ -46,9 +45,7 @@ export function Summary({
 
   // Fetch and validate predicted address on initial load
   useEffect(() => {
-    if (predictAddress && isAddressAvailable) {
-      validatePredictedAddress();
-    }
+    validatePredictedAddress();
   }, []);
 
   // Validate predicted address before form submission if the functions are provided

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/form.tsx
@@ -6,6 +6,8 @@ import {
   type CreateCryptoCurrencyInput,
 } from "@/lib/mutations/cryptocurrency/create/create-schema";
 import type { SafeActionResult } from "@/lib/mutations/safe-action";
+import { isAddressAvailable } from "@/lib/queries/cryptocurrency-factory/cryptocurrency-factory-address-available";
+import { getPredictedAddress } from "@/lib/queries/cryptocurrency-factory/cryptocurrency-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { FormProvider, useForm } from "react-hook-form";
@@ -93,6 +95,8 @@ export function CreateCryptoCurrencyForm({
             form={cryptoForm}
             onBack={onPrevStep}
             onSubmit={verificationWrapper(createCryptoCurrency)}
+            predictAddress={getPredictedAddress}
+            isAddressAvailable={isAddressAvailable}
           />
         );
       default:

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -6,6 +6,8 @@ import {
   type CreateDepositInput,
 } from "@/lib/mutations/deposit/create/create-schema";
 import type { SafeActionResult } from "@/lib/mutations/safe-action";
+import { isAddressAvailable } from "@/lib/queries/deposit-factory/deposit-factory-address-available";
+import { getPredictedAddress } from "@/lib/queries/deposit-factory/deposit-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { FormProvider, useForm } from "react-hook-form";
@@ -88,6 +90,8 @@ export function CreateDepositForm({
             form={depositForm}
             onBack={onPrevStep}
             onSubmit={verificationWrapper(createDeposit)}
+            predictAddress={getPredictedAddress}
+            isAddressAvailable={isAddressAvailable}
           />
         );
       default:

--- a/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
@@ -6,6 +6,8 @@ import {
   type CreateEquityInput,
 } from "@/lib/mutations/equity/create/create-schema";
 import type { SafeActionResult } from "@/lib/mutations/safe-action";
+import { isAddressAvailable } from "@/lib/queries/equity-factory/equity-factory-address-available";
+import { getPredictedAddress } from "@/lib/queries/equity-factory/equity-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { FormProvider, useForm } from "react-hook-form";
@@ -87,6 +89,8 @@ export function CreateEquityForm({
             form={equityForm}
             onBack={onPrevStep}
             onSubmit={verificationWrapper(createEquity)}
+            predictAddress={getPredictedAddress}
+            isAddressAvailable={isAddressAvailable}
           />
         );
       default:

--- a/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
@@ -6,6 +6,8 @@ import {
   type CreateFundInput,
 } from "@/lib/mutations/fund/create/create-schema";
 import type { SafeActionResult } from "@/lib/mutations/safe-action";
+import { isAddressAvailable } from "@/lib/queries/fund-factory/fund-factory-address-available";
+import { getPredictedAddress } from "@/lib/queries/fund-factory/fund-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { FormProvider, useForm } from "react-hook-form";
@@ -89,6 +91,8 @@ export function CreateFundForm({
             form={fundForm}
             onBack={onPrevStep}
             onSubmit={verificationWrapper(createFund)}
+            predictAddress={getPredictedAddress}
+            isAddressAvailable={isAddressAvailable}
           />
         );
       default:

--- a/kit/dapp/src/lib/mutations/bond/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-function.ts
@@ -7,8 +7,7 @@ import { portalClient, portalGraphql } from "@/lib/settlemint/portal";
 import { withAccessControl } from "@/lib/utils/access-control";
 import { formatDate } from "@/lib/utils/date";
 import { grantRolesToAdmins } from "@/lib/utils/role-granting";
-import { safeParse } from "@/lib/utils/typebox";
-import { t } from "elysia";
+import { safeParse, t } from "@/lib/utils/typebox";
 import { parseUnits } from "viem";
 import type { CreateBondInput } from "./create-schema";
 

--- a/kit/dapp/src/lib/mutations/user/two-factor/enable-two-factor-schema.ts
+++ b/kit/dapp/src/lib/mutations/user/two-factor/enable-two-factor-schema.ts
@@ -1,5 +1,4 @@
-import type { StaticDecode } from "@/lib/utils/typebox";
-import { t } from "elysia";
+import { t, type StaticDecode } from "@/lib/utils/typebox";
 
 export function EnableTwoFactorSchema() {
   return t.Object(


### PR DESCRIPTION
There was a unique constraint violation err because the predicted address was always being set to the zero address, then the offchain asset creation method was failing

## Summary by Sourcery

Bug Fixes:
- Correct typebox import to resolve import error in enable-two-factor-schema.ts.