### PR TITLE
feat: structure all asset screens like bonds

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -1356,23 +1356,51 @@
           },
           "cryptocurrencies": {
             "description": "Set parameters specific to your cryptocurrency.",
-            "title": "Cryptocurrency configuration"
+            "title": "Cryptocurrency configuration",
+            "title-supply": "Supply",
+            "title-value": "Denomination",
+            "description-supply": "Configure the supply and franctionalization of this cryptocurrency. This information is immutable.",
+            "description-value": "Configure the price for your cryptocurrency."
           },
           "deposits": {
             "description": "Set parameters specific to your deposit.",
-            "title": "Deposit configuration"
+            "title": "Deposit configuration",
+            "title-collateral": "Collateral",
+            "description-collateral": "Configure the collateral for your deposit.",
+            "title-value": "Denomination",
+            "description-value": "Configure the price for your deposit.",
+            "title-supply": "Supply",
+            "description-supply": "Configure the supply and franctionalization of this deposit. This information is immutable."
           },
           "equities": {
             "description": "Set parameters specific to your equity.",
-            "title": "Equity configuration"
+            "title": "Equity configuration",
+            "title-supply": "Supply",
+            "title-value": "Denomination",
+            "description-supply": "Configure the supply and franctionalization of this equity. This information is immutable.",
+            "description-value": "Configure the price for your equity.",
+            "title-classification": "Classification",
+            "description-classification": "Configure the classification for your equity."
           },
           "funds": {
             "description": "Set parameters specific to your fund.",
-            "title": "Fund configuration"
+            "title": "Fund configuration",
+            "title-supply": "Supply",
+            "title-value": "Denomination",
+            "description-supply": "Configure the supply and franctionalization of this fund. This information is immutable.",
+            "description-value": "Configure the price for your fund.",
+            "title-classification": "Classification",
+            "description-classification": "Configure the classification for your fund."
           },
           "stablecoins": {
             "description": "Set parameters specific to your stable coin.",
-            "title": "Stable coin configuration"
+            "title": "Stable coin configuration",
+            "title-supply": "Supply",
+            "title-value": "Denomination",
+            "description-supply": "Configure the supply and franctionalization of this stable coin. This information is immutable.",
+            "description-value": "Configure the price for your stable coin.",
+            "title-collateral": "Collateral",
+            "description-collateral": "Configure the collateral for your stable coin."
           }
         },
         "form": {
@@ -1510,11 +1538,12 @@
             "name-placeholder": "Company XYZ Bond 2023",
             "symbol-placeholder": "XYZ23",
             "underlying-asset-description": "Address of the asset that backs this bond",
-            "underlying-asset-label": "Underlying asset"
+            "underlying-asset-label": "Underlying asset",
+            "symbol-description": "The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
           },
           "common": {
             "collateral-proof-validity-label": "Collateral proof validity",
-            "decimals-description": "The number of decimals to use for the bond. This is used to determine the precision of the bond.",
+            "decimals-description": "The number of decimals to use for the asset. This is used to determine the precision of the asset.",
             "decimals-label": "Decimals",
             "internalid-label": "Internal ID",
             "isin-label": "ISIN",
@@ -1540,22 +1569,25 @@
             }
           },
           "cryptocurrencies": {
-            "initial-supply-description": "Initial amount of assets to be minted",
+            "initial-supply-description": "Initial amount of assets to be minted.",
             "initial-supply-label": "Initial supply",
             "name-placeholder": "Bitcoin",
-            "symbol-placeholder": "BTC"
+            "symbol-placeholder": "BTC",
+            "symbol-description": "The symbol of the cryptocurrency. This a unique identifier for the cryptocurrency for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
           },
           "deposits": {
             "isin-placeholder": "EU1234567890",
             "name-placeholder": "Deposited Euro",
-            "symbol-placeholder": "EURD"
+            "symbol-placeholder": "EURD",
+            "symbol-description": "The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
           },
           "equities": {
             "equity-category-label": "Equity category",
             "equity-class-label": "Equity class",
             "isin-placeholder": "US1234567890",
             "name-placeholder": "Global Equity",
-            "symbol-placeholder": "GLEQ"
+            "symbol-placeholder": "GLEQ",
+            "symbol-description": "The symbol of the equity. This a unique identifier for the equity for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
           },
           "funds": {
             "basis-points": "bps",
@@ -1565,12 +1597,14 @@
             "management-fee-description": "Annual management fee in basis points (100 bps = 1%)",
             "management-fee-label": "Management fee",
             "name-placeholder": "Global Growth Fund",
-            "symbol-placeholder": "GGF"
+            "symbol-placeholder": "GGF",
+            "symbol-description": "The symbol of the fund. This a unique identifier for the fund for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
           },
           "stablecoins": {
             "isin-placeholder": "DEFI4EVER2024",
             "name-placeholder": "TotallyNotTether",
-            "symbol-placeholder": "SAFU"
+            "symbol-placeholder": "SAFU",
+            "symbol-description": "The symbol of the stablecoin. This a unique identifier for the stablecoin for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
           }
         },
         "summary": {

--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -825,6 +825,7 @@
     "sending": "Sending",
     "string": "Please enter text",
     "string-format": "Please enter text in the correct {format} format",
+    "string-format-isin": "Please enter a valid ISIN. Format: 2 letters (country code), 9 alphanumeric characters, and 1 check digit (e.g., US0378331005)",
     "string-format-unknown": "Unknown format '{format}'",
     "string-format-asset-symbol": "Please enter a valid asset symbol (uppercase letters and numbers)",
     "string-max-length": "Please enter no more than {maxLength} characters",
@@ -841,6 +842,7 @@
     "uint8array-min-byte-length": "File is too small",
     "undefined": "This field should be empty",
     "union": "Please enter a valid value",
+    "union-min-max": "Please enter a value between {min} and {max}",
     "unknown": "Invalid value entered",
     "validation-errors": "Validation error",
     "void": "This field should be empty"

--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
@@ -43,7 +43,7 @@ export function Basics() {
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
                 placeholder={t("parameters.bonds.symbol-placeholder")}
-                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                description={t("parameters.bonds.symbol-description")}
                 alphanumeric
                 required
                 maxLength={10}

--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/basics.tsx
@@ -85,6 +85,7 @@ export function Basics() {
 Basics.validatedFields = [
   "assetName",
   "symbol",
+  "isin",
 ] satisfies (keyof CreateBondInput)[];
 
 // Export step definition for the asset designer

--- a/kit/dapp/src/components/blocks/create-forms/bond/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/steps/configuration.tsx
@@ -10,7 +10,7 @@ import { useTranslations } from "next-intl";
 import { useFormContext, type UseFormReturn } from "react-hook-form";
 
 export function Configuration() {
-  const { control, getValues, setError } = useFormContext<CreateBondInput>();
+  const { control } = useFormContext<CreateBondInput>();
   const t = useTranslations("private.assets.create");
 
   return (

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
@@ -42,8 +42,12 @@ export function Basics() {
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.bonds.symbol-placeholder")}
-                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                placeholder={t(
+                  "parameters.cryptocurrencies.symbol-placeholder"
+                )}
+                description={t(
+                  "parameters.cryptocurrencies.symbol-description"
+                )}
                 alphanumeric
                 required
                 maxLength={10}

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
@@ -89,7 +89,7 @@ export function Basics() {
 Basics.validatedFields = [
   "assetName",
   "symbol",
-  "decimals",
+  "isin",
 ] satisfies (keyof CreateCryptoCurrencyInput)[];
 
 // Export step definition for the asset designer

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/basics.tsx
@@ -24,32 +24,57 @@ export function Basics() {
         <FormStep
           title={t("basics.title-onchain")}
           description={t("basics.description-onchain")}
+          className="w-full"
+          contentClassName="w-full"
         >
-          <div className="grid grid-cols-1 gap-6">
-            <FormInput
-              control={control}
-              name="assetName"
-              label={t("parameters.common.name-label")}
-              placeholder={t("parameters.cryptocurrencies.name-placeholder")}
-              required
-              maxLength={50}
-            />
-            <FormInput
-              control={control}
-              name="symbol"
-              label={t("parameters.common.symbol-label")}
-              placeholder={t("parameters.cryptocurrencies.symbol-placeholder")}
-              alphanumeric
-              required
-              maxLength={10}
-            />
-            <FormInput
-              control={control}
-              type="number"
-              name="decimals"
-              label={t("parameters.common.decimals-label")}
-              required
-            />
+          <div className="grid grid-cols-1 gap-6 w-full">
+            <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="assetName"
+                label={t("parameters.common.name-label")}
+                placeholder={t("parameters.bonds.name-placeholder")}
+                description="The name of the bond. This is used to identify the bond in the UI and cannot be changed after creation."
+                required
+                maxLength={50}
+              />
+              <FormInput
+                control={control}
+                name="symbol"
+                label={t("parameters.common.symbol-label")}
+                placeholder={t("parameters.bonds.symbol-placeholder")}
+                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                alphanumeric
+                required
+                maxLength={10}
+              />
+            </div>
+          </div>
+        </FormStep>
+        <FormStep
+          title={t("basics.title-offchain")}
+          description={t("basics.description-offchain")}
+          className="w-full"
+          contentClassName="w-full"
+        >
+          <div className="grid grid-cols-1 gap-6 w-full">
+            <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="isin"
+                label={t("parameters.common.isin-label")}
+                placeholder={t("parameters.bonds.isin-placeholder")}
+                description="The ISIN of the bond. This is an optional unique identifier for the bond in the financial system."
+                maxLength={12}
+              />
+              <FormInput
+                control={control}
+                name="internalid"
+                label={t("parameters.common.internalid-label")}
+                description="The internal ID of the bond. This is an optional unique identifier for the bond in your internal system."
+                maxLength={12}
+              />
+            </div>
           </div>
         </FormStep>
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/steps/configuration.tsx
@@ -28,12 +28,18 @@ export function Configuration() {
         </div>
 
         <FormStep
-          title="Cryptocurrency Configuration"
-          description="Configure initial supply and pricing for your cryptocurrency."
-          className="w-full"
-          contentClassName="w-full"
+          title={t("configuration.cryptocurrencies.title-supply")}
+          description={t("configuration.cryptocurrencies.description-supply")}
         >
-          <div className="grid grid-cols-2 gap-6 w-full">
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="decimals"
+              label={t("parameters.common.decimals-label")}
+              description={t("parameters.common.decimals-description")}
+              required
+            />
             <FormInput
               control={control}
               name="initialSupply"
@@ -44,7 +50,14 @@ export function Configuration() {
               )}
               required
             />
+          </div>
+        </FormStep>
 
+        <FormStep
+          title={t("configuration.cryptocurrencies.title-value")}
+          description={t("configuration.cryptocurrencies.description-value")}
+        >
+          <div className="grid grid-cols-2 gap-6">
             <FormInput
               control={control}
               type="number"
@@ -69,6 +82,7 @@ export function Configuration() {
 }
 
 Configuration.validatedFields = [
+  "decimals",
   "initialSupply",
   "price",
 ] satisfies (keyof CreateCryptoCurrencyInput)[];

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
@@ -22,45 +22,59 @@ export function Basics() {
         </div>
 
         <FormStep
-          title={t("basics.title")}
-          description={t("basics.description")}
+          title={t("basics.title-onchain")}
+          description={t("basics.description-onchain")}
           className="w-full"
           contentClassName="w-full"
         >
           <div className="grid grid-cols-1 gap-6 w-full">
-            <FormInput
-              control={control}
-              name="assetName"
-              label={t("parameters.common.name-label")}
-              placeholder={t("parameters.deposits.name-placeholder")}
-              required
-              maxLength={50}
-            />
             <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="assetName"
+                label={t("parameters.common.name-label")}
+                placeholder={t("parameters.bonds.name-placeholder")}
+                description="The name of the bond. This is used to identify the bond in the UI and cannot be changed after creation."
+                required
+                maxLength={50}
+              />
               <FormInput
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.deposits.symbol-placeholder")}
-                textOnly
+                placeholder={t("parameters.bonds.symbol-placeholder")}
+                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                alphanumeric
                 required
                 maxLength={10}
               />
+            </div>
+          </div>
+        </FormStep>
+        <FormStep
+          title={t("basics.title-offchain")}
+          description={t("basics.description-offchain")}
+          className="w-full"
+          contentClassName="w-full"
+        >
+          <div className="grid grid-cols-1 gap-6 w-full">
+            <div className="grid grid-cols-2 gap-6">
               <FormInput
                 control={control}
                 name="isin"
                 label={t("parameters.common.isin-label")}
-                placeholder={t("parameters.deposits.isin-placeholder")}
+                placeholder={t("parameters.bonds.isin-placeholder")}
+                description="The ISIN of the bond. This is an optional unique identifier for the bond in the financial system."
+                maxLength={12}
+              />
+              <FormInput
+                control={control}
+                name="internalid"
+                label={t("parameters.common.internalid-label")}
+                description="The internal ID of the bond. This is an optional unique identifier for the bond in your internal system."
+                maxLength={12}
               />
             </div>
-            <FormInput
-              control={control}
-              type="number"
-              name="decimals"
-              label={t("parameters.common.decimals-label")}
-              defaultValue={6}
-              required
-            />
           </div>
         </FormStep>
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
@@ -85,7 +85,6 @@ export function Basics() {
 Basics.validatedFields = [
   "assetName",
   "symbol",
-  "decimals",
   "isin",
 ] satisfies (keyof CreateDepositInput)[];
 

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/basics.tsx
@@ -42,8 +42,8 @@ export function Basics() {
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.bonds.symbol-placeholder")}
-                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                placeholder={t("parameters.deposits.symbol-placeholder")}
+                description={t("parameters.deposits.symbol-description")}
                 alphanumeric
                 required
                 maxLength={10}

--- a/kit/dapp/src/components/blocks/create-forms/deposit/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/steps/configuration.tsx
@@ -42,12 +42,49 @@ export function Configuration() {
         </div>
 
         <FormStep
-          title={t("configuration.deposits.title")}
-          description={t("configuration.deposits.description")}
-          className="w-full"
-          contentClassName="w-full"
+          title={t("configuration.deposits.title-supply")}
+          description={t("configuration.deposits.description-supply")}
         >
-          <div className="grid grid-cols-2 gap-6 w-full">
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="decimals"
+              label={t("parameters.common.decimals-label")}
+              description={t("parameters.common.decimals-description")}
+              required
+            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.deposits.title-value")}
+          description={t("configuration.deposits.description-value")}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="price.amount"
+              required
+              label={t("parameters.common.price-label")}
+              postfix={
+                <FormSelect
+                  name="price.currency"
+                  control={control}
+                  options={currencyOptions}
+                  className="border-l-0 rounded-l-none w-26 shadow-none -mx-3"
+                />
+              }
+            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.deposits.title-collateral")}
+          description={t("configuration.deposits.description-collateral")}
+        >
+          <div className="grid grid-cols-2 gap-6">
             <FormInput
               control={control}
               type="number"
@@ -60,21 +97,6 @@ export function Configuration() {
                   control={control}
                   options={timeUnitOptions}
                   defaultValue="months"
-                  className="border-l-0 rounded-l-none w-26 shadow-none -mx-3"
-                />
-              }
-            />
-            <FormInput
-              control={control}
-              type="number"
-              name="price.amount"
-              required
-              label={t("parameters.common.price-label")}
-              postfix={
-                <FormSelect
-                  name="price.currency"
-                  control={control}
-                  options={currencyOptions}
                   className="border-l-0 rounded-l-none w-26 shadow-none -mx-3"
                 />
               }

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/_components/equity-categories.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/_components/equity-categories.tsx
@@ -4,7 +4,13 @@ import type { equityCategories } from "@/lib/utils/typebox/equity-categories";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function EquityCategoriesSelect({ label }: { label: string }) {
+export function EquityCategoriesSelect({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
   const { control } = useFormContext<CreateEquityInput>();
   const t = useTranslations("private.assets.fields");
 
@@ -159,6 +165,7 @@ export function EquityCategoriesSelect({ label }: { label: string }) {
       control={control}
       name="equityCategory"
       label={label}
+      className={className}
       options={translatedEquityCategories.sort((a, b) =>
         a.label.localeCompare(b.label)
       )}

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/_components/equity-classes.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/_components/equity-classes.tsx
@@ -4,7 +4,13 @@ import type { equityClasses } from "@/lib/utils/typebox/equity-classes";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function EquityClassesSelect({ label }: { label: string }) {
+export function EquityClassesSelect({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
   const { control } = useFormContext<CreateEquityInput>();
   const t = useTranslations("private.assets.fields");
 
@@ -51,6 +57,7 @@ export function EquityClassesSelect({ label }: { label: string }) {
       control={control}
       name="equityClass"
       label={label}
+      className={className}
       options={translatedEquityClasses.sort((a, b) =>
         a.label.localeCompare(b.label)
       )}

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
@@ -22,44 +22,59 @@ export function Basics() {
         </div>
 
         <FormStep
-          title={t("basics.title")}
-          description={t("basics.description")}
+          title={t("basics.title-onchain")}
+          description={t("basics.description-onchain")}
           className="w-full"
           contentClassName="w-full"
         >
           <div className="grid grid-cols-1 gap-6 w-full">
-            <FormInput
-              control={control}
-              name="assetName"
-              label={t("parameters.common.name-label")}
-              placeholder={t("parameters.equities.name-placeholder")}
-              required
-              maxLength={50}
-            />
             <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="assetName"
+                label={t("parameters.common.name-label")}
+                placeholder={t("parameters.bonds.name-placeholder")}
+                description="The name of the bond. This is used to identify the bond in the UI and cannot be changed after creation."
+                required
+                maxLength={50}
+              />
               <FormInput
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.equities.symbol-placeholder")}
-                textOnly
+                placeholder={t("parameters.bonds.symbol-placeholder")}
+                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                alphanumeric
                 required
                 maxLength={10}
               />
+            </div>
+          </div>
+        </FormStep>
+        <FormStep
+          title={t("basics.title-offchain")}
+          description={t("basics.description-offchain")}
+          className="w-full"
+          contentClassName="w-full"
+        >
+          <div className="grid grid-cols-1 gap-6 w-full">
+            <div className="grid grid-cols-2 gap-6">
               <FormInput
                 control={control}
                 name="isin"
                 label={t("parameters.common.isin-label")}
-                placeholder={t("parameters.equities.isin-placeholder")}
+                placeholder={t("parameters.bonds.isin-placeholder")}
+                description="The ISIN of the bond. This is an optional unique identifier for the bond in the financial system."
+                maxLength={12}
+              />
+              <FormInput
+                control={control}
+                name="internalid"
+                label={t("parameters.common.internalid-label")}
+                description="The internal ID of the bond. This is an optional unique identifier for the bond in your internal system."
+                maxLength={12}
               />
             </div>
-            <FormInput
-              control={control}
-              type="number"
-              name="decimals"
-              label={t("parameters.common.decimals-label")}
-              required
-            />
           </div>
         </FormStep>
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
@@ -84,7 +84,6 @@ export function Basics() {
 Basics.validatedFields = [
   "assetName",
   "symbol",
-  "decimals",
   "isin",
 ] satisfies (keyof CreateEquityInput)[];
 

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/basics.tsx
@@ -42,9 +42,8 @@ export function Basics() {
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.bonds.symbol-placeholder")}
-                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
-                alphanumeric
+                placeholder={t("parameters.equities.symbol-placeholder")}
+                description={t("parameters.equities.symbol-description")}
                 required
                 maxLength={10}
               />

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/configuration.tsx
@@ -10,7 +10,7 @@ import { EquityCategoriesSelect } from "./_components/equity-categories";
 import { EquityClassesSelect } from "./_components/equity-classes";
 
 export function Configuration() {
-  const { control, formState, trigger } = useFormContext<CreateEquityInput>();
+  const { control } = useFormContext<CreateEquityInput>();
   const t = useTranslations("private.assets.create");
   const currencyOptions = fiatCurrencies.map((currency) => ({
     value: currency,

--- a/kit/dapp/src/components/blocks/create-forms/equity/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/steps/configuration.tsx
@@ -30,16 +30,26 @@ export function Configuration() {
         </div>
 
         <FormStep
-          title={t("configuration.equities.title")}
-          description={t("configuration.equities.description")}
+          title={t("configuration.equities.title-supply")}
+          description={t("configuration.equities.description-supply")}
         >
-          <div className="grid grid-cols-1 gap-6">
-            <EquityClassesSelect
-              label={t("parameters.equities.equity-class-label")}
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="decimals"
+              label={t("parameters.common.decimals-label")}
+              description={t("parameters.common.decimals-description")}
+              required
             />
-            <EquityCategoriesSelect
-              label={t("parameters.equities.equity-category-label")}
-            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.equities.title-value")}
+          description={t("configuration.equities.description-value")}
+        >
+          <div className="grid grid-cols-2 gap-6">
             <FormInput
               control={control}
               type="number"
@@ -57,12 +67,29 @@ export function Configuration() {
             />
           </div>
         </FormStep>
+
+        <FormStep
+          title={t("configuration.equities.title-classification")}
+          description={t("configuration.equities.description-classification")}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <EquityClassesSelect
+              label={t("parameters.equities.equity-class-label")}
+              className="w-full"
+            />
+            <EquityCategoriesSelect
+              label={t("parameters.equities.equity-category-label")}
+              className="w-full"
+            />
+          </div>
+        </FormStep>
       </div>
     </StepContent>
   );
 }
 
 Configuration.validatedFields = [
+  "decimals",
   "equityCategory",
   "equityClass",
   "price",

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/_components/fund-categories.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/_components/fund-categories.tsx
@@ -4,7 +4,13 @@ import type { fundCategories } from "@/lib/utils/typebox/fund-categories";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function FundCategoriesSelect({ label }: { label: string }) {
+export function FundCategoriesSelect({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
   const { control } = useFormContext<CreateFundInput>();
   const t = useTranslations("private.assets.fields");
 
@@ -83,6 +89,7 @@ export function FundCategoriesSelect({ label }: { label: string }) {
       control={control}
       name="fundCategory"
       label={label}
+      className={className}
       options={translatedFundCategories.sort((a, b) =>
         a.label.localeCompare(b.label)
       )}

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/_components/fund-classes.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/_components/fund-classes.tsx
@@ -4,7 +4,13 @@ import type { fundClasses } from "@/lib/utils/typebox/fund-classes";
 import { useTranslations } from "next-intl";
 import { useFormContext } from "react-hook-form";
 
-export function FundClassesSelect({ label }: { label: string }) {
+export function FundClassesSelect({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
   const { control } = useFormContext<CreateFundInput>();
   const t = useTranslations("private.assets.fields");
 
@@ -71,6 +77,7 @@ export function FundClassesSelect({ label }: { label: string }) {
       control={control}
       name="fundClass"
       label={label}
+      className={className}
       options={translatedFundClasses.sort((a, b) =>
         a.label.localeCompare(b.label)
       )}

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
@@ -20,44 +20,59 @@ export function Basics() {
         </div>
 
         <FormStep
-          title={t("basics.title")}
-          description={t("basics.description")}
+          title={t("basics.title-onchain")}
+          description={t("basics.description-onchain")}
           className="w-full"
           contentClassName="w-full"
         >
-          <div className="grid grid-cols-1 gap-6">
-            <FormInput
-              control={control}
-              name="assetName"
-              label={t("parameters.common.name-label")}
-              placeholder={t("parameters.funds.name-placeholder")}
-              required
-              maxLength={50}
-            />
+          <div className="grid grid-cols-1 gap-6 w-full">
             <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="assetName"
+                label={t("parameters.common.name-label")}
+                placeholder={t("parameters.bonds.name-placeholder")}
+                description="The name of the bond. This is used to identify the bond in the UI and cannot be changed after creation."
+                required
+                maxLength={50}
+              />
               <FormInput
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.funds.symbol-placeholder")}
-                textOnly
+                placeholder={t("parameters.bonds.symbol-placeholder")}
+                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                alphanumeric
                 required
                 maxLength={10}
               />
+            </div>
+          </div>
+        </FormStep>
+        <FormStep
+          title={t("basics.title-offchain")}
+          description={t("basics.description-offchain")}
+          className="w-full"
+          contentClassName="w-full"
+        >
+          <div className="grid grid-cols-1 gap-6 w-full">
+            <div className="grid grid-cols-2 gap-6">
               <FormInput
                 control={control}
                 name="isin"
                 label={t("parameters.common.isin-label")}
-                placeholder={t("parameters.funds.isin-placeholder")}
+                placeholder={t("parameters.bonds.isin-placeholder")}
+                description="The ISIN of the bond. This is an optional unique identifier for the bond in the financial system."
+                maxLength={12}
+              />
+              <FormInput
+                control={control}
+                name="internalid"
+                label={t("parameters.common.internalid-label")}
+                description="The internal ID of the bond. This is an optional unique identifier for the bond in your internal system."
+                maxLength={12}
               />
             </div>
-            <FormInput
-              control={control}
-              type="number"
-              name="decimals"
-              label={t("parameters.common.decimals-label")}
-              required
-            />
           </div>
         </FormStep>
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
@@ -83,7 +83,6 @@ export function Basics() {
 Basics.validatedFields = [
   "assetName",
   "symbol",
-  "decimals",
   "isin",
 ] satisfies (keyof CreateFundInput)[];
 

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/basics.tsx
@@ -40,8 +40,8 @@ export function Basics() {
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.bonds.symbol-placeholder")}
-                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                placeholder={t("parameters.funds.symbol-placeholder")}
+                description={t("parameters.funds.symbol-description")}
                 alphanumeric
                 required
                 maxLength={10}

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/configuration.tsx
@@ -30,23 +30,42 @@ export function Configuration() {
         </div>
 
         <FormStep
-          title={t("configuration.funds.title")}
-          description={t("configuration.funds.description")}
+          title={t("configuration.funds.title-supply")}
+          description={t("configuration.funds.description-supply")}
         >
           <div className="grid grid-cols-2 gap-6">
-            <FundCategoriesSelect
-              label={t("parameters.funds.fund-category-label")}
-            />
-            <FundClassesSelect label={t("parameters.funds.fund-class-label")} />
             <FormInput
               control={control}
               type="number"
-              name="managementFeeBps"
-              label={t("parameters.funds.management-fee-label")}
-              description={t("parameters.funds.management-fee-description")}
-              postfix={t("parameters.funds.basis-points")}
+              name="decimals"
+              label={t("parameters.common.decimals-label")}
+              description={t("parameters.common.decimals-description")}
               required
             />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.stablecoins.title-supply")}
+          description={t("configuration.stablecoins.description-supply")}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="decimals"
+              label={t("parameters.common.decimals-label")}
+              description={t("parameters.common.decimals-description")}
+              required
+            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.funds.title-value")}
+          description={t("configuration.funds.description-value")}
+        >
+          <div className="grid grid-cols-2 gap-6">
             <FormInput
               control={control}
               type="number"
@@ -62,6 +81,31 @@ export function Configuration() {
                 />
               }
             />
+            <FormInput
+              control={control}
+              type="number"
+              name="managementFeeBps"
+              label={t("parameters.funds.management-fee-label")}
+              description={t("parameters.funds.management-fee-description")}
+              postfix={t("parameters.funds.basis-points")}
+              required
+            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.funds.title-classification")}
+          description={t("configuration.funds.description-classification")}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <FundCategoriesSelect
+              label={t("parameters.funds.fund-category-label")}
+              className="w-full"
+            />
+            <FundClassesSelect
+              label={t("parameters.funds.fund-class-label")}
+              className="w-full"
+            />
           </div>
         </FormStep>
       </div>
@@ -70,6 +114,7 @@ export function Configuration() {
 }
 
 Configuration.validatedFields = [
+  "decimals",
   "fundCategory",
   "fundClass",
   "managementFeeBps",

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
@@ -20,39 +20,59 @@ export function Basics() {
         </div>
 
         <FormStep
-          title={t("basics.title")}
-          description={t("basics.description")}
+          title={t("basics.title-onchain")}
+          description={t("basics.description-onchain")}
           className="w-full"
           contentClassName="w-full"
         >
-          <div className="grid grid-cols-1 gap-6">
-            <FormInput
-              control={control}
-              name="assetName"
-              label={t("parameters.common.name-label")}
-              placeholder={t("parameters.stablecoins.name-placeholder")}
-              required
-              maxLength={50}
-            />
+          <div className="grid grid-cols-1 gap-6 w-full">
             <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="assetName"
+                label={t("parameters.common.name-label")}
+                placeholder={t("parameters.bonds.name-placeholder")}
+                description="The name of the bond. This is used to identify the bond in the UI and cannot be changed after creation."
+                required
+                maxLength={50}
+              />
               <FormInput
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.stablecoins.symbol-placeholder")}
-                textOnly
+                placeholder={t("parameters.bonds.symbol-placeholder")}
+                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
+                alphanumeric
                 required
                 maxLength={10}
               />
             </div>
-            <FormInput
-              control={control}
-              type="number"
-              name="decimals"
-              label={t("parameters.common.decimals-label")}
-              defaultValue={6}
-              required
-            />
+          </div>
+        </FormStep>
+        <FormStep
+          title={t("basics.title-offchain")}
+          description={t("basics.description-offchain")}
+          className="w-full"
+          contentClassName="w-full"
+        >
+          <div className="grid grid-cols-1 gap-6 w-full">
+            <div className="grid grid-cols-2 gap-6">
+              <FormInput
+                control={control}
+                name="isin"
+                label={t("parameters.common.isin-label")}
+                placeholder={t("parameters.bonds.isin-placeholder")}
+                description="The ISIN of the bond. This is an optional unique identifier for the bond in the financial system."
+                maxLength={12}
+              />
+              <FormInput
+                control={control}
+                name="internalid"
+                label={t("parameters.common.internalid-label")}
+                description="The internal ID of the bond. This is an optional unique identifier for the bond in your internal system."
+                maxLength={12}
+              />
+            </div>
           </div>
         </FormStep>
       </div>

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
@@ -40,9 +40,8 @@ export function Basics() {
                 control={control}
                 name="symbol"
                 label={t("parameters.common.symbol-label")}
-                placeholder={t("parameters.bonds.symbol-placeholder")}
-                description="The symbol of the bond. This a unique identifier for the bond for onchain purposes. It can be up to 10 characters long and cannot be changed after creation."
-                alphanumeric
+                placeholder={t("parameters.stablecoins.symbol-placeholder")}
+                description={t("parameters.stablecoins.symbol-description")}
                 required
                 maxLength={10}
               />

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/basics.tsx
@@ -82,7 +82,7 @@ export function Basics() {
 Basics.validatedFields = [
   "assetName",
   "symbol",
-  "decimals",
+  "isin",
 ] satisfies (keyof CreateStablecoinInput)[];
 
 // Export step definition for the asset designer

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/configuration.tsx
@@ -40,8 +40,47 @@ export function Configuration() {
         </div>
 
         <FormStep
-          title={t("configuration.stablecoins.title")}
-          description={t("configuration.stablecoins.description")}
+          title={t("configuration.stablecoins.title-supply")}
+          description={t("configuration.stablecoins.description-supply")}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="decimals"
+              label={t("parameters.common.decimals-label")}
+              description={t("parameters.common.decimals-description")}
+              required
+            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.stablecoins.title-value")}
+          description={t("configuration.stablecoins.description-value")}
+        >
+          <div className="grid grid-cols-2 gap-6">
+            <FormInput
+              control={control}
+              type="number"
+              name="price.amount"
+              required
+              label={t("parameters.common.price-label")}
+              postfix={
+                <FormSelect
+                  name="price.currency"
+                  control={control}
+                  options={currencyOptions}
+                  className="border-l-0 rounded-l-none w-26 shadow-none -mx-3"
+                />
+              }
+            />
+          </div>
+        </FormStep>
+
+        <FormStep
+          title={t("configuration.stablecoins.title-collateral")}
+          description={t("configuration.stablecoins.description-collateral")}
         >
           <div className="grid grid-cols-2 gap-6">
             <FormInput
@@ -56,21 +95,6 @@ export function Configuration() {
                   control={control}
                   options={timeUnitOptions}
                   defaultValue="months"
-                  className="border-l-0 rounded-l-none w-26 shadow-none -mx-3"
-                />
-              }
-            />
-            <FormInput
-              control={control}
-              type="number"
-              name="price.amount"
-              required
-              label={t("parameters.common.price-label")}
-              postfix={
-                <FormSelect
-                  name="price.currency"
-                  control={control}
-                  options={currencyOptions}
                   className="border-l-0 rounded-l-none w-26 shadow-none -mx-3"
                 />
               }

--- a/kit/dapp/src/components/blocks/form/form.tsx
+++ b/kit/dapp/src/components/blocks/form/form.tsx
@@ -246,6 +246,9 @@ export function Form<
         if (error.schema.format === "asset-symbol") {
           return t("error.string-format-asset-symbol");
         }
+        if (error.schema.format === "isin") {
+          return t("error.string-format-isin");
+        }
         return t("error.string-format", { format: error.schema.format });
       case ValueErrorType.StringMaxLength:
         return t("error.string-max-length", {
@@ -280,6 +283,21 @@ export function Form<
       case ValueErrorType.Undefined:
         return t("error.undefined");
       case ValueErrorType.Union:
+        // Check for min/max in anyOf schemas
+        if (error.schema.anyOf) {
+          const integerSchema = error.schema.anyOf.find(
+            (schema: any) => schema.type === "integer"
+          );
+          if (
+            integerSchema?.minimum !== undefined &&
+            integerSchema?.maximum !== undefined
+          ) {
+            return t("error.union-min-max", {
+              min: integerSchema.minimum,
+              max: integerSchema.maximum,
+            });
+          }
+        }
         return t("error.union");
       case ValueErrorType.Void:
         return t("error.void");

--- a/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
@@ -59,6 +59,7 @@ export function CreateBondSchema({
       cap: t.Amount({
         decimals,
         description: "Maximum issuance amount",
+        minimum: 1,
       }),
       faceValue: t.Amount({
         decimals,

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-function.ts
@@ -69,6 +69,8 @@ export const createCryptoCurrencyFunction = withAccessControl(
       assetName,
       symbol,
       decimals,
+      isin,
+      internalid,
       verificationCode,
       verificationType,
       initialSupply,
@@ -87,6 +89,8 @@ export const createCryptoCurrencyFunction = withAccessControl(
 
     await hasuraClient.request(CreateOffchainCryptoCurrency, {
       id: predictedAddress,
+      isin: isin,
+      internalid: internalid,
     });
 
     await hasuraClient.request(AddAssetPrice, {

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
@@ -28,6 +28,16 @@ export function CreateCryptoCurrencySchema({
         description: "The symbol of the cryptocurrency (ticker)",
         maxLength: 10,
       }),
+      isin: t.Optional(
+        t.Isin({
+          description: "International Securities Identification Number",
+        })
+      ),
+      internalid: t.Optional(
+        t.String({
+          description: "Internal ID of the bond",
+        })
+      ),
       decimals: t.Decimals({
         description: "The number of decimal places for the token",
       }),

--- a/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
@@ -73,6 +73,7 @@ export const createDepositFunction = withAccessControl(
       predictedAddress,
       price,
       assetAdmins,
+      internalid,
     },
     ctx: { user },
   }: {
@@ -82,6 +83,7 @@ export const createDepositFunction = withAccessControl(
     await hasuraClient.request(CreateOffchainDeposit, {
       id: predictedAddress,
       isin,
+      internalid,
     });
 
     await hasuraClient.request(AddAssetPrice, {

--- a/kit/dapp/src/lib/mutations/deposit/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-schema.ts
@@ -30,23 +30,14 @@ export function CreateDepositSchema() {
         description: "The number of decimal places for the token",
       }),
       isin: t.Optional(
-        t.Union(
-          [
-            t.String({
-              pattern: "^$",
-              description: "Empty ISIN value",
-            }),
-            t.Isin({
-              description:
-                "Optional International Securities Identification Number",
-              error:
-                "Please enter text in the correct ISIN format or leave it empty",
-            }),
-          ],
-          {
-            description: "Either an empty string or a valid ISIN",
-          }
-        )
+        t.Isin({
+          description: "International Securities Identification Number",
+        })
+      ),
+      internalid: t.Optional(
+        t.String({
+          description: "Internal ID of the bond",
+        })
       ),
       verificationCode: t.VerificationCode({
         description:

--- a/kit/dapp/src/lib/mutations/equity/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-function.ts
@@ -76,6 +76,7 @@ export const createEquityFunction = withAccessControl(
       predictedAddress,
       price,
       assetAdmins,
+      internalid,
     },
     ctx: { user },
   }: {
@@ -85,6 +86,7 @@ export const createEquityFunction = withAccessControl(
     await hasuraClient.request(CreateOffchainEquity, {
       id: predictedAddress,
       isin: isin,
+      internalid: internalid,
     });
 
     await hasuraClient.request(AddAssetPrice, {

--- a/kit/dapp/src/lib/mutations/equity/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-schema.ts
@@ -31,8 +31,12 @@ export function CreateEquitySchema() {
       }),
       isin: t.Optional(
         t.Isin({
-          description:
-            "Optional International Securities Identification Number",
+          description: "International Securities Identification Number",
+        })
+      ),
+      internalid: t.Optional(
+        t.String({
+          description: "Internal ID of the bond",
         })
       ),
       verificationCode: t.VerificationCode({

--- a/kit/dapp/src/lib/mutations/fund/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-function.ts
@@ -78,6 +78,7 @@ export const createFundFunction = withAccessControl(
       predictedAddress,
       price,
       assetAdmins,
+      internalid,
     },
     ctx: { user },
   }: {
@@ -87,6 +88,7 @@ export const createFundFunction = withAccessControl(
     await hasuraClient.request(CreateOffchainFund, {
       id: predictedAddress,
       isin,
+      internalid,
     });
 
     await hasuraClient.request(AddAssetPrice, {

--- a/kit/dapp/src/lib/mutations/fund/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-schema.ts
@@ -36,6 +36,11 @@ export function CreateFundSchema() {
             "Optional International Securities Identification Number",
         })
       ),
+      internalid: t.Optional(
+        t.String({
+          description: "Internal ID of the fund",
+        })
+      ),
       verificationCode: t.VerificationCode({
         description:
           "The verification code (PIN, 2FA, or secret code) for signing the transaction",

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-function.ts
@@ -87,6 +87,8 @@ export const createStablecoinFunction = withAccessControl(
       predictedAddress,
       price,
       assetAdmins,
+      isin,
+      internalid,
     },
     ctx: { user },
   }: {
@@ -95,6 +97,8 @@ export const createStablecoinFunction = withAccessControl(
   }) => {
     await hasuraClient.request(CreateOffchainStablecoin, {
       id: predictedAddress,
+      isin,
+      internalid,
     });
 
     await hasuraClient.request(AddAssetPrice, {

--- a/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/stablecoin/create/create-schema.ts
@@ -31,6 +31,16 @@ export function CreateStablecoinSchema() {
         decimals: t.Decimals({
           description: "The number of decimal places for the token",
         }),
+        isin: t.Optional(
+          t.Isin({
+            description: "International Securities Identification Number",
+          })
+        ),
+        internalid: t.Optional(
+          t.String({
+            description: "Internal ID of the stablecoin",
+          })
+        ),
         collateralLivenessValue: t.Number({
           description: "The duration value for collateral validity",
           minimum: 1,

--- a/kit/dapp/src/lib/utils/typebox/isin.ts
+++ b/kit/dapp/src/lib/utils/typebox/isin.ts
@@ -7,12 +7,14 @@
 import type { SchemaOptions } from "@sinclair/typebox";
 import { FormatRegistry, t, TypeRegistry } from "elysia/type-system";
 
+const ISIN_PATTERN = /^[A-Z]{2}[A-Z0-9]{9}[0-9]$/;
+
 // ISIN format validator
 if (!FormatRegistry.Has("isin")) {
   FormatRegistry.Set("isin", (value) => {
     if (typeof value !== "string") return false;
     if (value === "") return true;
-    return /^[A-Z]{2}[A-Z0-9]{9}[0-9]$/.test(value);
+    return ISIN_PATTERN.test(value);
   });
 }
 
@@ -20,7 +22,7 @@ if (!TypeRegistry.Has("isin")) {
   TypeRegistry.Set<string>("isin", (_schema, value) => {
     if (typeof value !== "string") return false;
     if (value === "") return true;
-    return /^[A-Z]{2}[A-Z0-9]{9}[0-9]$/.test(value);
+    return ISIN_PATTERN.test(value);
   });
 }
 


### PR DESCRIPTION
# feat
- structure all asset screens like bond

# fix
- bond: no error when enter 0 in Maximum supply
- no error message for ISIN field
- unclear error on decimals 
![Screenshot 2025-05-15 at 11 48 20](https://github.com/user-attachments/assets/6a8ddc7a-3e0c-4ae4-814f-5189975e6779)
![Screenshot 2025-05-15 at 11 48 00](https://github.com/user-attachments/assets/c162c2c6-fb6e-4e77-b460-4917b8468313)
![Screenshot 2025-05-15 at 11 26 34](https://github.com/user-attachments/assets/5ab35718-4060-483c-9c1c-5054d415acb3)

