### PR TITLE
fix: asset type selection spacing

### DIFF
--- a/kit/dapp/src/components/blocks/asset-designer/steps/asset-type-selection.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/steps/asset-type-selection.tsx
@@ -238,7 +238,7 @@ export function AssetTypeSelection({
               <Card
                 className={cn(
                   "flex flex-col h-full cursor-pointer transition-all duration-200 overflow-hidden",
-                  "border relative gap-2",
+                  "border relative gap-3",
                   selectedType === assetInfo.type
                     ? "border-primary shadow-[0_2px_8px_rgba(0,0,0,0.05)] ring-1 ring-primary/20"
                     : "border-muted hover:border-primary/30 hover:shadow-[0_2px_8px_rgba(0,0,0,0.05)]",

--- a/kit/dapp/src/components/blocks/asset-designer/steps/asset-type-selection.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/steps/asset-type-selection.tsx
@@ -27,7 +27,7 @@ interface AssetTypeInfo {
 const assetTypesInfo: AssetTypeInfo[] = [
   {
     type: "bond",
-    descriptionKey: "private.assets.create.form.description.bonds",
+    descriptionKey: "private.assets.table.topinfo-title.bond",
     extendedDescriptionKey: "private.assets.table.topinfo-description.bond",
     featureKeys: [
       {
@@ -58,8 +58,9 @@ const assetTypesInfo: AssetTypeInfo[] = [
   },
   {
     type: "cryptocurrency",
-    descriptionKey: "private.assets.create.form.description.cryptocurrencies",
-    extendedDescriptionKey: "private.assets.table.topinfo-title.cryptocurrency",
+    descriptionKey: "private.assets.table.topinfo-title.cryptocurrency",
+    extendedDescriptionKey:
+      "private.assets.table.topinfo-description.cryptocurrency",
     featureKeys: [
       {
         status: true,
@@ -89,8 +90,8 @@ const assetTypesInfo: AssetTypeInfo[] = [
   },
   {
     type: "equity",
-    descriptionKey: "private.assets.create.form.description.equities",
-    extendedDescriptionKey: "private.assets.table.topinfo-title.equity",
+    descriptionKey: "private.assets.table.topinfo-title.equity",
+    extendedDescriptionKey: "private.assets.table.topinfo-description.equity",
     featureKeys: [
       {
         status: true,
@@ -120,8 +121,8 @@ const assetTypesInfo: AssetTypeInfo[] = [
   },
   {
     type: "fund",
-    descriptionKey: "private.assets.create.form.description.funds",
-    extendedDescriptionKey: "private.assets.table.topinfo-title.fund",
+    descriptionKey: "private.assets.table.topinfo-title.fund",
+    extendedDescriptionKey: "private.assets.table.topinfo-description.fund",
     featureKeys: [
       {
         status: true,
@@ -151,8 +152,9 @@ const assetTypesInfo: AssetTypeInfo[] = [
   },
   {
     type: "stablecoin",
-    descriptionKey: "private.assets.create.form.description.stablecoins",
-    extendedDescriptionKey: "private.assets.table.topinfo-title.stablecoin",
+    descriptionKey: "private.assets.table.topinfo-title.stablecoin",
+    extendedDescriptionKey:
+      "private.assets.table.topinfo-description.stablecoin",
     featureKeys: [
       {
         status: true,
@@ -182,8 +184,8 @@ const assetTypesInfo: AssetTypeInfo[] = [
   },
   {
     type: "deposit",
-    descriptionKey: "private.assets.create.form.description.deposits",
-    extendedDescriptionKey: "private.assets.table.topinfo-title.deposit",
+    descriptionKey: "private.assets.table.topinfo-title.deposit",
+    extendedDescriptionKey: "private.assets.table.topinfo-description.deposit",
     featureKeys: [
       {
         status: true,
@@ -230,13 +232,13 @@ export function AssetTypeSelection({
         </p>
       </div>
       <div className="flex-1 overflow-y-auto pr-4 px-0">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 pb-8 mb-2">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 pb-4">
           {assetTypesInfo.map((assetInfo) => (
             <div key={assetInfo.type} className="pl-2">
               <Card
                 className={cn(
                   "flex flex-col h-full cursor-pointer transition-all duration-200 overflow-hidden",
-                  "border relative",
+                  "border relative gap-2",
                   selectedType === assetInfo.type
                     ? "border-primary shadow-[0_2px_8px_rgba(0,0,0,0.05)] ring-1 ring-primary/20"
                     : "border-muted hover:border-primary/30 hover:shadow-[0_2px_8px_rgba(0,0,0,0.05)]",
@@ -273,11 +275,11 @@ export function AssetTypeSelection({
                       </HoverCardContent>
                     </HoverCard>
                   </div>
-                  <p className="text-xs text-muted-foreground mt-4">
+                  <p className="hidden xl:block text-xs text-muted-foreground mt-2">
                     {t(assetInfo.descriptionKey as any)}
                   </p>
                 </CardHeader>
-                <CardContent className="space-y-4 mt-auto relative z-10">
+                <CardContent className="mt-auto relative z-10">
                   <div className="space-y-2">
                     <h4 className="text-xs font-medium text-foreground">
                       {t("asset-designer.type-selection.key-features")}

--- a/kit/dapp/src/components/blocks/asset-designer/steps/asset-type-selection.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/steps/asset-type-selection.tsx
@@ -275,7 +275,7 @@ export function AssetTypeSelection({
                       </HoverCardContent>
                     </HoverCard>
                   </div>
-                  <p className="hidden xl:block text-xs text-muted-foreground mt-2">
+                  <p className="text-xs text-muted-foreground mt-2">
                     {t(assetInfo.descriptionKey as any)}
                   </p>
                 </CardHeader>

--- a/kit/dapp/src/components/blocks/create-forms/fund/steps/configuration.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/steps/configuration.tsx
@@ -30,22 +30,6 @@ export function Configuration() {
         </div>
 
         <FormStep
-          title={t("configuration.funds.title-supply")}
-          description={t("configuration.funds.description-supply")}
-        >
-          <div className="grid grid-cols-2 gap-6">
-            <FormInput
-              control={control}
-              type="number"
-              name="decimals"
-              label={t("parameters.common.decimals-label")}
-              description={t("parameters.common.decimals-description")}
-              required
-            />
-          </div>
-        </FormStep>
-
-        <FormStep
           title={t("configuration.stablecoins.title-supply")}
           description={t("configuration.stablecoins.description-supply")}
         >


### PR DESCRIPTION
![Screenshot 2025-05-15 at 14 25 51](https://github.com/user-attachments/assets/7ad31747-4c1c-4ef2-a807-d8921e5e8b82)

## Summary by Sourcery

Update translation keys for asset type descriptions and refine spacing in the AssetTypeSelection component.

Bug Fixes:
- Fix layout and spacing issues in the asset type grid and card elements for consistent presentation.

Enhancements:
- Use table topinfo translation keys for asset type descriptions and extended descriptions.
- Add `gap-2` utility to card elements to increase spacing between items.
- Reduce bottom padding of the asset type grid container from `pb-8 mb-2` to `pb-4`.
- Hide asset description paragraphs on screens smaller than xl and adjust top margin from `mt-4` to `mt-2`.
- Remove `space-y-4` utility from card content to eliminate extra vertical spacing.