### PR TITLE
feat: reuse the db by leveraging react cache

### DIFF
--- a/kit/dapp/src/lib/db/index.ts
+++ b/kit/dapp/src/lib/db/index.ts
@@ -1,4 +1,5 @@
 import { drizzle } from "drizzle-orm/node-postgres";
+import { cache } from "react";
 import { postgresPool } from "../settlemint/postgres";
 import * as regulationConfigsSchema from "./regulations/schema-base-regulation-configs";
 import * as micaRegulationConfigsSchema from "./regulations/schema-mica-regulation-configs";
@@ -7,14 +8,18 @@ import * as authSchema from "./schema-auth";
 import * as exchangeRatesSchema from "./schema-exchange-rates";
 import * as settingsSchema from "./schema-settings";
 
-export const db = drizzle(postgresPool, {
-  // logger: process.env.NODE_ENV === 'development',
-  schema: {
-    ...authSchema,
-    ...assetTokenizationSchema,
-    ...settingsSchema,
-    ...exchangeRatesSchema,
-    ...regulationConfigsSchema,
-    ...micaRegulationConfigsSchema,
-  },
+const getDb = cache(() => {
+  return drizzle(postgresPool, {
+    // logger: process.env.NODE_ENV === 'development',
+    schema: {
+      ...authSchema,
+      ...assetTokenizationSchema,
+      ...settingsSchema,
+      ...exchangeRatesSchema,
+      ...regulationConfigsSchema,
+      ...micaRegulationConfigsSchema,
+    },
+  });
 });
+
+export const db = getDb();


### PR DESCRIPTION
See https://opennext.js.org/cloudflare/howtos/db#postgresql

## Summary by Sourcery

Enhancements:
- Cache the Drizzle database client initialization using React cache to reuse the Postgres connection instead of recreating it on each import