### PR TITLE
fix: validation errors in other step than the current disable the next button

### DIFF
--- a/kit/dapp/src/components/blocks/create-forms/bond/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/form.tsx
@@ -55,7 +55,7 @@ export function CreateBondForm({
       verificationType: "pincode",
       predictedAddress: "0x0000000000000000000000000000000000000000",
     },
-    mode: "onChange", // Validate as fields change for real-time feedback
+    mode: "onTouched",
     resolver: (...args) =>
       typeboxResolver(
         CreateBondSchema({

--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
@@ -4,6 +4,7 @@ import { StepContent } from "@/components/blocks/asset-designer/step-wizard/step
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateBondInput } from "@/lib/mutations/bond/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
@@ -17,18 +18,15 @@ export function Basics({ onNext, onBack }: BasicsProps) {
   const t = useTranslations("private.assets.create");
 
   // Fields for this step - used for validation
-  const stepFields = ["assetName", "symbol", "decimals", "isin"];
+  const stepFields = ["assetName", "symbol", "decimals", "isin"] as const;
 
-  // We can directly use formState.isValid for the whole form (resolver validates everything)
-  // But for a multi-step form, we only want to check the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {
     // Trigger validation for just these fields
-    const isValid = await trigger(stepFields as (keyof CreateBondInput)[]);
+    const isValid = await trigger(stepFields);
     if (isValid && onNext) {
       onNext();
     }

--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/configuration.tsx
@@ -82,7 +82,6 @@ export function Configuration({ onNext, onBack }: ConfigurationProps) {
               type="number"
               name="decimals"
               label={t("parameters.common.decimals-label")}
-              defaultValue={18}
               description={t("parameters.common.decimals-description")}
               required
             />

--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/configuration.tsx
@@ -6,6 +6,7 @@ import { FormAssets } from "@/components/blocks/form/inputs/form-assets";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateBondInput } from "@/lib/mutations/bond/create/create-schema";
 import { isValidFutureDate } from "@/lib/utils/date";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
@@ -20,12 +21,10 @@ export function Configuration({ onNext, onBack }: ConfigurationProps) {
   const t = useTranslations("private.assets.create");
 
   // Fields for this step
-  const stepFields = ["cap", "faceValue", "underlyingAsset", "maturityDate"];
+  const stepFields = ["cap", "faceValue", "underlyingAsset"] as const;
 
-  // Check for any errors in this step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Special validation for maturity date (this can't be handled by TypeBox schema)
   const validateMaturityDate = async () => {
@@ -50,7 +49,7 @@ export function Configuration({ onNext, onBack }: ConfigurationProps) {
     if (!isMaturityDateValid) return;
 
     // Then trigger validation for fields in this step
-    const isValid = await trigger(stepFields as (keyof CreateBondInput)[]);
+    const isValid = await trigger(stepFields);
     if (isValid && onNext) {
       onNext();
     }

--- a/kit/dapp/src/components/blocks/create-forms/common/asset-admins/asset-admins.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/common/asset-admins/asset-admins.tsx
@@ -5,6 +5,7 @@ import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import { FormUsers } from "@/components/blocks/form/inputs/form-users";
 import type { User } from "@/lib/queries/user/user-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { useFormContext } from "react-hook-form";
@@ -98,17 +99,20 @@ export function AssetAdmins({ userDetails, onNext, onBack }: AssetAdminsProps) {
     form.trigger("assetAdmins");
   };
 
+  // Fields for this step - used for validation
+  const stepFields = ["assetAdmins"] as const;
+
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, form.formState);
+
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {
     // Trigger validation for assetAdmins field
-    const isValid = await form.trigger("assetAdmins");
+    const isValid = await form.trigger(stepFields);
     if (isValid && onNext) {
       onNext();
     }
   };
-
-  // Check if there are errors in the assetAdmins field
-  const hasStepErrors = !!form.formState.errors.assetAdmins;
 
   return (
     <StepContent
@@ -174,9 +178,6 @@ export function AssetAdmins({ userDetails, onNext, onBack }: AssetAdminsProps) {
     </StepContent>
   );
 }
-
-// Define validatedFields for the AssetAdmins component
-AssetAdmins.validatedFields = ["assetAdmins"];
 
 // Export step definition for the asset designer
 export const stepDefinition = {

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/form.tsx
@@ -65,7 +65,7 @@ export function CreateCryptoCurrencyForm({
       predictedAddress: "0x0000000000000000000000000000000000000000",
       assetAdmins: [],
     },
-    mode: "onChange", // Validate as fields change for real-time feedback
+    mode: "onTouched",
     resolver: (...args) =>
       typeboxResolver(
         CreateCryptoCurrencySchema({

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
@@ -73,7 +73,6 @@ export function Basics({ onNext, onBack }: CryptoStepProps) {
               type="number"
               name="decimals"
               label={t("parameters.common.decimals-label")}
-              defaultValue={18}
               required
             />
           </div>

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
@@ -4,6 +4,7 @@ import { StepContent } from "@/components/blocks/asset-designer/step-wizard/step
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateCryptoCurrencyInput } from "@/lib/mutations/cryptocurrency/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 import type { CryptoStepProps } from "../form";
@@ -16,10 +17,8 @@ export function Basics({ onNext, onBack }: CryptoStepProps) {
   // Fields for this step - used for validation
   const stepFields = ["assetName", "symbol", "decimals"];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -65,7 +65,7 @@ export function CreateDepositForm({
       verificationType: "pincode",
       assetAdmins: [],
     },
-    mode: "onChange", // Validate as fields change for real-time feedback
+    mode: "onTouched",
     resolver: typeboxResolver(CreateDepositSchema()),
   });
 

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
@@ -4,6 +4,7 @@ import { StepContent } from "@/components/blocks/asset-designer/step-wizard/step
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateDepositInput } from "@/lib/mutations/deposit/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 import type { DepositStepProps } from "../form";
@@ -15,10 +16,8 @@ export function Basics({ onNext, onBack }: DepositStepProps) {
   // Fields for this step - used for validation
   const stepFields = ["assetName", "symbol", "decimals", "isin"];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/configuration.tsx
@@ -5,6 +5,7 @@ import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import { FormSelect } from "@/components/blocks/form/inputs/form-select";
 import type { CreateDepositInput } from "@/lib/mutations/deposit/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { timeUnits } from "@/lib/utils/typebox/time-units";
 import { useTranslations } from "next-intl";
@@ -38,16 +39,8 @@ export function Configuration({ onNext, onBack }: DepositStepProps) {
     "price.currency",
   ];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some((field) => {
-    const [parent, child] = field.split(".");
-    if (child) {
-      return !!(
-        formState.errors[parent as keyof typeof formState.errors] as any
-      )?.[child];
-    }
-    return !!formState.errors[field as keyof typeof formState.errors];
-  });
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
@@ -64,7 +64,7 @@ export function CreateEquityForm({
       verificationType: "pincode",
       assetAdmins: [],
     },
-    mode: "onChange", // Validate as fields change for real-time feedback
+    mode: "onTouched",
     resolver: typeboxResolver(CreateEquitySchema()),
   });
 

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
@@ -4,6 +4,7 @@ import { StepContent } from "@/components/blocks/asset-designer/step-wizard/step
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateEquityInput } from "@/lib/mutations/equity/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 import type { EquityStepProps } from "../form";
@@ -15,10 +16,8 @@ export function Basics({ onNext, onBack }: EquityStepProps) {
   // Fields for this step - used for validation
   const stepFields = ["assetName", "symbol", "decimals", "isin"];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
@@ -80,7 +80,6 @@ export function Basics({ onNext, onBack }: EquityStepProps) {
               type="number"
               name="decimals"
               label={t("parameters.common.decimals-label")}
-              defaultValue={18}
               required
             />
           </div>

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/configuration.tsx
@@ -3,6 +3,7 @@ import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import { FormSelect } from "@/components/blocks/form/inputs/form-select";
 import type { CreateEquityInput } from "@/lib/mutations/equity/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
@@ -26,10 +27,8 @@ export function Configuration({ onNext, onBack }: EquityStepProps) {
     "price.currency",
   ];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
@@ -66,7 +66,7 @@ export function CreateFundForm({
       verificationType: "pincode",
       assetAdmins: [],
     },
-    mode: "onChange", // Validate as fields change for real-time feedback
+    mode: "onTouched",
     resolver: typeboxResolver(CreateFundSchema()),
   });
 

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
@@ -2,6 +2,7 @@ import { StepContent } from "@/components/blocks/asset-designer/step-wizard/step
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateFundInput } from "@/lib/mutations/fund/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 import type { FundStepProps } from "../form";
@@ -13,10 +14,8 @@ export function Basics({ onNext, onBack }: FundStepProps) {
   // Fields for this step - used for validation
   const stepFields = ["assetName", "symbol", "decimals", "isin"];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
@@ -78,7 +78,6 @@ export function Basics({ onNext, onBack }: FundStepProps) {
               type="number"
               name="decimals"
               label={t("parameters.common.decimals-label")}
-              defaultValue={18}
               required
             />
           </div>

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/configuration.tsx
@@ -3,6 +3,7 @@ import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import { FormSelect } from "@/components/blocks/form/inputs/form-select";
 import type { CreateFundInput } from "@/lib/mutations/fund/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
@@ -27,10 +28,8 @@ export function Configuration({ onNext, onBack }: FundStepProps) {
     "price.currency",
   ];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
@@ -65,7 +65,7 @@ export function CreateStablecoinForm({
       verificationType: "pincode",
       assetAdmins: [],
     },
-    mode: "onChange", // Validate as fields change for real-time feedback
+    mode: "onTouched",
     resolver: typeboxResolver(CreateStablecoinSchema()),
   });
 

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
@@ -2,6 +2,7 @@ import { StepContent } from "@/components/blocks/asset-designer/step-wizard/step
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import type { CreateStablecoinInput } from "@/lib/mutations/stablecoin/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 import type { StablecoinStepProps } from "../form";
@@ -14,10 +15,8 @@ export function Basics({ onNext, onBack }: StablecoinStepProps) {
   // Fields for this step - used for validation
   const stepFields = ["assetName", "symbol", "decimals"];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/configuration.tsx
@@ -3,6 +3,7 @@ import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import { FormSelect } from "@/components/blocks/form/inputs/form-select";
 import type { CreateStablecoinInput } from "@/lib/mutations/stablecoin/create/create-schema";
+import { hasStepFieldErrors } from "@/lib/utils/form-steps";
 import { fiatCurrencies } from "@/lib/utils/typebox/fiat-currency";
 import { timeUnits } from "@/lib/utils/typebox/time-units";
 import { useTranslations } from "next-intl";
@@ -37,10 +38,8 @@ export function Configuration({ onNext, onBack }: StablecoinStepProps) {
     "price.currency",
   ];
 
-  // Check if there are errors in the current step's fields
-  const hasStepErrors = stepFields.some(
-    (field) => !!formState.errors[field as keyof typeof formState.errors]
-  );
+  // Check if any touched fields in this step have errors
+  const hasStepErrors = hasStepFieldErrors(stepFields, formState);
 
   // Handle next button click - trigger validation before proceeding
   const handleNext = async () => {

--- a/kit/dapp/src/lib/utils/form-steps.ts
+++ b/kit/dapp/src/lib/utils/form-steps.ts
@@ -1,0 +1,30 @@
+import type { FieldValues, FormState, Path } from "react-hook-form";
+
+/**
+ * Checks if any fields in a step have validation errors.
+ * Only considers errors for fields that have been touched by the user.
+ *
+ * @param stepFields - Array of field names to check
+ * @param formState - Current form state from useFormContext
+ * @returns True if any touched fields have errors, false otherwise
+ */
+export function hasStepFieldErrors<TFieldValues extends FieldValues>(
+  stepFields: readonly string[],
+  formState: FormState<TFieldValues>
+): boolean {
+  const { touchedFields, errors } = formState;
+
+  // Check if any touched fields have errors
+  return stepFields.some((fieldName) => {
+    // Convert to unknown path type for safe access
+    const field = fieldName as unknown as Path<TFieldValues>;
+
+    // Check if the field has been touched
+    const isTouched = field in touchedFields;
+
+    // Check if the field has an error
+    const hasError = field in errors;
+
+    return isTouched && hasError;
+  });
+}


### PR DESCRIPTION
## Summary by Sourcery

Unify multi-step form validation by introducing a shared helper to check touched field errors, updating all form steps to trigger and disable navigation based only on the current step’s fields, and switching validation mode to 'onTouched'.

New Features:
- Add hasStepFieldErrors utility to detect validation errors only for touched fields in a given step

Bug Fixes:
- Prevent validation errors in non-active steps from disabling the Next button

Enhancements:
- Refactor each step component to use hasStepFieldErrors instead of custom error-checking logic
- Restrict validation triggers in handleNext to the current step’s fields across all forms
- Remove deprecated validatedFields assignments and default decimal values from step inputs
- Change form validation mode from 'onChange' to 'onTouched' in all Create*Form components