### PR TITLE
fix: need to click on start using my wallet twice in onboarding

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/portfolio/my-contacts/_components/add-contact-form/form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/my-contacts/_components/add-contact-form/form.tsx
@@ -32,7 +32,7 @@ export function AddContactForm({
           label: t("contact.title"),
         }}
         secureForm={false}
-        toastMessages={{
+        toast={{
           loading: t("contact.adding"),
           success: t("contact.added"),
         }}

--- a/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/form.tsx
+++ b/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/form.tsx
@@ -54,6 +54,9 @@ export function SetupWalletSecurityForm() {
         onSuccess={() => {
           refetch();
         }}
+        toast={{
+          disabled: true,
+        }}
         disablePreviousButton
       >
         <SelectMethod key="select-method" />

--- a/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/form.tsx
+++ b/kit/dapp/src/components/blocks/auth/setup-wallet-security-form/form.tsx
@@ -51,6 +51,9 @@ export function SetupWalletSecurityForm() {
             refetch();
           }
         }}
+        onSuccess={() => {
+          refetch();
+        }}
         disablePreviousButton
       >
         <SelectMethod key="select-method" />

--- a/kit/dapp/src/components/blocks/create-forms/bond/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/bond/form.tsx
@@ -92,7 +92,7 @@ export function CreateBondForm({
       }}
       secureForm={true}
       hideStepProgress={true}
-      toastMessages={{
+      toast={{
         loading: t("toasts.bond.submitting"),
         success: t("toasts.bond.success"),
       }}

--- a/kit/dapp/src/components/blocks/create-forms/cryptocurrency/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/cryptocurrency/form.tsx
@@ -94,7 +94,7 @@ export function CreateCryptoCurrencyForm({
       }}
       secureForm={true}
       hideStepProgress={true}
-      toastMessages={{
+      toast={{
         loading: t("toasts.cryptocurrency.submitting"),
         success: t("toasts.cryptocurrency.success"),
       }}

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -94,7 +94,7 @@ export function CreateDepositForm({
       }}
       secureForm={true}
       hideStepProgress={true}
-      toastMessages={{
+      toast={{
         loading: t("toasts.deposit.submitting"),
         success: t("toasts.deposit.success"),
       }}

--- a/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/equity/form.tsx
@@ -94,7 +94,7 @@ export function CreateEquityForm({
       }}
       secureForm={true}
       hideStepProgress={true}
-      toastMessages={{
+      toast={{
         loading: t("toasts.equity.submitting"),
         success: t("toasts.equity.success"),
       }}

--- a/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/fund/form.tsx
@@ -118,7 +118,7 @@ export function CreateFundForm({
       }}
       secureForm={true}
       hideStepProgress={true}
-      toastMessages={{
+      toast={{
         loading: t("toasts.fund.submitting"),
         success: t("toasts.fund.success"),
       }}

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
@@ -118,7 +118,7 @@ export function CreateStablecoinForm({
       }}
       secureForm={true}
       hideStepProgress={true}
-      toastMessages={{
+      toast={{
         loading: t("toasts.stablecoin.submitting"),
         success: t("toasts.stablecoin.success"),
       }}

--- a/kit/dapp/src/components/blocks/form/form.tsx
+++ b/kit/dapp/src/components/blocks/form/form.tsx
@@ -62,6 +62,7 @@ interface FormProps<
     }
   ) => void;
   onStepChange?: (newStep: number) => void;
+  onSuccess?: () => void;
   disablePreviousButton?: boolean;
 }
 
@@ -87,6 +88,7 @@ export function Form<
   disablePreviousButton = false,
   onStepChange,
   hideStepProgress = false,
+  onSuccess,
 }: FormProps<ServerError, S, BAS, CVE, CBAVE, Data, FormContext>) {
   const [currentStep, setCurrentStep] = useState(0);
   const t = useTranslations();
@@ -341,6 +343,7 @@ export function Form<
         : {}),
       success: async () => {
         await revalidate();
+        onSuccess?.();
         const successMessage =
           toastMessages?.success || t("transactions.success");
         return successMessage;


### PR DESCRIPTION
## Summary by Sourcery

Standardize toast handling in the Form component by replacing the legacy toastMessages API with a unified toast prop (including loading, success, disabled flags, and onSuccess callback), migrate submission logic to use sonnerToast.promise, update all form usages to the new API, and resolve the double-click issue in the onboarding wallet flow.

New Features:
- Introduce a disabled flag and onSuccess callback in the Form component’s toast prop.

Bug Fixes:
- Fix the onboarding wallet security form requiring two clicks to start using the wallet.

Enhancements:
- Refactor form submission to use sonnerToast.promise instead of the old toast.promise and streamline loading/success messaging.
- Update all form instantiations to adopt the new toast prop shape in place of toastMessages.