### PR TITLE
fix: remove XvP feature flag

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/_components/sidebar/items/trade-management.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/_components/sidebar/items/trade-management.tsx
@@ -3,15 +3,9 @@
 import { NavMain } from "@/components/layout/nav-main";
 import { RefreshCWIcon } from "@/components/ui/refresh-cw";
 import { useTranslations } from "next-intl";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 
 export function TradeManagement() {
   const t = useTranslations("admin.sidebar.trade-management");
-  const flagEnabled = useFeatureFlagEnabled("trade-management");
-
-  if (process.env.NEXT_PUBLIC_POSTHOG_KEY && !flagEnabled) {
-    return null;
-  }
 
   return (
     <NavMain


### PR DESCRIPTION
## Summary by Sourcery

Remove the XvP feature flag gating from the Trade Management sidebar component to ensure it always renders.

Bug Fixes:
- Always display the Trade Management sidebar item by removing conditional PostHog flag checks

Enhancements:
- Clean up by removing the unused feature flag import and related logic