### PR TITLE
fix: anvil config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,21 @@ services:
   anvil:
     image: ghcr.io/settlemint/btp-anvil-test-node:v7.7.5
     restart: always
+    # No Gas network
+    entrypoint:
+      [
+        "anvil",
+        "--host",
+        "0.0.0.0",
+        "--chain-id",
+        "31337",
+        "--gas-limit",
+        "5000000000000",
+        "--gas-price",
+        "0",
+        "--block-base-fee-per-gas",
+        "0",
+      ]
     ports:
       - "8545:8545" # Ethereum JSON-RPC
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Configure the anvil service entrypoint in docker-compose with host 0.0.0.0, chain ID 31337, high gas limit, zero gas price, and zero block base fee to run a no-gas network