### PR TITLE
fix: cannot search for myself as a regular user

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/platform/users/(table)/_components/actions/update-kyc-status-action.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/users/(table)/_components/actions/update-kyc-status-action.tsx
@@ -34,7 +34,7 @@ export function UpdateKycStatusAction({
       setIsLoading(true);
       await updateKycStatus({
         userId: user.id,
-        kycVerified: user.kyc_verified_at ? null : new Date().toJSON(),
+        kycVerified: user.kycVerifiedAt ? null : new Date().toJSON(),
       });
 
       toast.success(t("success"));
@@ -57,12 +57,12 @@ export function UpdateKycStatusAction({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {user.kyc_verified_at
+              {user.kycVerifiedAt
                 ? t("remove-kyc-status.title")
                 : t("set-kyc-status.title")}
             </DialogTitle>
             <DialogDescription>
-              {user.kyc_verified_at
+              {user.kycVerifiedAt
                 ? t("remove-kyc-status.description", {
                     userName: user.name,
                   })
@@ -82,13 +82,13 @@ export function UpdateKycStatusAction({
               {t("buttons.cancel")}
             </Button>
             <Button
-              variant={user.kyc_verified_at ? "destructive" : "default"}
+              variant={user.kycVerifiedAt ? "destructive" : "default"}
               onClick={handleStatusChange}
               disabled={isLoading}
             >
               {isLoading
                 ? t("buttons.loading")
-                : user.kyc_verified_at
+                : user.kycVerifiedAt
                   ? t("buttons.remove")
                   : t("buttons.set")}
             </Button>

--- a/kit/dapp/src/app/[locale]/(private)/platform/users/(table)/_components/columns.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/users/(table)/_components/columns.tsx
@@ -78,7 +78,7 @@ export function Columns() {
           <span>{renderValue()}</span>
           {row.original.banned && (
             <Badge variant="destructive">
-              {t("banned_reason", { reason: row.original.ban_reason ?? "" })}
+              {t("banned_reason", { reason: row.original.banReason ?? "" })}
             </Badge>
           )}
         </>
@@ -173,7 +173,7 @@ export function Columns() {
         options: STATUS_OPTIONS,
       }),
     }),
-    columnHelper.accessor("kyc_verified_at", {
+    columnHelper.accessor("kycVerifiedAt", {
       header: t("columns.kyc_status"),
       cell: ({ getValue }) => {
         const verified = getValue();

--- a/kit/dapp/src/app/[locale]/(private)/platform/users/[id]/(details)/_components/details-grid.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/platform/users/[id]/(details)/_components/details-grid.tsx
@@ -54,11 +54,11 @@ export async function DetailsGrid({ id }: DetailsGridProps) {
         </Badge>
       </DetailGridItem>
       <DetailGridItem label={t("detail.values.created_at")}>
-        {formatDate(user.created_at, { type: "distance", locale: locale })}
+        {formatDate(user.createdAt, { type: "distance", locale: locale })}
       </DetailGridItem>
       <DetailGridItem label={t("detail.values.verified_at")}>
-        {user.kyc_verified_at
-          ? formatDate(user.kyc_verified_at, {
+        {user.kycVerifiedAt
+          ? formatDate(user.kycVerifiedAt, {
               type: "distance",
               locale: locale,
             })
@@ -87,8 +87,8 @@ export async function DetailsGrid({ id }: DetailsGridProps) {
           : t("status.never")}
       </DetailGridItem>
       <DetailGridItem label={t("detail.values.last_login")}>
-        {user.last_login_at
-          ? formatDate(user.last_login_at, { type: "distance", locale: locale })
+        {user.lastLoginAt
+          ? formatDate(user.lastLoginAt, { type: "distance", locale: locale })
           : t("status.never")}
       </DetailGridItem>
     </DetailGrid>

--- a/kit/dapp/src/components/blocks/form/inputs/form-users.tsx
+++ b/kit/dapp/src/components/blocks/form/inputs/form-users.tsx
@@ -182,12 +182,7 @@ function FormUsersList({
           term: debounced,
         },
       });
-      const results = data || [];
-      return role
-        ? results.filter(
-            (user: User | Contact) => isUser(user) && user.role === role
-          )
-        : results;
+      return data || [];
     },
     {
       revalidateOnFocus: false,
@@ -286,8 +281,4 @@ function FormUsersList({
       )}
     </CommandList>
   );
-}
-
-function isUser(user: User | Contact): user is User {
-  return "role" in user;
 }

--- a/kit/dapp/src/lib/api/index.ts
+++ b/kit/dapp/src/lib/api/index.ts
@@ -107,7 +107,12 @@ export const api = new Elysia({
       if (path && path.includes("/transaction/recent")) {
         return []; // Return empty array instead of error for transaction endpoints
       }
-
+      console.error(
+        "Caught Check is not defined error in:",
+        path,
+        "error stack:",
+        error.stack
+      );
       return elysiaStatus(500, "Transaction processing error");
     }
 

--- a/kit/dapp/src/lib/api/user.ts
+++ b/kit/dapp/src/lib/api/user.ts
@@ -120,7 +120,7 @@ export const UserApi = new Elysia({
         }),
       }),
       response: {
-        200: t.Union([t.Array(UserSchema), t.Array(ContactSchema)]),
+        200: t.Array(t.Union([UserSchema, ContactSchema])),
         ...defaultErrorSchema,
       },
     }

--- a/kit/dapp/src/lib/queries/user/user-count.ts
+++ b/kit/dapp/src/lib/queries/user/user-count.ts
@@ -58,14 +58,14 @@ export type UserCountResult = {
  * @param users - Array of users with creation timestamps
  * @returns Array of daily cumulative user counts
  */
-function calculateCumulativeUsersByDay(users: { created_at: Date }[]) {
+function calculateCumulativeUsersByDay(users: { createdAt: Date }[]) {
   if (!users.length) return [];
 
   const dailyCounts = new Map<string, number>();
 
   // Group users by day and find min/max dates
   users.forEach((user) => {
-    const date = new Date(user.created_at);
+    const date = new Date(user.createdAt);
     const dateStr = format(date, "yyyy-MM-dd");
 
     dailyCounts.set(dateStr, (dailyCounts.get(dateStr) || 0) + 1);

--- a/kit/dapp/src/lib/queries/user/user-fragment.ts
+++ b/kit/dapp/src/lib/queries/user/user-fragment.ts
@@ -21,14 +21,14 @@ export const UserFragment = hasuraGraphql(`
     name
     email
     wallet
-    created_at
-    updated_at
-    kyc_verified_at
+    createdAt: created_at
+    updatedAt: updated_at
+    kycVerifiedAt: kyc_verified_at
     role
     banned
-    ban_reason
-    ban_expires
-    last_login_at
+    banReason: ban_reason
+    banExpires: ban_expires
+    lastLoginAt: last_login_at
     image
     currency
   }

--- a/kit/dapp/src/lib/queries/user/user-schema.ts
+++ b/kit/dapp/src/lib/queries/user/user-schema.ts
@@ -21,46 +21,64 @@ export const UserSchema = t.Object(
     wallet: t.EthereumAddress({
       description: "The Ethereum wallet address of the user",
     }),
-    created_at: t.Timestamp({
-      description: "The timestamp when the user was created",
-    }),
-    updated_at: t.MaybeEmpty(
-      t.Timestamp({
-        description: "The timestamp when the user was last updated",
-      })
+    created_at: t.Optional(
+      t.MaybeEmpty(
+        t.Timestamp({
+          description: "The timestamp when the user was created",
+        })
+      )
     ),
-    kyc_verified_at: t.MaybeEmpty(
-      t.Timestamp({
-        description: "The timestamp when the user's KYC was verified",
-      })
+    updated_at: t.Optional(
+      t.MaybeEmpty(
+        t.Timestamp({
+          description: "The timestamp when the user was last updated",
+        })
+      )
+    ),
+    kyc_verified_at: t.Optional(
+      t.MaybeEmpty(
+        t.Timestamp({
+          description: "The timestamp when the user's KYC was verified",
+        })
+      )
     ),
     role: t.UserRoles({
       description: "The role of the user in the system",
     }),
-    banned: t.MaybeEmpty(
-      t.Boolean({
-        description: "Whether the user is banned from the platform",
-      })
+    banned: t.Optional(
+      t.MaybeEmpty(
+        t.Boolean({
+          description: "Whether the user is banned from the platform",
+        })
+      )
     ),
-    ban_reason: t.MaybeEmpty(
-      t.String({
-        description: "The reason why the user was banned",
-      })
+    ban_reason: t.Optional(
+      t.MaybeEmpty(
+        t.String({
+          description: "The reason why the user was banned",
+        })
+      )
     ),
-    ban_expires: t.MaybeEmpty(
-      t.Timestamp({
-        description: "The timestamp when the user's ban expires",
-      })
+    ban_expires: t.Optional(
+      t.MaybeEmpty(
+        t.Timestamp({
+          description: "The timestamp when the user's ban expires",
+        })
+      )
     ),
     last_login_at: t.Optional(
-      t.Timestamp({
-        description: "The timestamp of the user's last login",
-      })
+      t.MaybeEmpty(
+        t.Timestamp({
+          description: "The timestamp of the user's last login",
+        })
+      )
     ),
-    image: t.MaybeEmpty(
-      t.String({
-        description: "The URL of the user's profile image",
-      })
+    image: t.Optional(
+      t.MaybeEmpty(
+        t.String({
+          description: "The URL of the user's profile image",
+        })
+      )
     ),
     currency: t.FiatCurrency({
       description: "The preferred currency of the user",
@@ -82,10 +100,12 @@ export const AccountSchema = t.Object(
       description: "The Ethereum address of the account",
     }),
     balancesCount: t.Optional(
-      t.StringifiedBigInt({
-        description:
-          "The number of token balances associated with this account",
-      })
+      t.MaybeEmpty(
+        t.StringifiedBigInt({
+          description:
+            "The number of token balances associated with this account",
+        })
+      )
     ),
     lastActivity: t.String({
       description: "The timestamp of the user's last activity",

--- a/kit/dapp/src/lib/queries/user/user-schema.ts
+++ b/kit/dapp/src/lib/queries/user/user-schema.ts
@@ -21,21 +21,17 @@ export const UserSchema = t.Object(
     wallet: t.EthereumAddress({
       description: "The Ethereum wallet address of the user",
     }),
-    created_at: t.Optional(
-      t.MaybeEmpty(
-        t.Timestamp({
-          description: "The timestamp when the user was created",
-        })
-      )
-    ),
-    updated_at: t.Optional(
+    createdAt: t.Timestamp({
+      description: "The timestamp when the user was created",
+    }),
+    updatedAt: t.Optional(
       t.MaybeEmpty(
         t.Timestamp({
           description: "The timestamp when the user was last updated",
         })
       )
     ),
-    kyc_verified_at: t.Optional(
+    kycVerifiedAt: t.Optional(
       t.MaybeEmpty(
         t.Timestamp({
           description: "The timestamp when the user's KYC was verified",
@@ -52,21 +48,21 @@ export const UserSchema = t.Object(
         })
       )
     ),
-    ban_reason: t.Optional(
+    banReason: t.Optional(
       t.MaybeEmpty(
         t.String({
           description: "The reason why the user was banned",
         })
       )
     ),
-    ban_expires: t.Optional(
+    banExpires: t.Optional(
       t.MaybeEmpty(
         t.Timestamp({
           description: "The timestamp when the user's ban expires",
         })
       )
     ),
-    last_login_at: t.Optional(
+    lastLoginAt: t.Optional(
       t.MaybeEmpty(
         t.Timestamp({
           description: "The timestamp of the user's last login",

--- a/kit/dapp/src/lib/queries/user/user-search.ts
+++ b/kit/dapp/src/lib/queries/user/user-search.ts
@@ -107,9 +107,21 @@ export const getUserSearch = withTracing(
     (User | Contact)[]
   > => {
     const user = ctx?.user ?? (await getUser());
-    if (user.role === "user") {
-      return getContactsList(user.id, searchTerm);
+
+    if (user.role !== "user") {
+      return getAllUsersSearch({ searchTerm, ctx: { user } });
     }
-    return getAllUsersSearch({ searchTerm, ctx: { user } });
+
+    const contacts = await getContactsList(user.id, searchTerm);
+    const includeCurrentUser =
+      user.wallet.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      searchTerm.toLowerCase().includes(user.wallet.toLowerCase()) ||
+      (user.name && user.name.toLowerCase().includes(searchTerm.toLowerCase()));
+
+    if (includeCurrentUser) {
+      return contacts.concat(user);
+    }
+
+    return contacts;
   }
 );


### PR DESCRIPTION
## Summary by Sourcery

Enable regular users to find themselves in user searches, make several user schema fields optional, unify the API response type for user search results, add error logging on API failures, and simplify the user form list logic.

Bug Fixes:
- Include the current user in contact searches when a regular user searches for their own identifier

Enhancements:
- Mark user fields like created_at, updated_at, kyc_verified_at, banned, ban_reason, ban_expires, last_login_at, image, and balancesCount as optional in the schema
- Change the user search API response schema to an array of a union type instead of a union of arrays
- Remove additional client-side role filtering in the form user list

Chores:
- Log errors for undefined checks in the API index handler before returning a 500 status