### PR TITLE
feat: add reserve audit document upload to form

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -628,16 +628,16 @@
       },
       "document-upload": {
         "accepted-format": "Accepted formats: {formats} (Max: {maxSize}MB)",
-        "add-document": "Add Document",
+        "add-document": "Add document",
         "cancel": "Cancel",
-        "choose-file": "Choose File",
-        "delete-document": "Delete Document",
+        "choose-file": "Choose file",
+        "delete-document": "Delete document",
         "document-description": "Description",
         "document-description-placeholder": "Brief description of the document",
-        "document-file": "Upload File",
-        "document-title": "Document Title",
+        "document-file": "Upload file",
+        "document-title": "Document title",
         "document-title-placeholder": "e.g. MiCA Compliance White Paper",
-        "document-type": "Document Type",
+        "document-type": "Document type",
         "file-too-large": "File is too large. Maximum size is {maxSize}MB.",
         "invalid-file-format": "Invalid file format. Only {formats} files are accepted.",
         "no-documents": "No documents have been uploaded yet",
@@ -645,7 +645,7 @@
         "select-document-type": "Select document type",
         "upload-document": "Upload",
         "upload-document-description": "Upload white papers, audit reports, and other compliance documents",
-        "upload-document-title": "Upload Document",
+        "upload-document-title": "Upload document",
         "uploading": "Uploading",
         "uploading-document": "Uploading..."
       },
@@ -2795,7 +2795,8 @@
                   "pending-review": "Pending review",
                   "under-investigation": "Under investigation",
                   "non-compliant": "Non-compliant"
-                }
+                },
+                "audit-documents": "Audit documents"
               }
             }
           }

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/regulations/mica/_components/reserve-status/edit-form/form.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/regulations/mica/_components/reserve-status/edit-form/form.tsx
@@ -30,7 +30,7 @@ export function ReserveForm({ address, config }: ReserveFormProps) {
   const steps = [
     <TokenTypeStep key="token-type" />,
     <Composition key="composition" />,
-    <AuditDetails key="audit-details" />,
+    <AuditDetails key="audit-details" config={config} />,
   ];
 
   return (

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/regulations/mica/_components/reserve-status/edit-form/steps/audit-details.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/regulations/mica/_components/reserve-status/edit-form/steps/audit-details.tsx
@@ -1,17 +1,82 @@
 "use client";
 
+import { uploadDocument } from "@/app/actions/upload-document";
+import { DocumentUploadDialog } from "@/components/blocks/asset-designer/components/document-upload-dialog";
+import type { UploadedDocument } from "@/components/blocks/asset-designer/types";
 import { FormStep } from "@/components/blocks/form/form-step";
 import { FormInput } from "@/components/blocks/form/inputs/form-input";
 import { FormSelect } from "@/components/blocks/form/inputs/form-select";
-import { ReserveComplianceStatus } from "@/lib/db/regulations/schema-mica-regulation-configs";
+import { FormLabel } from "@/components/ui/form";
+import { deleteFile } from "@/lib/actions/delete-file";
+import {
+  ReserveComplianceStatus,
+  type MicaRegulationConfig,
+} from "@/lib/db/regulations/schema-mica-regulation-configs";
 import { useTranslations } from "next-intl";
+import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
-export function AuditDetails() {
+export function AuditDetails({ config }: { config: MicaRegulationConfig }) {
   const t = useTranslations(
     "regulations.mica.dashboard.reserve-status.form.fields.audit-details"
   );
+  const docsT = useTranslations("components.form.document-upload");
   const form = useFormContext();
+  const [uploadedDocuments, setUploadedDocuments] = useState<{
+    [regulationId: string]: UploadedDocument[];
+  }>({});
+  const [showUploadDialog, setShowUploadDialog] = useState(false);
+
+  const handleDocumentUploaded = (
+    regulationId: string,
+    document: UploadedDocument
+  ) => {
+    setUploadedDocuments((prev) => ({
+      ...prev,
+      [regulationId]: [...(prev[regulationId] || []), document],
+    }));
+  };
+
+  const handleDeleteDocument = async (
+    regulationId: string,
+    documentId: string
+  ) => {
+    // Find the document to delete
+    const docToDelete = uploadedDocuments[regulationId]?.find(
+      (doc) => doc.id === documentId
+    );
+
+    if (!docToDelete) {
+      console.error(
+        `Document with ID ${documentId} not found for regulation ${regulationId}`
+      );
+      return;
+    }
+
+    try {
+      // Call our enhanced deleteFile function to delete from MinIO
+      if (docToDelete.objectName) {
+        // Try to delete with both the objectName and possible variations
+        const result = await deleteFile(docToDelete.objectName);
+
+        if (!result.success && docToDelete.type === "mica") {
+          // Try the specific MiCA path if the first attempt failed
+          const micaPath = `regulations/mica/${docToDelete.fileName || ""}`;
+          await deleteFile(micaPath);
+        }
+      }
+
+      // Update local state
+      setUploadedDocuments((prev) => ({
+        ...prev,
+        [regulationId]: prev[regulationId].filter(
+          (doc) => doc.id !== documentId
+        ),
+      }));
+    } catch (error) {
+      console.error("Error deleting document from MinIO:", error);
+    }
+  };
 
   return (
     <FormStep
@@ -53,6 +118,57 @@ export function AuditDetails() {
           },
         ]}
       />
+
+      <div className="mt-4">
+        <div className="flex justify-between items-center mb-2">
+          <FormLabel>{t("audit-documents")}</FormLabel>
+          <button
+            type="button"
+            onClick={() => setShowUploadDialog(true)}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 text-xs px-3 py-1.5 rounded-md"
+          >
+            {docsT("add-document")}
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          {uploadedDocuments[config.id]?.length > 0 ? (
+            uploadedDocuments[config.id].map((document) => (
+              <div
+                key={document.id}
+                className="bg-muted/30 p-3 rounded-md flex items-center justify-between"
+              >
+                <div>
+                  <span className="font-medium text-sm">{document.title}</span>
+                  <p className="text-xs text-muted-foreground">
+                    {document.type}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleDeleteDocument(config.id, document.id)}
+                  className="text-destructive hover:text-destructive/80 flex items-center gap-1 text-xs"
+                >
+                  {docsT("delete-document")}
+                </button>
+              </div>
+            ))
+          ) : (
+            <p className="text-xs text-muted-foreground italic">
+              {docsT("no-documents")}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {showUploadDialog && (
+        <DocumentUploadDialog
+          regulationId={config.id}
+          onClose={() => setShowUploadDialog(false)}
+          onUpload={handleDocumentUploaded}
+          uploadAction={uploadDocument}
+        />
+      )}
     </FormStep>
   );
 }

--- a/kit/dapp/src/components/blocks/asset-designer/components/document-upload-dialog.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/components/document-upload-dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { MicaDocumentType } from "@/lib/db/regulations/schema-mica-regulation-configs";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
 import type { UploadedDocument } from "../types";
@@ -20,9 +22,12 @@ export function DocumentUploadDialog({
   onUpload,
   uploadAction,
 }: DocumentUploadDialogProps) {
+  const t = useTranslations("regulations.mica.documents.types");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [documentTitle, setDocumentTitle] = useState<string>("");
-  const [documentType, setDocumentType] = useState<string>("");
+  const [documentType, setDocumentType] = useState<MicaDocumentType>(
+    MicaDocumentType.AUDIT
+  );
   const [documentDescription, setDocumentDescription] = useState<string>("");
   const [isUploading, setIsUploading] = useState(false);
 
@@ -63,9 +68,8 @@ export function DocumentUploadDialog({
       // Create form data for upload
       const formData = new FormData();
       formData.append("file", selectedFile);
-      // Add required fields that uploadDocument expects
       formData.append("title", documentTitle);
-      formData.append("type", documentType || "Other");
+      formData.append("type", documentType);
       formData.append("description", documentDescription || "");
 
       // Use the server action to upload the file with the regulation ID as path
@@ -76,7 +80,7 @@ export function DocumentUploadDialog({
       const newDocument: UploadedDocument = {
         id: result.id,
         name: selectedFile.name,
-        title: documentTitle || selectedFile.name,
+        title: documentTitle,
         type: documentType,
         description: documentDescription,
         url: result.url,
@@ -163,17 +167,21 @@ export function DocumentUploadDialog({
               id="document-type"
               className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               value={documentType}
-              onChange={(e) => setDocumentType(e.target.value)}
+              onChange={(e) =>
+                setDocumentType(e.target.value as MicaDocumentType)
+              }
             >
-              <option value="" disabled>
-                Select document type
+              <option value={MicaDocumentType.WHITE_PAPER}>
+                {t("white_paper")}
               </option>
-              <option value="Compliance">Compliance</option>
-              <option value="Legal">Legal</option>
-              <option value="Financial">Financial</option>
-              <option value="Audit">Audit</option>
-              <option value="Whitepaper">Whitepaper</option>
-              <option value="Other">Other</option>
+              <option value={MicaDocumentType.AUDIT}>{t("audit")}</option>
+              <option value={MicaDocumentType.POLICY}>{t("policy")}</option>
+              <option value={MicaDocumentType.GOVERNANCE}>
+                {t("governance")}
+              </option>
+              <option value={MicaDocumentType.PROCEDURE}>
+                {t("procedure")}
+              </option>
             </select>
           </div>
 

--- a/kit/dapp/src/components/blocks/asset-designer/types.ts
+++ b/kit/dapp/src/components/blocks/asset-designer/types.ts
@@ -1,3 +1,4 @@
+import { MicaDocumentType } from "@/lib/db/regulations/schema-mica-regulation-configs";
 import { AssetType } from "@/lib/utils/typebox/asset-types";
 import { useTranslations } from "next-intl";
 
@@ -62,10 +63,10 @@ export interface UploadedDocument {
   id: string;
   name: string;
   title: string;
-  type: string;
+  type: MicaDocumentType;
   description: string;
-  url?: string;
-  objectName?: string; // Path in MinIO storage
+  url: string;
+  objectName: string; // Path in MinIO storage
   fileName?: string; // Original file name
 }
 

--- a/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-action.ts
+++ b/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-action.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { action } from "@/lib/mutations/safe-action";
+import { t } from "@/lib/utils/typebox";
+import { updateDocumentsFunction } from "./update-documents-function";
+import { UpdateDocumentsSchema } from "./update-documents-schema";
+
+export const updateDocuments = action
+  .schema(UpdateDocumentsSchema())
+  .outputSchema(t.Hashes())
+  .action(updateDocumentsFunction);

--- a/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-function.ts
+++ b/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-function.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import type { User } from "@/lib/auth/types";
+import { hasuraClient, hasuraGraphql } from "@/lib/settlemint/hasura";
+import { withAccessControl } from "@/lib/utils/access-control";
+import { safeParse, t } from "@/lib/utils/typebox";
+import type { UpdateDocumentsInput } from "./update-documents-schema";
+
+// GraphQL mutation for updating MICA documents
+const UpdateMicaDocuments = hasuraGraphql(`
+  mutation UpdateMicaDocuments(
+    $id: String!
+    $documents: jsonb!
+  ) {
+    update_mica_regulation_configs_by_pk(
+      pk_columns: { id: $id }
+      _set: {
+        documents: $documents
+      }
+    ) {
+      id
+      documents
+    }
+  }
+`);
+
+export const updateDocumentsFunction = withAccessControl(
+  {
+    requiredPermissions: {
+      asset: ["manage"],
+    },
+  },
+  async ({
+    parsedInput,
+  }: {
+    parsedInput: UpdateDocumentsInput;
+    ctx: { user: User };
+  }) => {
+    try {
+      const result = await hasuraClient.request(UpdateMicaDocuments, {
+        id: parsedInput.regulationId,
+        documents: JSON.stringify(parsedInput.documents),
+      });
+
+      if (!result.update_mica_regulation_configs_by_pk) {
+        throw new Error("Failed to update MICA documents");
+      }
+
+      return safeParse(t.Hashes(), []);
+    } catch (error) {
+      console.error("Error updating MICA documents:", error);
+      throw error;
+    }
+  }
+);

--- a/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-function.ts
+++ b/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-function.ts
@@ -1,10 +1,24 @@
 "use server";
 
+import { deleteFile } from "@/lib/actions/delete-file";
 import type { User } from "@/lib/auth/types";
 import { hasuraClient, hasuraGraphql } from "@/lib/settlemint/hasura";
 import { withAccessControl } from "@/lib/utils/access-control";
 import { safeParse, t } from "@/lib/utils/typebox";
-import type { UpdateDocumentsInput } from "./update-documents-schema";
+import {
+  DocumentOperation,
+  type MicaDocumentInput,
+  type UpdateDocumentsInput,
+} from "./update-documents-schema";
+
+// GraphQL query to get current documents
+const GetMicaDocuments = hasuraGraphql(`
+  query GetMicaDocuments($id: String!) {
+    mica_regulation_configs_by_pk(id: $id) {
+      documents
+    }
+  }
+`);
 
 // GraphQL mutation for updating MICA documents
 const UpdateMicaDocuments = hasuraGraphql(`
@@ -37,9 +51,62 @@ export const updateDocumentsFunction = withAccessControl(
     ctx: { user: User };
   }) => {
     try {
+      // Get current documents
+      const currentResult = await hasuraClient.request(GetMicaDocuments, {
+        id: parsedInput.regulationId,
+      });
+
+      // Parse the documents from JSON string, handling potential double encoding
+      let currentDocuments: MicaDocumentInput[] = [];
+      try {
+        const rawDocuments =
+          currentResult.mica_regulation_configs_by_pk?.documents;
+        if (rawDocuments) {
+          // Handle potential double encoding
+          const parsedDocs =
+            typeof rawDocuments === "string"
+              ? JSON.parse(rawDocuments)
+              : rawDocuments;
+          currentDocuments = Array.isArray(parsedDocs) ? parsedDocs : [];
+        }
+      } catch (error) {
+        console.error("Error parsing documents:", error);
+        currentDocuments = [];
+      }
+
+      let updatedDocuments: MicaDocumentInput[];
+      switch (parsedInput.operation) {
+        case DocumentOperation.ADD:
+          // Add new document to the list
+          updatedDocuments = [...currentDocuments, parsedInput.document];
+          break;
+
+        case DocumentOperation.DELETE:
+          // Remove document from the list
+          updatedDocuments = currentDocuments.filter((doc) => {
+            const matches = doc.id !== parsedInput.document.id;
+            return matches;
+          });
+
+          // Delete the file from storage if it exists
+          if (parsedInput.document.url) {
+            try {
+              await deleteFile(parsedInput.document.url);
+            } catch (error) {
+              console.error("Error deleting file:", error);
+              // Continue with document deletion even if file deletion fails
+            }
+          }
+          break;
+
+        default:
+          throw new Error(`Invalid operation: ${parsedInput.operation}`);
+      }
+
+      // Update documents in database
       const result = await hasuraClient.request(UpdateMicaDocuments, {
         id: parsedInput.regulationId,
-        documents: JSON.stringify(parsedInput.documents),
+        documents: JSON.stringify(updatedDocuments),
       });
 
       if (!result.update_mica_regulation_configs_by_pk) {

--- a/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-schema.ts
+++ b/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-schema.ts
@@ -29,11 +29,23 @@ const DocumentSchema = t.Object(
   { $id: "MicaDocument" }
 );
 
+export const DocumentOperation = {
+  ADD: "add",
+  DELETE: "delete",
+} as const;
+
+export type DocumentOperation =
+  (typeof DocumentOperation)[keyof typeof DocumentOperation];
+
 export function UpdateDocumentsSchema() {
   return t.Object(
     {
       regulationId: t.String(),
-      documents: t.Array(DocumentSchema),
+      operation: t.Union([
+        t.Literal(DocumentOperation.ADD),
+        t.Literal(DocumentOperation.DELETE),
+      ]),
+      document: DocumentSchema,
     },
     { $id: "UpdateDocuments" }
   );

--- a/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-schema.ts
+++ b/kit/dapp/src/lib/mutations/regulations/mica/update-documents/update-documents-schema.ts
@@ -1,0 +1,47 @@
+import {
+  DocumentStatus,
+  MicaDocumentType,
+} from "@/lib/db/regulations/schema-mica-regulation-configs";
+import { type StaticDecode, t } from "@/lib/utils/typebox";
+
+const DocumentSchema = t.Object(
+  {
+    id: t.String(),
+    title: t.String(),
+    type: t.Union([
+      t.Literal(MicaDocumentType.WHITE_PAPER),
+      t.Literal(MicaDocumentType.AUDIT),
+      t.Literal(MicaDocumentType.POLICY),
+      t.Literal(MicaDocumentType.GOVERNANCE),
+      t.Literal(MicaDocumentType.PROCEDURE),
+    ]),
+    url: t.String({
+      format: "uri",
+      error: "Must be a valid URL",
+    }),
+    status: t.Union([
+      t.Literal(DocumentStatus.PENDING),
+      t.Literal(DocumentStatus.APPROVED),
+      t.Literal(DocumentStatus.REJECTED),
+    ]),
+    description: t.Optional(t.String()),
+  },
+  { $id: "MicaDocument" }
+);
+
+export function UpdateDocumentsSchema() {
+  return t.Object(
+    {
+      regulationId: t.String(),
+      documents: t.Array(DocumentSchema),
+    },
+    { $id: "UpdateDocuments" }
+  );
+}
+
+export type UpdateDocumentsInput = StaticDecode<
+  ReturnType<typeof UpdateDocumentsSchema>
+>;
+
+// Export the document schema for reuse if needed
+export type MicaDocumentInput = StaticDecode<typeof DocumentSchema>;


### PR DESCRIPTION
![Screenshot 2025-05-23 at 11 49 16](https://github.com/user-attachments/assets/e9959fdf-8764-47b6-acce-fddd09090c39)

## Summary by Sourcery

Enable upload and management of reserve audit documents in the MICA reserve status form and enhance the reserve status page to display dynamic reserve metrics.

New Features:
- Add audit document upload and deletion in the reserve status form via a server-backed DocumentUploadDialog
- Introduce updateDocuments server action and GraphQL mutation to persist MICA regulation documents
- Fetch and transform MICA regulation configuration and asset details for use in form defaults and layout props
- Add ReserveRatio, ReserveComposition, and ReserveDetails components to visualize reserve metrics and audit data

Enhancements:
- Refactor ReserveForm to derive default values from fetched config and consolidate form steps into a dynamic array
- Extend GraphQL queries and schemas to include totalSupply, collateral, and collateralRatio, and enforce lowercase asset IDs for consistency

Chores:
- Update asset user fragments and queries to parse snake_case responses into camelCase
- Improve utility functions for date formatting and configuration transformation