### PR TITLE
fix: table column header sizes are different

### DIFF
--- a/kit/dapp/src/components/blocks/data-table/data-table-column-header.tsx
+++ b/kit/dapp/src/components/blocks/data-table/data-table-column-header.tsx
@@ -83,7 +83,7 @@ export function DataTableColumnHeader<TData, TValue>({
 
   if (!column.getCanSort()) {
     return (
-      <div className={cn("text-xs", headerVariants({ variant, className }))}>
+      <div className={cn("text-sm", headerVariants({ variant, className }))}>
         {children}
       </div>
     );


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix mismatched table column header sizes by changing non-sortable headers from text-xs to text-sm.