### PR TITLE
fix: form validation rules

### DIFF
--- a/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-schema.ts
@@ -64,6 +64,7 @@ export function CreateBondSchema({
       faceValue: t.Amount({
         decimals,
         description: "Face value of the bond",
+        minimum: 1,
       }),
       maturityDate: t.String({
         description: "Maturity date of the bond",

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-schema.ts
@@ -51,7 +51,7 @@ export function CreateCryptoCurrencySchema({
       initialSupply: t.Amount({
         decimals,
         description: "Initial supply of tokens",
-        default: 0,
+        minimum: 1,
       }),
       predictedAddress: t.EthereumAddress({
         description: "Predicted address of the cryptocurrency",


### PR DESCRIPTION
# fix
- [Cryptocurrency]Missing error when entered 0 in Initial Supply
- [Bond] No error when enter 0 in Face value

## Summary by Sourcery

Enforce minimum value of 1 for the initial supply in the cryptocurrency creation schema and for the face value in the bond creation schema.

Bug Fixes:
- Require initial supply to be at least 1 in cryptocurrency schema
- Require face value to be at least 1 in bond schema