### PR TITLE
fix: stray semicolon

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/assets/actions/completed/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/actions/completed/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 export default async function ActionsPage() {
   return (
     <Suspense fallback={<DataTableSkeleton />}>
-      <ActionsTable status="COMPLETED" type="Admin" />;
+      <ActionsTable status="COMPLETED" type="Admin" />
     </Suspense>
   );
 }

--- a/kit/dapp/src/app/[locale]/(private)/assets/actions/pending/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/actions/pending/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 export default async function ActionsPage() {
   return (
     <Suspense fallback={<DataTableSkeleton />}>
-      <ActionsTable status="PENDING" type="Admin" />;
+      <ActionsTable status="PENDING" type="Admin" />
     </Suspense>
   );
 }

--- a/kit/dapp/src/app/[locale]/(private)/assets/actions/upcoming/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/actions/upcoming/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 export default async function ActionsPage() {
   return (
     <Suspense fallback={<DataTableSkeleton />}>
-      <ActionsTable status="UPCOMING" type="Admin" />;
+      <ActionsTable status="UPCOMING" type="Admin" />
     </Suspense>
   );
 }

--- a/kit/dapp/src/app/[locale]/(private)/portfolio/my-actions/completed/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/my-actions/completed/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 export default async function ActionsPage() {
   return (
     <Suspense fallback={<DataTableSkeleton />}>
-      <ActionsTable status="COMPLETED" type="User" />;
+      <ActionsTable status="COMPLETED" type="User" />
     </Suspense>
   );
 }

--- a/kit/dapp/src/app/[locale]/(private)/portfolio/my-actions/pending/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/my-actions/pending/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 export default async function ActionsPage() {
   return (
     <Suspense fallback={<DataTableSkeleton />}>
-      <ActionsTable status="PENDING" type="User" />;
+      <ActionsTable status="PENDING" type="User" />
     </Suspense>
   );
 }

--- a/kit/dapp/src/app/[locale]/(private)/portfolio/my-actions/upcoming/page.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/my-actions/upcoming/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 export default async function ActionsPage() {
   return (
     <Suspense fallback={<DataTableSkeleton />}>
-      <ActionsTable status="UPCOMING" type="User" />;
+      <ActionsTable status="UPCOMING" type="User" />
     </Suspense>
   );
 }


### PR DESCRIPTION
There was an extra ; below the actions tables.

## Summary by Sourcery

Remove stray semicolons from JSX elements in various action pages.

Bug Fixes:
- Remove redundant semicolons after ActionsTable components in admin completed, pending, and upcoming pages
- Remove redundant semicolons after ActionsTable components in user completed, pending, and upcoming pages