### PR TITLE
fix: use Asset type for airdrop token

### DIFF
--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -509,7 +509,7 @@ type AirdropFactory @entity(immutable: false) {
 interface Airdrop {
   id: Bytes! # Contract address
   factory: AirdropFactory!
-  token: Bytes! # Changed from Asset! to Bytes!
+  token: Asset!
   merkleRoot: Bytes!
   owner: Account!
   deployedOn: BigInt!
@@ -525,7 +525,7 @@ interface Airdrop {
 type StandardAirdrop implements Airdrop @entity(immutable: false) {
   id: Bytes! # Contract address
   factory: AirdropFactory!
-  token: Bytes! # Matches interface
+  token: Asset! # Matches interface
   merkleRoot: Bytes!
   owner: Account!
   deployedOn: BigInt!
@@ -544,7 +544,7 @@ type StandardAirdrop implements Airdrop @entity(immutable: false) {
 type VestingAirdrop implements Airdrop @entity(immutable: false) {
   id: Bytes! # Contract address
   factory: AirdropFactory!
-  token: Bytes! # Matches interface
+  token: Asset! # Matches interface
   merkleRoot: Bytes!
   owner: Account!
   deployedOn: BigInt!
@@ -563,7 +563,7 @@ type VestingAirdrop implements Airdrop @entity(immutable: false) {
 type PushAirdrop implements Airdrop @entity(immutable: false) {
   id: Bytes! # Contract address
   factory: AirdropFactory!
-  token: Bytes! # Matches interface
+  token: Asset! # Matches interface
   merkleRoot: Bytes!
   owner: Account!
   deployedOn: BigInt!

--- a/kit/subgraph/src/factories/airdrop-factory.ts
+++ b/kit/subgraph/src/factories/airdrop-factory.ts
@@ -65,7 +65,7 @@ export function handleStandardAirdropDeployed(
   let owner = fetchAccount(ownerAddress);
 
   airdrop.factory = factoryEntity.id;
-  airdrop.token = tokenAddress; // Store token address directly (Bytes)
+  airdrop.token = tokenAddress;
   airdrop.owner = owner.id;
   airdrop.deployedOn = event.block.timestamp;
   airdrop.deploymentTx = event.transaction.hash;


### PR DESCRIPTION
## Summary by Sourcery

Standardize airdrop token handling by migrating to the new Asset type and replacing custom decimal logic with a shared utility

Enhancements:
- Use the unified fetchAssetDecimals utility for all token decimal lookups in airdrop handlers
- Remove the manual getTokenDecimals helper function
- Change the Airdrop.token field type from Bytes to Asset across the Graph schema
- Update factory event handlers to assign the token as an Asset instead of raw Bytes