### PR TITLE
fix: disable mica on deposits

### DIFF
--- a/kit/dapp/src/app/[locale]/(private)/_components/detail-page-header.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/_components/detail-page-header.tsx
@@ -1,4 +1,4 @@
-import { hasMica } from "@/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled";
+import { isMicaEnabledForAsset } from "@/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled";
 import { ActivePill } from "@/components/blocks/active-pill/active-pill";
 import { EvmAddress } from "@/components/blocks/evm-address/evm-address";
 import { EvmAddressBalances } from "@/components/blocks/evm-address/evm-address-balances";
@@ -80,7 +80,7 @@ export async function DetailPageHeader({
         })
       : null;
 
-  const isMicaEnabled = await hasMica(assettype, address);
+  const isMicaEnabled = await isMicaEnabledForAsset(assettype, address);
   const regulationPills = isMicaEnabled
     ? await getRegulationPills(address)
     : [];

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/asset-tabs.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/asset-tabs.tsx
@@ -9,9 +9,9 @@ import { BadgeLoader, BadgeSpinner } from "./badge-loader"; // Assuming badge-lo
 import {
   hasAllowlist,
   hasBlocklist,
-  hasMica,
   hasUnderlyingAsset,
   hasYield,
+  isMicaEnabledForAsset,
 } from "./features-enabled";
 
 interface AssetTabsProps {
@@ -32,7 +32,7 @@ const tabs = async ({
 
   let isMicaEnabled = false; // Default to false to hide the tab in case of error
   try {
-    isMicaEnabled = await hasMica(assettype, address);
+    isMicaEnabled = await isMicaEnabledForAsset(assettype, address);
   } catch (error) {
     console.error("Failed to check MICA availability:", error);
   }

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled.ts
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled.ts
@@ -22,14 +22,17 @@ export const hasFreeze = (assettype: AssetType) =>
  * @param assetId The ID of the asset to check
  * @returns True if MICA is available and enabled for this asset
  */
-export const hasMica = async (assettype: AssetType, assetId: Address) => {
-  const flagEnabled = await isFeatureEnabled("mica");
-  if (!flagEnabled) {
+export const isMicaEnabledForAsset = async (
+  assettype: AssetType,
+  assetId: Address
+) => {
+  const isAvailable = assettype === "stablecoin";
+  if (!isAvailable) {
     return false;
   }
 
-  const isAvailable = assettype === "stablecoin";
-  if (!isAvailable) {
+  const isFeatureFlagEnabled = await isFeatureEnabled("mica");
+  if (!isFeatureFlagEnabled) {
     return false;
   }
 

--- a/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled.ts
+++ b/kit/dapp/src/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled.ts
@@ -28,7 +28,7 @@ export const hasMica = async (assettype: AssetType, assetId: Address) => {
     return false;
   }
 
-  const isAvailable = assettype === "deposit" || assettype === "stablecoin";
+  const isAvailable = assettype === "stablecoin";
   if (!isAvailable) {
     return false;
   }

--- a/kit/dapp/src/app/[locale]/(private)/portfolio/my-assets/[assettype]/[address]/_components/asset-tabs.tsx
+++ b/kit/dapp/src/app/[locale]/(private)/portfolio/my-assets/[assettype]/[address]/_components/asset-tabs.tsx
@@ -1,4 +1,4 @@
-import { hasMica } from "@/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled";
+import { isMicaEnabledForAsset } from "@/app/[locale]/(private)/assets/[assettype]/[address]/_components/features-enabled";
 import type { TabItemProps } from "@/components/blocks/tab-navigation/tab-item";
 import { TabNavigation } from "@/components/blocks/tab-navigation/tab-navigation";
 import type { AssetType } from "@/lib/utils/typebox/asset-types";
@@ -24,7 +24,7 @@ const tabs = async ({
 
   let isMicaEnabled = false; // Default to false to hide the tab in case of error
   try {
-    isMicaEnabled = await hasMica(assettype, address);
+    isMicaEnabled = await isMicaEnabledForAsset(assettype, address);
   } catch (error) {
     console.error("Failed to check MICA availability:", error);
   }

--- a/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
@@ -38,11 +38,7 @@ export function AssetDesignerDialog({
 
   // Check if MICA feature flag is enabled
   const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  // Always enable MiCA in development mode, regardless of PostHog configuration
-  const isMicaEnabled =
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === undefined
-      ? true
-      : !!micaFlagFromPostHog;
+  const isMicaEnabled = !!micaFlagFromPostHog;
 
   // Create a unified representation of all steps, filtering out regulation step if MICA is disabled
   const allSteps: Step[] = useMemo(() => {

--- a/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
@@ -7,10 +7,10 @@ import {
   type Step,
 } from "@/components/blocks/step-wizard/step-wizard";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import type { AssetType } from "@/lib/utils/typebox/asset-types";
 import type { User } from "better-auth";
 import { useTranslations } from "next-intl";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AssetTypeSelection } from "./steps/asset-type-selection";
 import { assetForms, type AssetFormDefinition } from "./types";
@@ -37,8 +37,7 @@ export function AssetDesignerDialog({
     useState<React.ComponentType<any> | null>(null);
 
   // Check if MICA feature flag is enabled
-  const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  const isMicaEnabled = !!micaFlagFromPostHog;
+  const isMicaEnabled = isFeatureEnabled("mica");
 
   // Create a unified representation of all steps, filtering out regulation step if MICA is disabled
   const allSteps: Step[] = useMemo(() => {

--- a/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
+++ b/kit/dapp/src/components/blocks/asset-designer/asset-designer-dialog.tsx
@@ -7,7 +7,7 @@ import {
   type Step,
 } from "@/components/blocks/step-wizard/step-wizard";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { isFeatureEnabled } from "@/lib/utils/feature-flags";
+import { useFeatureEnabled } from "@/lib/hooks/use-feature-enabled";
 import type { AssetType } from "@/lib/utils/typebox/asset-types";
 import type { User } from "better-auth";
 import { useTranslations } from "next-intl";
@@ -36,8 +36,7 @@ export function AssetDesignerDialog({
   const [formComponent, setFormComponent] =
     useState<React.ComponentType<any> | null>(null);
 
-  // Check if MICA feature flag is enabled
-  const isMicaEnabled = isFeatureEnabled("mica");
+  const isMicaEnabled = useFeatureEnabled("mica");
 
   // Create a unified representation of all steps, filtering out regulation step if MICA is disabled
   const allSteps: Step[] = useMemo(() => {

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -7,7 +7,6 @@ import { CreateDepositSchema } from "@/lib/mutations/deposit/create/create-schem
 import { isAddressAvailable } from "@/lib/queries/deposit-factory/deposit-factory-address-available";
 import { getPredictedAddress } from "@/lib/queries/deposit-factory/deposit-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
-import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
@@ -57,7 +56,6 @@ export function CreateDepositForm({
   onOpenChange,
 }: CreateDepositFormProps) {
   const t = useTranslations("private.assets.create.form");
-  const isMicaEnabled = isFeatureEnabled("mica");
 
   // Create component instances for each step
   const BasicsComponent = basicsStep.component;
@@ -83,7 +81,7 @@ export function CreateDepositForm({
     );
 
     return baseSteps;
-  }, [userDetails, onPrevStep, onNextStep, isMicaEnabled]);
+  }, [userDetails, onPrevStep, onNextStep]);
 
   // Define step order and mapping
   const stepIdToIndex = useMemo(() => {

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -58,11 +58,7 @@ export function CreateDepositForm({
 }: CreateDepositFormProps) {
   const t = useTranslations("private.assets.create.form");
   const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  // Always enable MiCA in development mode, regardless of PostHog configuration
-  const isMicaEnabled =
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === undefined
-      ? true
-      : !!micaFlagFromPostHog;
+  const isMicaEnabled = !!micaFlagFromPostHog;
 
   // Create component instances for each step
   const BasicsComponent = basicsStep.component;

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -7,9 +7,9 @@ import { CreateDepositSchema } from "@/lib/mutations/deposit/create/create-schem
 import { isAddressAvailable } from "@/lib/queries/deposit-factory/deposit-factory-address-available";
 import { getPredictedAddress } from "@/lib/queries/deposit-factory/deposit-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
+import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 import type { AssetFormDefinition } from "../../asset-designer/types";
@@ -57,8 +57,7 @@ export function CreateDepositForm({
   onOpenChange,
 }: CreateDepositFormProps) {
   const t = useTranslations("private.assets.create.form");
-  const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  const isMicaEnabled = !!micaFlagFromPostHog;
+  const isMicaEnabled = isFeatureEnabled("mica");
 
   // Create component instances for each step
   const BasicsComponent = basicsStep.component;

--- a/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/deposit/form.tsx
@@ -10,7 +10,7 @@ import type { User } from "@/lib/queries/user/user-schema";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
 import { useFeatureFlagEnabled } from "posthog-js/react";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 import type { AssetFormDefinition } from "../../asset-designer/types";
 import { stepDefinition as adminsStep } from "../common/asset-admins/asset-admins";
@@ -78,17 +78,6 @@ export function CreateDepositForm({
       <AdminsComponent key="admins" userDetails={userDetails} />,
     ];
 
-    // Only include regulation step if MICA is enabled
-    if (isMicaEnabled) {
-      baseSteps.push(
-        <RegulationStepWrapper
-          key="regulation"
-          onBack={onPrevStep}
-          onNext={onNextStep}
-        />
-      );
-    }
-
     baseSteps.push(
       <SummaryComponent
         key="summary"
@@ -103,25 +92,14 @@ export function CreateDepositForm({
 
   // Define step order and mapping
   const stepIdToIndex = useMemo(() => {
-    if (isMicaEnabled) {
-      const steps: Record<string, number> = {
-        details: 0,
-        configuration: 1,
-        admins: 2,
-        regulation: 3,
-        summary: 4,
-      };
-      return steps;
-    } else {
-      const steps: Record<string, number> = {
-        details: 0,
-        configuration: 1,
-        admins: 2,
-        summary: 3,
-      };
-      return steps;
-    }
-  }, [isMicaEnabled]);
+    const steps: Record<string, number> = {
+      details: 0,
+      configuration: 1,
+      admins: 2,
+      summary: 3,
+    };
+    return steps;
+  }, []);
 
   // Use the step synchronization hook
   const { isLastStep, onStepChange, onAnyFieldChange } = useFormStepSync({
@@ -130,13 +108,6 @@ export function CreateDepositForm({
     onNextStep,
     onPrevStep,
   });
-
-  // If MICA is disabled but the current step is regulation, redirect to summary
-  useEffect(() => {
-    if (!isMicaEnabled && currentStepId === "regulation") {
-      onNextStep();
-    }
-  }, [isMicaEnabled, currentStepId, onNextStep]);
 
   return (
     <Form
@@ -180,13 +151,7 @@ export function CreateDepositForm({
 CreateDepositForm.displayName = "CreateDepositForm";
 
 // Collect all the step definitions
-const depositSteps = [
-  basicsStep,
-  configurationStep,
-  adminsStep,
-  regulationStep,
-  summaryStep,
-];
+const depositSteps = [basicsStep, configurationStep, adminsStep, summaryStep];
 
 // Export form definition for the asset designer
 export const depositFormDefinition: AssetFormDefinition = {

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
@@ -30,10 +30,10 @@ import { CreateStablecoinSchema } from "@/lib/mutations/stablecoin/create/create
 import { isAddressAvailable } from "@/lib/queries/stablecoin-factory/stablecoin-factory-address-available";
 import { getPredictedAddress } from "@/lib/queries/stablecoin-factory/stablecoin-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
+import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import type { FiatCurrency } from "@/lib/utils/typebox/fiat-currency";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useEffect, useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 import type { AssetFormDefinition } from "../../asset-designer/types";
@@ -81,8 +81,7 @@ export function CreateStablecoinForm({
   onOpenChange,
 }: CreateStablecoinFormProps) {
   const t = useTranslations("private.assets.create.form");
-  const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  const isMicaEnabled = !!micaFlagFromPostHog;
+  const isMicaEnabled = isFeatureEnabled("mica");
 
   // Create component instances for each step
   const BasicsComponent = basicsStep.component;

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
@@ -82,11 +82,7 @@ export function CreateStablecoinForm({
 }: CreateStablecoinFormProps) {
   const t = useTranslations("private.assets.create.form");
   const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  // Always enable MiCA in development mode, regardless of PostHog configuration
-  const isMicaEnabled =
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === undefined
-      ? true
-      : !!micaFlagFromPostHog;
+  const isMicaEnabled = !!micaFlagFromPostHog;
 
   // Create component instances for each step
   const BasicsComponent = basicsStep.component;

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/form.tsx
@@ -24,13 +24,13 @@
  */
 
 import { Form } from "@/components/blocks/form/form";
+import { useFeatureEnabled } from "@/lib/hooks/use-feature-enabled";
 import { useFormStepSync } from "@/lib/hooks/use-form-step-sync";
 import { createStablecoin } from "@/lib/mutations/stablecoin/create/create-action";
 import { CreateStablecoinSchema } from "@/lib/mutations/stablecoin/create/create-schema";
 import { isAddressAvailable } from "@/lib/queries/stablecoin-factory/stablecoin-factory-address-available";
 import { getPredictedAddress } from "@/lib/queries/stablecoin-factory/stablecoin-factory-predict-address";
 import type { User } from "@/lib/queries/user/user-schema";
-import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import type { FiatCurrency } from "@/lib/utils/typebox/fiat-currency";
 import { typeboxResolver } from "@hookform/resolvers/typebox";
 import { useTranslations } from "next-intl";
@@ -81,7 +81,7 @@ export function CreateStablecoinForm({
   onOpenChange,
 }: CreateStablecoinFormProps) {
   const t = useTranslations("private.assets.create.form");
-  const isMicaEnabled = isFeatureEnabled("mica");
+  const isMicaEnabled = useFeatureEnabled("mica");
 
   // Create component instances for each step
   const BasicsComponent = basicsStep.component;

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/regulation.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/regulation.tsx
@@ -11,8 +11,8 @@ import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { deleteFile } from "@/lib/actions/delete-file";
 import { uploadDocument } from "@/lib/actions/upload-document";
+import { useFeatureEnabled } from "@/lib/hooks/use-feature-enabled";
 import { cn } from "@/lib/utils";
-import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import type { AssetType } from "@/lib/utils/typebox/asset-types";
 import { Check, Info, MapPin } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -442,7 +442,7 @@ export function AssetRegulationStep({
   const [uploadedDocuments, setUploadedDocuments] = useState<{
     [regulationId: string]: UploadedDocument[];
   }>({});
-  const isMicaEnabled = isFeatureEnabled("mica");
+  const isMicaEnabled = useFeatureEnabled("mica");
 
   // Initialize selectedRegulations if not already set
   useEffect(() => {

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/regulation.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/regulation.tsx
@@ -443,11 +443,7 @@ export function AssetRegulationStep({
     [regulationId: string]: UploadedDocument[];
   }>({});
   const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  // Always enable MiCA in development mode, regardless of PostHog configuration
-  const isMicaEnabled =
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === undefined
-      ? true
-      : !!micaFlagFromPostHog;
+  const isMicaEnabled = !!micaFlagFromPostHog;
 
   // Initialize selectedRegulations if not already set
   useEffect(() => {

--- a/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/regulation.tsx
+++ b/kit/dapp/src/components/blocks/create-forms/stablecoin/steps/regulation.tsx
@@ -12,10 +12,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { deleteFile } from "@/lib/actions/delete-file";
 import { uploadDocument } from "@/lib/actions/upload-document";
 import { cn } from "@/lib/utils";
+import { isFeatureEnabled } from "@/lib/utils/feature-flags";
 import type { AssetType } from "@/lib/utils/typebox/asset-types";
 import { Check, Info, MapPin } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useEffect, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
@@ -442,8 +442,7 @@ export function AssetRegulationStep({
   const [uploadedDocuments, setUploadedDocuments] = useState<{
     [regulationId: string]: UploadedDocument[];
   }>({});
-  const micaFlagFromPostHog = useFeatureFlagEnabled("mica");
-  const isMicaEnabled = !!micaFlagFromPostHog;
+  const isMicaEnabled = isFeatureEnabled("mica");
 
   // Initialize selectedRegulations if not already set
   useEffect(() => {

--- a/kit/dapp/src/lib/hooks/use-feature-enabled.ts
+++ b/kit/dapp/src/lib/hooks/use-feature-enabled.ts
@@ -1,0 +1,30 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * Client-side hook to check if a feature is enabled based on PostHog feature flags.
+ *
+ * This hook complements the server-side `isFeatureEnabled` utility in `@/lib/utils/feature-flags.ts`.
+ * While both serve similar purposes, they operate in different contexts:
+ *
+ * - This hook (use-feature-enabled.ts):
+ *   - Runs on the client-side in React components
+ *   - Uses PostHog's React hooks for real-time feature flag updates
+ *   - Suitable for client components marked with "use client"
+ *
+ * - Server utility (feature-flags.ts):
+ *   - Runs on the server-side in Server Components or API routes
+ *   - Uses PostHog's Node.js SDK
+ *   - Handles user authentication context for personalized flags
+ *
+ * Both implementations return true if PostHog is not configured (NEXT_PUBLIC_POSTHOG_KEY not set).
+ */
+export function useFeatureEnabled(featureKey: string): boolean {
+  const isEnabled = useFeatureFlagEnabled(featureKey) ?? false;
+
+  // If PostHog is not configured, feature flags are enabled
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    return true;
+  }
+
+  return isEnabled;
+}


### PR DESCRIPTION
## Summary by Sourcery

Disable MiCA on deposit assets and streamline feature flag logic by introducing a unified client hook, renaming the server util for asset-level gating, and removing deposit-specific MiCA workflows

New Features:
- Add useFeatureEnabled React hook for client-side PostHog feature flag checks

Enhancements:
- Remove MiCA regulation step and related gating from the deposit creation flow
- Simplify form step index mapping by dropping conditional MiCA dependency
- Replace hasMica with isMicaEnabledForAsset util that only enables MiCA for stablecoins and backed by the server-side feature flag
- Update asset-tabs and detail-page-header components to use the new isMicaEnabledForAsset util

Chores:
- Rename server-side hasMica function to isMicaEnabledForAsset and adjust its signature
- Remove legacy development-mode bypass and redundant PostHog feature-flag logic