### PR TITLE
fix: rename initiator to sender

### DIFF
--- a/kit/contracts/contracts/SMARTBond.sol
+++ b/kit/contracts/contracts/SMARTBond.sol
@@ -89,22 +89,22 @@ contract SMARTBond is
     event BondMatured(uint256 timestamp);
 
     /// @notice Emitted when a bond is redeemed for underlying assets
-    /// @param initiator The address that initiated the redemption
+    /// @param sender The address that initiated the redemption
     /// @param holder The address redeeming the bonds
     /// @param bondAmount The amount of bonds redeemed
     /// @param underlyingAmount The amount of underlying assets received
-    event BondRedeemed(address indexed initiator, address indexed holder, uint256 bondAmount, uint256 underlyingAmount);
+    event BondRedeemed(address indexed sender, address indexed holder, uint256 bondAmount, uint256 underlyingAmount);
 
     /// @notice Emitted when underlying assets are topped up
-    /// @param initiator The address that initiated the top up
+    /// @param sender The address that initiated the top up
     /// @param amount The amount of underlying assets added
-    event UnderlyingAssetTopUp(address indexed initiator, uint256 amount);
+    event UnderlyingAssetTopUp(address indexed sender, uint256 amount);
 
     /// @notice Emitted when underlying assets are withdrawn
-    /// @param initiator The address that initiated the withdrawal
+    /// @param sender The address that initiated the withdrawal
     /// @param to The address receiving the underlying assets
     /// @param amount The amount of underlying assets withdrawn
-    event UnderlyingAssetWithdrawn(address indexed initiator, address indexed to, uint256 amount);
+    event UnderlyingAssetWithdrawn(address indexed sender, address indexed to, uint256 amount);
 
     /// @notice Modifier to prevent operations after bond maturity
     /// @dev Reverts with BondAlreadyMatured if the bond has matured

--- a/kit/contracts/contracts/SMARTFund.sol
+++ b/kit/contracts/contracts/SMARTFund.sol
@@ -73,10 +73,10 @@ contract SMARTFund is
     string private _fundCategory;
 
     /// @notice Emitted when management fees are collected
-    /// @param initiator The address that collected the management fees
+    /// @param sender The address that collected the management fees
     /// @param amount The amount of tokens minted as management fees
     /// @param timestamp The timestamp when the fees were collected
-    event ManagementFeeCollected(address indexed initiator, uint256 amount, uint256 timestamp);
+    event ManagementFeeCollected(address indexed sender, uint256 amount, uint256 timestamp);
 
     /// @notice Deploys a new SMARTFund token contract
     /// @dev Sets up the token with specified parameters and initializes governance capabilities.
@@ -196,9 +196,9 @@ contract SMARTFund is
         uint256 fee = Math.mulDiv(Math.mulDiv(aum, _managementFeeBps, 10_000), timeElapsed, 365 days);
 
         if (fee > 0) {
-            address initiator = _msgSender();
-            _mint(initiator, fee);
-            emit ManagementFeeCollected(initiator, fee, block.timestamp);
+            address sender = _msgSender();
+            _mint(sender, fee);
+            emit ManagementFeeCollected(sender, fee, block.timestamp);
         }
 
         _lastFeeCollection = uint40(block.timestamp);

--- a/kit/contracts/contracts/SMARTTokenRegistry.sol
+++ b/kit/contracts/contracts/SMARTTokenRegistry.sol
@@ -24,14 +24,14 @@ contract SMARTTokenRegistry is ERC2771Context, AccessControlEnumerable {
     mapping(address tokenAddress => bool isRegistered) public isTokenRegistered;
 
     /// @notice Emitted when a token is registered.
-    /// @param initiator The address of the initiator of the registration.
+    /// @param sender The address of the sender of the registration.
     /// @param token The address of the registered token.
-    event TokenRegistered(address indexed initiator, address indexed token);
+    event TokenRegistered(address indexed sender, address indexed token);
 
     /// @notice Emitted when a token is unregistered.
-    /// @param initiator The address of the initiator of the unregistration.
+    /// @param sender The address of the sender of the unregistration.
     /// @param token The address of the unregistered token.
-    event TokenUnregistered(address indexed initiator, address indexed token);
+    event TokenUnregistered(address indexed sender, address indexed token);
 
     /// @notice Deploys the registry contract.
     /// @dev Sets up the initial admin and registrar roles using AccessControl's _grantRole.


### PR DESCRIPTION
## Summary by Sourcery

Standardize event parameter naming from `initiator` to `sender` across the SMARTBond, SMARTFund, and SMARTTokenRegistry contracts and update related code accordingly.

Enhancements:
- Rename the `initiator` parameter to `sender` in event definitions and their doc comments across SMARTBond, SMARTFund, and SMARTTokenRegistry
- Update variable assignments and event emissions in SMARTFund to use `sender` instead of `initiator`