### PR TITLE
fix: indexing of correct account address for events

### DIFF
--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -161,8 +161,8 @@ type Identity @entity(immutable: false) {
   id: Bytes!
   registry: IdentityRegistry
   claims: [IdentityClaim!]! @derivedFrom(field: "identity")
-  account: Account @derivedFrom(field: "identity")
-  token: Token @derivedFrom(field: "identity")
+  account: Account
+  token: Token
 }
 
 type IdentityClaim @entity(immutable: false) {

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -119,6 +119,7 @@ type TokenFactory @entity(immutable: false) {
 
 type Token @entity(immutable: false) {
   id: Bytes!
+  account: Account!
   accessControl: AccessControl
   identity: Identity
   balances: [TokenBalance!]! @derivedFrom(field: "token")

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -119,7 +119,6 @@ type TokenFactory @entity(immutable: false) {
 
 type Token @entity(immutable: false) {
   id: Bytes!
-  account: Account!
   accessControl: AccessControl
   identity: Identity
   balances: [TokenBalance!]! @derivedFrom(field: "token")
@@ -161,6 +160,7 @@ type Identity @entity(immutable: false) {
   id: Bytes!
   registry: IdentityRegistry
   claims: [IdentityClaim!]! @derivedFrom(field: "identity")
+  account: Account @derivedFrom(field: "identity")
   token: Token @derivedFrom(field: "identity")
 }
 
@@ -168,7 +168,7 @@ type IdentityClaim @entity(immutable: false) {
   id: Bytes!
   identity: Identity!
   name: String!
-  issuer: Account!
+  issuer: Identity!
   uri: String
   revoked: Boolean!
   values: [IdentityClaimValue!]! @derivedFrom(field: "claim")

--- a/kit/subgraph/src/collateral/utils/collateral-utils.ts
+++ b/kit/subgraph/src/collateral/utils/collateral-utils.ts
@@ -11,16 +11,14 @@ export function updateCollateral(collateralClaim: IdentityClaim): void {
   const identityAddress = Address.fromBytes(collateralClaim.identity);
 
   const identity = fetchIdentity(identityAddress);
-  const tokens = identity.token.load();
-  if (!tokens || tokens.length === 0) {
-    log.warning(`No tokens found for identity {}`, [
+  if (!identity.token) {
+    log.warning(`No token found for identity {}`, [
       identityAddress.toHexString(),
     ]);
     return;
   }
 
-  const token = tokens[0];
-  const collateral = fetchCollateral(Address.fromBytes(token.id));
+  const collateral = fetchCollateral(Address.fromBytes(identity.token!));
   collateral.identityClaim = collateralClaim.id;
 
   collateral.save();

--- a/kit/subgraph/src/event/fetch/event.ts
+++ b/kit/subgraph/src/event/fetch/event.ts
@@ -1,6 +1,7 @@
-import { Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
 import { Event, EventValue } from "../../../generated/schema";
 import { fetchAccount } from "../../account/fetch/account";
+import { fetchIdentity } from "../../identity/fetch/identity";
 
 export function convertEthereumValue(value: ethereum.Value): string {
   if (value.kind == ethereum.ValueKind.ADDRESS) {
@@ -44,7 +45,12 @@ export function fetchEvent(event: ethereum.Event, eventType: string): Event {
     return eventEntity;
   }
 
-  const emitter = fetchAccount(event.address);
+  const emitterIdentity = fetchIdentity(event.address);
+  const account = emitterIdentity.account.load();
+  const emitter =
+    account && account.length > 0
+      ? fetchAccount(Address.fromBytes(account[0].id))
+      : null;
   const txSender = fetchAccount(event.transaction.from);
 
   const entry = new Event(id);
@@ -53,14 +59,38 @@ export function fetchEvent(event: ethereum.Event, eventType: string): Event {
   entry.blockTimestamp = event.block.timestamp;
   entry.txIndex = event.transaction.index;
   entry.transactionHash = event.transaction.hash;
-  entry.emitter = emitter.id;
+  if (emitter) {
+    log.info(
+      "Emitter mapped for event '{}' with emitter '{}' and identity '{}'",
+      [eventType, emitter.id.toHexString(), emitterIdentity.id.toHexString()]
+    );
+    entry.emitter = emitter.id;
+  } else {
+    log.warning("No emitter found for event '{}' with identity '{}'", [
+      eventType,
+      emitterIdentity.id.toHexString(),
+    ]);
+    entry.emitter = txSender.id;
+  }
   entry.sender = txSender.id;
 
-  const involvedAccounts: Bytes[] = [txSender.id, emitter.id];
+  const involvedAccounts: Bytes[] = [txSender.id];
+  if (emitter) {
+    involvedAccounts.push(emitter.id);
+  }
 
   for (let i = 0; i < event.parameters.length; i++) {
     const param = event.parameters[i];
     if (param.value.kind == ethereum.ValueKind.ADDRESS) {
+      const isEmitterIdentity =
+        param.value.toAddress().toHexString() == event.address.toHexString();
+      if (isEmitterIdentity) {
+        log.info("Skipping emitter identity for event '{}' with id '{}'", [
+          eventType,
+          id.toHexString(),
+        ]);
+        continue;
+      }
       const address = fetchAccount(param.value.toAddress());
       if (param.name == "sender") {
         entry.sender = address.id;

--- a/kit/subgraph/src/event/fetch/event.ts
+++ b/kit/subgraph/src/event/fetch/event.ts
@@ -109,13 +109,11 @@ export function fetchEvent(event: ethereum.Event, eventType: string): Event {
 }
 
 function getAccount(address: Address): Account {
+  let accountAddress = address;
   // First check if the address is an existing identity
   const identity = Identity.load(address);
-  if (identity) {
-    const accounts = identity.account.load();
-    if (accounts && accounts.length > 0) {
-      return accounts[0];
-    }
+  if (identity && identity.account) {
+    accountAddress = Address.fromBytes(identity.account!);
   }
-  return fetchAccount(address);
+  return fetchAccount(accountAddress);
 }

--- a/kit/subgraph/src/identity-factory/identity-factory.ts
+++ b/kit/subgraph/src/identity-factory/identity-factory.ts
@@ -8,11 +8,12 @@ import { fetchIdentity } from "../identity/fetch/identity";
 import { fetchToken } from "../token/fetch/token";
 
 export function handleIdentityCreated(event: IdentityCreated): void {
-  fetchEvent(event, "IdentityCreated");
   const identity = fetchIdentity(event.params.identity);
   const account = fetchAccount(event.params.wallet);
   account.identity = identity.id;
   account.save();
+  // Put at the end as IdentityCreated event is needed to be processed first as the account needs to be set on the identity
+  fetchEvent(event, "IdentityCreated");
 }
 
 export function handleTokenIdentityCreated(event: TokenIdentityCreated): void {

--- a/kit/subgraph/src/identity-factory/identity-factory.ts
+++ b/kit/subgraph/src/identity-factory/identity-factory.ts
@@ -12,14 +12,17 @@ export function handleIdentityCreated(event: IdentityCreated): void {
   const account = fetchAccount(event.params.wallet);
   account.identity = identity.id;
   account.save();
-  // Put at the end as IdentityCreated event is needed to be processed first as the account needs to be set on the identity
+  // Record the event that created the identity for the account
+  // needs to be after creating the account as we map the involved accounts in the event
   fetchEvent(event, "IdentityCreated");
 }
 
 export function handleTokenIdentityCreated(event: TokenIdentityCreated): void {
-  fetchEvent(event, "TokenIdentityCreated");
   const identity = fetchIdentity(event.params.identity);
   const token = fetchToken(event.params.token);
   token.identity = identity.id;
   token.save();
+  // Record the event that created the identity for the account
+  // needs to be after creating the account as we map the involved accounts in the event
+  fetchEvent(event, "TokenIdentityCreated");
 }

--- a/kit/subgraph/src/identity-factory/identity-factory.ts
+++ b/kit/subgraph/src/identity-factory/identity-factory.ts
@@ -12,6 +12,8 @@ export function handleIdentityCreated(event: IdentityCreated): void {
   const account = fetchAccount(event.params.wallet);
   account.identity = identity.id;
   account.save();
+  identity.account = account.id;
+  identity.save();
   // Record the event that created the identity for the account
   // needs to be after creating the account as we map the involved accounts in the event
   fetchEvent(event, "IdentityCreated");
@@ -22,6 +24,8 @@ export function handleTokenIdentityCreated(event: TokenIdentityCreated): void {
   const token = fetchToken(event.params.token);
   token.identity = identity.id;
   token.save();
+  identity.token = token.id;
+  identity.save();
   // Record the event that created the identity for the account
   // needs to be after creating the account as we map the involved accounts in the event
   fetchEvent(event, "TokenIdentityCreated");

--- a/kit/subgraph/src/identity/identity.ts
+++ b/kit/subgraph/src/identity/identity.ts
@@ -9,7 +9,6 @@ import {
   KeyAdded,
   KeyRemoved,
 } from "../../generated/templates/Identity/Identity";
-import { fetchAccount } from "../account/fetch/account";
 import {
   isCollateralClaim,
   updateCollateral,
@@ -27,7 +26,7 @@ export function handleClaimAdded(event: ClaimAdded): void {
   fetchEvent(event, "ClaimAdded");
   const identity = fetchIdentity(event.address);
   const identityClaim = fetchIdentityClaim(identity, event.params.claimId);
-  identityClaim.issuer = fetchAccount(event.params.issuer).id;
+  identityClaim.issuer = fetchIdentity(event.params.issuer).id;
   identityClaim.uri = event.params.uri;
   identityClaim.save();
 
@@ -43,7 +42,7 @@ export function handleClaimChanged(event: ClaimChanged): void {
   fetchEvent(event, "ClaimChanged");
   const identity = fetchIdentity(event.address);
   const identityClaim = fetchIdentityClaim(identity, event.params.claimId);
-  identityClaim.issuer = fetchAccount(event.params.issuer).id;
+  identityClaim.issuer = fetchIdentity(event.params.issuer).id;
   identityClaim.uri = event.params.uri;
   identityClaim.save();
 

--- a/kit/subgraph/src/token/fetch/token.ts
+++ b/kit/subgraph/src/token/fetch/token.ts
@@ -5,7 +5,6 @@ import {
   Token as TokenTemplate,
 } from "../../../generated/templates";
 import { Token as TokenContract } from "../../../generated/templates/Token/Token";
-import { fetchAccount } from "../../account/fetch/account";
 import { fetchCollateral } from "../../collateral/fetch/collateral";
 import { fetchCustodian } from "../../custodian/fetch/custodian";
 import { InterfaceIds } from "../../erc165/utils/interfaceids";
@@ -17,7 +16,6 @@ export function fetchToken(address: Address): Token {
 
   if (!token) {
     token = new Token(address);
-    token.account = fetchAccount(address).id;
     token.type = "unknown";
 
     const tokenContract = TokenContract.bind(address);

--- a/kit/subgraph/src/token/fetch/token.ts
+++ b/kit/subgraph/src/token/fetch/token.ts
@@ -5,6 +5,7 @@ import {
   Token as TokenTemplate,
 } from "../../../generated/templates";
 import { Token as TokenContract } from "../../../generated/templates/Token/Token";
+import { fetchAccount } from "../../account/fetch/account";
 import { fetchCollateral } from "../../collateral/fetch/collateral";
 import { fetchCustodian } from "../../custodian/fetch/custodian";
 import { InterfaceIds } from "../../erc165/utils/interfaceids";
@@ -16,6 +17,7 @@ export function fetchToken(address: Address): Token {
 
   if (!token) {
     token = new Token(address);
+    token.account = fetchAccount(address).id;
     token.type = "unknown";
 
     const tokenContract = TokenContract.bind(address);


### PR DESCRIPTION
Identity and account addresses were being mixed up, this change ensures the account address is used in the events

## Summary by Sourcery

Ensure the events table records the correct account addresses by distinguishing identity and account entities and updating related mappings

Bug Fixes:
- Use a new getAccount helper to load the correct Account (falling back to Identity when applicable) instead of always using fetchAccount
- Change ClaimAdded and ClaimChanged handlers to assign the issuer as an Identity rather than an Account
- Remove the outdated account field on Token entities and no longer set it in fetchToken

Enhancements:
- Delay recording of IdentityCreated and TokenIdentityCreated events until after the associated accounts and tokens are created
- Update GraphQL schema to derive account on Identity and to use Identity for claim issuers instead of Account