### PR TITLE
fix: typo 'Issueing' in submission text

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -1494,27 +1494,27 @@
             },
             "stablecoin": {
               "issue": "Issue stablecoin",
-              "submitting": "Issueing stablecoin..."
+              "submitting": "Issuing stablecoin..."
             },
             "fund": {
               "issue": "Issue fund",
-              "submitting": "Issueing fund..."
+              "submitting": "Issuing fund..."
             },
             "equity": {
               "issue": "Issue equity",
-              "submitting": "Issueing equity..."
+              "submitting": "Issuing equity..."
             },
             "deposit": {
               "issue": "Issue deposit",
-              "submitting": "Issueing deposit..."
+              "submitting": "Issuing deposit..."
             },
             "cryptocurrency": {
               "issue": "Issue cryptocurrency",
-              "submitting": "Issueing cryptocurrency..."
+              "submitting": "Issuing cryptocurrency..."
             },
             "bond": {
               "issue": "Issue bond",
-              "submitting": "Issueing bond..."
+              "submitting": "Issuing bond..."
             }
           },
           "toast-action": {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct typo 'Issueing' to 'Issuing' in the submission text of messages/en.json.