### PR TITLE
fix: ordering for version

### DIFF
--- a/kit/charts/turbo.json
+++ b/kit/charts/turbo.json
@@ -10,7 +10,7 @@
     },
     "package": {
       "cache": false,
-      "dependsOn": ["package:push:ghcr", "package:push:harbor"]
+      "dependsOn": ["package:push:ghcr", "package:push:harbor", "//#version"]
     },
     "package:harbor": {
       "cache": false,


### PR DESCRIPTION
## Summary by Sourcery

Enhance the version update tooling to handle workspace dependencies, skip unnecessary files, optimize writes, and improve logging

Bug Fixes:
- Exclude package.json files under node_modules from version updates

Enhancements:
- Replace "workspace:*" dependency versions with the new version across all dependency fields
- Track and only write back package.json when actual version or workspace dependency changes occur
- Log per-package counts of updated workspace references and indicate when no changes were needed