### PR TITLE
fix: consistent asset designer modal size between steps

### DIFF
--- a/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
@@ -331,17 +331,15 @@ export function AssetDesignerDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[95vh] min-h-[70vh] h-auto w-[90vw] lg:w-[75vw] p-0 overflow-auto border-none right-0 !max-w-screen rounded-2xl"
+        className="h-[85vh] w-[90vw] lg:w-[75vw] border-none !max-w-screen rounded-2xl overflow-hidden p-0 m-0"
         onInteractOutside={(e) => {
           e.preventDefault();
         }}
         onOpenAutoFocus={(e) => e.preventDefault()}
         onFocusOutside={(e) => e.preventDefault()}
       >
-        <div className="relative">
+        <div className="h-full">
           <DialogTitle className="sr-only">Asset Designer</DialogTitle>
-          {/* TODO: Using 'as any' type assertions because dynamic translation keys from getAssetTitle/getAssetDescription
-              don't match the literal string types expected by next-intl's t function */}
           <StepWizard
             steps={allSteps}
             currentStepId={currentStepId}

--- a/kit/dapp/src/components/blocks/asset-designer/step-wizard/step-wizard.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/step-wizard/step-wizard.tsx
@@ -37,11 +37,11 @@ export function StepWizard({
   const t = useTranslations("private.assets.create");
 
   return (
-    <div className="flex h-full min-h-[65vh] flex-col" tabIndex={-1}>
-      <div className="flex flex-1 overflow-hidden p-6" tabIndex={-1}>
+    <div className="flex h-full" tabIndex={-1}>
+      <div className="flex h-full w-full" tabIndex={-1}>
         {/* Sidebar / Steps */}
         <div
-          className="w-[25%] bg-primary p-6 flex flex-col rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
+          className="w-[250px] h-[calc(85vh-3rem)] flex-shrink-0 bg-primary m-6 mr-0 p-6 flex flex-col rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.05)]"
           style={sidebarStyle}
           aria-hidden="true"
           tabIndex={-1}
@@ -57,7 +57,7 @@ export function StepWizard({
           </div>
 
           {/* Steps */}
-          <div className="space-y-0 flex-1 overflow-y-auto relative pt-1">
+          <div className="space-y-0 flex-1 relative pt-1">
             {steps.map((step, index) => {
               const isCurrent = currentStepId === step.id;
               const isCompleted = index < currentStepIndex;
@@ -223,8 +223,8 @@ export function StepWizard({
         </div>
 
         {/* Content area */}
-        <div className="flex flex-col flex-1 overflow-hidden bg-background ml-6 rounded-lg p-10 pt-6 pr-14">
-          {children}
+        <div className="h-[85vh] flex-1 overflow-y-auto bg-background py-6 rounded-lg">
+          <div className="p-10 pt-6">{children}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
![Screenshot 2025-05-14 at 15 42 01](https://github.com/user-attachments/assets/a0b070cd-f904-44cc-bbe3-57b72072184d)
![Screenshot 2025-05-14 at 15 41 48](https://github.com/user-attachments/assets/5c357d9d-5e71-486d-b552-0a841a23f7dd)

## Summary by Sourcery

Unify the modal and step wizard dimensions in the asset designer dialog to ensure a consistent size across all steps

Bug Fixes:
- Standardize the dialog and wizard containers to a fixed 85vh height to eliminate size inconsistencies between steps

Enhancements:
- Convert the sidebar to a fixed 250px width with a calculated height and adjust the content pane to a scrollable container with unified padding
- Update DialogContent classes to remove variable max-height constraints, enforce fixed dimensions, and manage overflow