### PR TITLE
fix: offchain asset create mutations

### DIFF
--- a/kit/dapp/src/lib/mutations/bond/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/bond/create/create-function.ts
@@ -48,7 +48,7 @@ const BondFactoryCreate = portalGraphql(`
  */
 const CreateOffchainBond = hasuraGraphql(`
   mutation CreateOffchainBond($id: String!, $isin: String, $internalid: String) {
-    insert_asset_one(object: {id: $id, isin: $isin, internalid: $internalid}) {
+    insert_asset_one(object: {id: $id, isin: $isin, internalid: $internalid}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
       id
     }
   }

--- a/kit/dapp/src/lib/mutations/cryptocurrency/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/cryptocurrency/create/create-function.ts
@@ -45,8 +45,8 @@ const CryptoCurrencyFactoryCreate = portalGraphql(`
  * Stores additional metadata about the cryptocurrency in Hasura
  */
 const CreateOffchainCryptoCurrency = hasuraGraphql(`
-  mutation CreateOffchainCryptoCurrency($id: String!) {
-    insert_asset_one(object: {id: $id}) {
+  mutation CreateOffchainCryptoCurrency($id: String!, $isin: String, $internalid: String) {
+    insert_asset_one(object: {id: $id, isin: $isin, internalid: $internalid}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
       id
     }
   }

--- a/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
@@ -45,8 +45,8 @@ const DepositFactoryCreate = portalGraphql(`
  * Stores additional metadata about the tokenized deposit in Hasura
  */
 const CreateOffchainDeposit = hasuraGraphql(`
-  mutation CreateOffchainDeposit($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
+  mutation CreateOffchainDeposit($id: String!, $isin: String, $internalid: String) {
+    insert_asset_one(object: {id: $id, isin: $isin, internalid: $internalid}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
       id
     }
   }

--- a/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/deposit/create/create-function.ts
@@ -46,7 +46,7 @@ const DepositFactoryCreate = portalGraphql(`
  */
 const CreateOffchainDeposit = hasuraGraphql(`
   mutation CreateOffchainDeposit($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
       id
     }
   }

--- a/kit/dapp/src/lib/mutations/equity/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-function.ts
@@ -45,7 +45,7 @@ const EquityFactoryCreate = portalGraphql(`
  */
 const CreateOffchainEquity = hasuraGraphql(`
     mutation CreateOffchainEquity($id: String!, $isin: String) {
-      insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+      insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
         id
       }
   }

--- a/kit/dapp/src/lib/mutations/equity/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/equity/create/create-function.ts
@@ -44,8 +44,8 @@ const EquityFactoryCreate = portalGraphql(`
  * Stores additional metadata about the equity in Hasura
  */
 const CreateOffchainEquity = hasuraGraphql(`
-    mutation CreateOffchainEquity($id: String!, $isin: String) {
-      insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
+    mutation CreateOffchainEquity($id: String!, $isin: String, $internalid: String) {
+      insert_asset_one(object: {id: $id, isin: $isin, internalid: $internalid}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
         id
       }
   }

--- a/kit/dapp/src/lib/mutations/fund/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-function.ts
@@ -43,8 +43,8 @@ const FundFactoryCreate = portalGraphql(`
  * Stores additional metadata about the fund in Hasura
  */
 const CreateOffchainFund = hasuraGraphql(`
-  mutation CreateOffchainFund($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
+  mutation CreateOffchainFund($id: String!, $isin: String, $internalid: String) {
+    insert_asset_one(object: {id: $id, isin: $isin, internalid: $internalid}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
       id
       isin
     }

--- a/kit/dapp/src/lib/mutations/fund/create/create-function.ts
+++ b/kit/dapp/src/lib/mutations/fund/create/create-function.ts
@@ -44,7 +44,7 @@ const FundFactoryCreate = portalGraphql(`
  */
 const CreateOffchainFund = hasuraGraphql(`
   mutation CreateOffchainFund($id: String!, $isin: String) {
-    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: isin}) {
+    insert_asset_one(object: {id: $id, isin: $isin}, on_conflict: {constraint: asset_pkey, update_columns: [isin, internalid]}) {
       id
       isin
     }


### PR DESCRIPTION
## Summary by Sourcery

Enable upserts for offchain asset creation mutations by adding on_conflict clauses and including isin and internalid fields to ensure metadata is updated on primary key conflicts.

Enhancements:
- Extend cryptocurrency and bond create mutations to accept isin and internalid parameters and upsert them on conflict
- Include internalid in the conflict update_columns for deposit, equity, and fund create mutations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asset creation processes to support updating both ISIN and internal ID fields when a duplicate asset is detected, improving data accuracy and consistency.
- **Bug Fixes**
	- Improved conflict handling during asset creation to prevent duplicate entries and ensure asset metadata is kept up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->