### PR TITLE
chore: bump SMART to v8.0.10

### DIFF
--- a/kit/contracts/foundry.toml
+++ b/kit/contracts/foundry.toml
@@ -23,7 +23,7 @@ forge-std = "1.9.6"
 "@onchainid" = { version = "v2.2.1", git = "https://github.com/onchain-id/solidity.git", rev = "2.2.1" }
 openzeppelin-community-contracts = { version = "0.0.1", git = "https://github.com/OpenZeppelin/openzeppelin-community-contracts.git", rev = "e33f73d1957e46b9ed17c319ed607bb3c7137944" }
 eas-contracts = { version = "1.4.0", git = "https://github.com/ethereum-attestation-service/eas-contracts.git", rev = "v1.4.0" }
-smart-protocol = "8.0.8"
+smart-protocol = "8.0.10"
 
 [profile.default]
   src = 'contracts'

--- a/kit/contracts/remappings.txt
+++ b/kit/contracts/remappings.txt
@@ -4,4 +4,4 @@
 @openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
 @openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.2.0/
 forge-std/=dependencies/forge-std-1.9.6/src/
-smart-protocol/=dependencies/smart-protocol-8.0.8/
+smart-protocol/=dependencies/smart-protocol-8.0.10/

--- a/kit/contracts/soldeer.lock
+++ b/kit/contracts/soldeer.lock
@@ -39,7 +39,7 @@ rev = "e33f73d1957e46b9ed17c319ed607bb3c7137944"
 
 [[dependencies]]
 name = "smart-protocol"
-version = "8.0.8"
-url = "https://soldeer-revisions.s3.amazonaws.com/smart-protocol/8_0_8_09-05-2025_20:19:30_solidity-smart-protocol.zip"
-checksum = "276b404b0d125f248b1fcfc64e30eab5d29276432a704fa27dba6a687641804f"
-integrity = "845408a1281f9f01e9215a0b5669733a773f1950c6886427f0bf746a11c95d36"
+version = "8.0.10"
+url = "https://soldeer-revisions.s3.amazonaws.com/smart-protocol/8_0_10_12-05-2025_09:32:49_solidity-smart-protocol.zip"
+checksum = "d7363c4362452f3debc3b80cf920d6f7a740ba002af8147aa07e84ca0875152d"
+integrity = "153f0b196700b402d3f6f00e5cfd7b1ab75d8246173f383fd876fd09349112ff"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump smart-protocol from v8.0.8 to v8.0.10 in foundry configuration and refresh lock files