### PR TITLE
fix: update homepage changelog title to be X vs Payment

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -870,7 +870,7 @@
   "homepage": {
     "asset-tokenization": "asset tokenization",
     "bonds-funds-equities": "bonds, funds, equities",
-    "changelog-link-title": "Introducing the SMART protocol",
+    "changelog-link-title": "Introducing X vs Payment",
     "cryptocurrencies": "cryptocurrencies",
     "documentation": "Documentation",
     "features": {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Update the homepage changelog title in kit/dapp/messages/en.json to 'X vs Payment'