### PR TITLE
fix: pincode setup

### DIFF
--- a/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/form.tsx
+++ b/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/form.tsx
@@ -1,18 +1,50 @@
 import { Form } from "@/components/blocks/form/form";
 import { authClient } from "@/lib/auth/client";
 import { setupWalletSecurity } from "@/lib/mutations/user/wallet/setup-wallet-security-action";
-import { SetupWalletSecuritySchema } from "@/lib/mutations/user/wallet/setup-wallet-security-schema";
+import {
+  SetupWalletSecuritySchema,
+  type SetupWalletSecurityInput,
+} from "@/lib/mutations/user/wallet/setup-wallet-security-schema";
 import { cn } from "@/lib/utils";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+import type { Path, UseFormReturn } from "react-hook-form";
 import { SecretCodes } from "./steps/secret-codes";
 import { SelectMethod } from "./steps/select-method";
 import { SetupVerification } from "./steps/setup-verification";
 import { Summary } from "./steps/summary";
 
+const WalletSecuritySchemaObject = SetupWalletSecuritySchema();
+
 export function SetupWalletSecurityForm() {
   const t = useTranslations("private.auth.wallet-security.form");
   const { refetch, isPending } = authClient.useSession();
+
+  const handleAnyFieldChange = useCallback(
+    (
+      form: UseFormReturn<SetupWalletSecurityInput>,
+      {
+        step,
+        goToStep,
+        changedFieldName,
+      }: {
+        step: number;
+        goToStep: (step: number) => void;
+        changedFieldName: Path<SetupWalletSecurityInput> | undefined;
+      }
+    ) => {
+      const currentVerificationTypeValue = form.getValues("verificationType");
+      if (
+        step === 0 &&
+        changedFieldName === "verificationType" &&
+        currentVerificationTypeValue === "pincode"
+      ) {
+        goToStep(1);
+      }
+    },
+    []
+  );
 
   return (
     <div
@@ -21,9 +53,16 @@ export function SetupWalletSecurityForm() {
         isPending ? "pointer-events-none opacity-50" : "opacity-100"
       )}
     >
-      <Form
+      <Form<
+        string, // ServerError
+        typeof WalletSecuritySchemaObject, // S (Schema)
+        readonly [], // BAS (BeforeActionSchemas)
+        any, // CVE (CustomValidationErrors)
+        any, // CBAVE (CustomBeforeActionValidationErrors)
+        any // Data (Action return type)
+      >
         action={setupWalletSecurity}
-        resolver={typeboxResolver(SetupWalletSecuritySchema())}
+        resolver={typeboxResolver(WalletSecuritySchemaObject)}
         buttonLabels={{
           label: t("button-label"),
           submittingLabel: t("submitting-label"),
@@ -31,20 +70,10 @@ export function SetupWalletSecurityForm() {
         }}
         hideButtons={(step) => step === 0}
         secureForm={false}
-        onAnyFieldChange={(
-          { getValues },
-          { step, goToStep, changedFieldName }
-        ) => {
-          if (
-            step === 0 &&
-            changedFieldName === "verificationType" &&
-            !!getValues("verificationType")
-          ) {
-            goToStep(1);
-          }
-        }}
+        onAnyFieldChange={handleAnyFieldChange}
         defaultValues={{
           secretCodes: [],
+          verificationType: undefined,
         }}
         onOpenChange={(open) => {
           if (!open) {

--- a/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/steps/select-method.tsx
+++ b/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/steps/select-method.tsx
@@ -1,10 +1,8 @@
 import { FormStep } from "@/components/blocks/form/form-step";
 import { Button } from "@/components/ui/button";
 import { FormField, FormItem } from "@/components/ui/form";
-import {
-  WalletSecurityMethodOptions,
-  type SetupWalletSecurityInput,
-} from "@/lib/mutations/user/wallet/setup-wallet-security-schema";
+import type { SetupWalletSecurityInput } from "@/lib/mutations/user/wallet/setup-wallet-security-schema";
+import { WalletSecurityMethodOptions } from "@/lib/mutations/user/wallet/setup-wallet-security-schema";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
@@ -17,7 +15,7 @@ export function SelectMethod() {
       <FormField
         control={control}
         name="verificationType"
-        render={() => (
+        render={({ field }) => (
           <FormItem className="flex flex-col space-y-1">
             <div className="flex flex-col gap-4">
               {/*<Button
@@ -25,7 +23,12 @@ export function SelectMethod() {
                 onClick={() => {
                   setValue(
                     "verificationType",
-                    WalletSecurityMethodOptions.TwoFactorAuthentication
+                    WalletSecurityMethodOptions.TwoFactorAuthentication,
+                    {
+                      shouldValidate: true,
+                      shouldDirty: true,
+                      shouldTouch: true,
+                    }
                   );
                 }}
               >
@@ -36,7 +39,12 @@ export function SelectMethod() {
                 onClick={() => {
                   setValue(
                     "verificationType",
-                    WalletSecurityMethodOptions.Pincode
+                    WalletSecurityMethodOptions.Pincode,
+                    {
+                      shouldValidate: true,
+                      shouldDirty: true,
+                      shouldTouch: true,
+                    }
                   );
                 }}
               >

--- a/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/steps/setup-verification.tsx
+++ b/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/steps/setup-verification.tsx
@@ -22,7 +22,6 @@ export function SetupVerification() {
     "private.auth.wallet-security.form.set-verification"
   );
   const selectedMethod = getValues("verificationType");
-  console.log("selectedMethod", selectedMethod);
 
   useEffect(() => {
     setValue("verificationCode", "");

--- a/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/steps/setup-verification.tsx
+++ b/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/steps/setup-verification.tsx
@@ -22,6 +22,7 @@ export function SetupVerification() {
     "private.auth.wallet-security.form.set-verification"
   );
   const selectedMethod = getValues("verificationType");
+  console.log("selectedMethod", selectedMethod);
 
   useEffect(() => {
     setValue("verificationCode", "");

--- a/kit/dapp/src/components/blocks/form/form.tsx
+++ b/kit/dapp/src/components/blocks/form/form.tsx
@@ -419,8 +419,8 @@ export function Form<
       return;
     }
 
-    const subscription = form.watch((_value, { name, type }) => {
-      if (type === "change") {
+    const subscription = form.watch((value, { name, type }) => {
+      if (name) {
         onAnyFieldChange(form as UseFormReturn<Infer<S>>, {
           changedFieldName: name,
           step: currentStep,
@@ -429,7 +429,9 @@ export function Form<
       }
     });
 
-    return () => subscription.unsubscribe();
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [currentStep, onAnyFieldChange, form]);
 
   const hasError = Object.keys(form.formState.errors).length > 0;


### PR DESCRIPTION
## Summary by Sourcery

Refactor the setup-wallet-security form to improve typing, schema reuse, and form change handling, and fix the pincode selection flow to auto-advance the step.

Bug Fixes:
- Automatically advance form step when "pincode" is selected as verification method

Enhancements:
- Extract onAnyFieldChange logic into a reusable callback for form step navigation
- Introduce a WalletSecuritySchemaObject constant and apply it in the form resolver
- Specify Form component generic parameters for stronger typing
- Update SelectMethod to use the render prop with form field and include validation flags in setValue
- Adjust form.watch subscription to guard on field name before triggering change handlers