### PR TITLE
feat: indexing of capped extension

### DIFF
--- a/kit/contracts/contracts/extensions/capped/ISMARTCapped.sol
+++ b/kit/contracts/contracts/extensions/capped/ISMARTCapped.sol
@@ -9,6 +9,11 @@ pragma solidity ^0.8.28;
 ///         and return types) but not *how* they are implemented. This allows other contracts or
 ///         off-chain applications to interact with any capped token in a standard way.
 interface ISMARTCapped {
+    /// @notice Emitted when the cap is set.
+    /// @param sender The address that set the cap.
+    /// @param cap The new cap.
+    event CapSet(address indexed sender, uint256 cap);
+
     /// @notice Returns the maximum allowed total supply for this token (the "cap").
     /// @dev This function provides a way to query the hard limit on the token's supply.
     ///      It is a `view` function, meaning it does not modify the contract's state and does not

--- a/kit/contracts/contracts/extensions/capped/internal/_SMARTCappedLogic.sol
+++ b/kit/contracts/contracts/extensions/capped/internal/_SMARTCappedLogic.sol
@@ -40,6 +40,7 @@ abstract contract _SMARTCappedLogic is _SMARTExtension, ISMARTCapped {
     ///      It sets the `_cap` state variable. It reverts with `SMARTInvalidCap` if `cap_` is 0,
     ///      as a cap of zero would render the token unusable (no tokens could be minted).
     ///      An "unchained" initializer doesn't call parent initializers, giving flexibility to the caller.
+    ///      Emits a `CapSet` event.
     /// @param cap_ The maximum total supply for the token. Must be greater than 0.
     function __SMARTCapped_init_unchained(uint256 cap_) internal {
         if (cap_ == 0) {
@@ -47,6 +48,7 @@ abstract contract _SMARTCappedLogic is _SMARTExtension, ISMARTCapped {
         }
         _cap = cap_;
         _registerInterface(type(ISMARTCapped).interfaceId); // Register interface for ERC165
+        emit ISMARTCapped.CapSet(_smartSender(), cap_);
     }
 
     /// @notice Returns the maximum allowed total supply for this token (the "cap").

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -132,6 +132,7 @@ type Token @entity(immutable: false) {
   totalSupplyExact: BigInt!
   pausable: TokenPausable
   collateral: TokenCollateral
+  capped: TokenCapped
 }
 
 type TokenBalance @entity(immutable: false) {
@@ -155,6 +156,12 @@ type TokenPausable @entity(immutable: false) {
 type TokenCollateral @entity(immutable: false) {
   id: Bytes!
   identityClaim: IdentityClaim
+}
+
+type TokenCapped @entity(immutable: false) {
+  id: Bytes!
+  cap: BigDecimal!
+  capExact: BigInt!
 }
 
 type Identity @entity(immutable: false) {

--- a/kit/subgraph/src/capped/capped.ts
+++ b/kit/subgraph/src/capped/capped.ts
@@ -1,0 +1,13 @@
+import { CapSet } from "../../generated/templates/Capped/Capped";
+import { fetchEvent } from "../event/fetch/event";
+import { fetchToken } from "../token/fetch/token";
+import { setBigNumber } from "../utils/bignumber";
+import { fetchCapped } from "./fetch/capped";
+
+export function handleCapSet(event: CapSet): void {
+  fetchEvent(event, "CapSet");
+  const token = fetchToken(event.address);
+  const capped = fetchCapped(event.address);
+  setBigNumber(capped, "cap", event.params.cap, token.decimals);
+  capped.save();
+}

--- a/kit/subgraph/src/capped/fetch/capped.ts
+++ b/kit/subgraph/src/capped/fetch/capped.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { TokenCapped } from "../../../generated/schema";
+import { Capped as CappedTemplate } from "../../../generated/templates";
 import { fetchToken } from "../../token/fetch/token";
 import { setBigNumber } from "../../utils/bignumber";
 
@@ -11,6 +12,7 @@ export function fetchCapped(address: Address): TokenCapped {
     const token = fetchToken(address);
     setBigNumber(capped, "cap", BigInt.zero(), token.decimals);
     capped.save();
+    CappedTemplate.create(address);
   }
 
   return capped;

--- a/kit/subgraph/src/capped/fetch/capped.ts
+++ b/kit/subgraph/src/capped/fetch/capped.ts
@@ -1,0 +1,17 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { TokenCapped } from "../../../generated/schema";
+import { fetchToken } from "../../token/fetch/token";
+import { setBigNumber } from "../../utils/bignumber";
+
+export function fetchCapped(address: Address): TokenCapped {
+  let capped = TokenCapped.load(address);
+
+  if (!capped) {
+    capped = new TokenCapped(address);
+    const token = fetchToken(address);
+    setBigNumber(capped, "cap", BigInt.zero(), token.decimals);
+    capped.save();
+  }
+
+  return capped;
+}

--- a/kit/subgraph/src/historical-balances/historical-balances.ts
+++ b/kit/subgraph/src/historical-balances/historical-balances.ts
@@ -1,8 +1,10 @@
 import { CheckpointUpdated } from "../../generated/templates/HistoricalBalances/HistoricalBalances";
+import { fetchEvent } from "../event/fetch/event";
 import { updateTokenBalanceValue } from "../token-balance/utils/token-balance-utils";
 import { fetchToken } from "../token/fetch/token";
 
 export function handleCheckpointUpdated(event: CheckpointUpdated): void {
+  fetchEvent(event, "CheckpointUpdated");
   const token = fetchToken(event.address);
   updateTokenBalanceValue(token, event.params.account, event.params.newBalance);
 }

--- a/kit/subgraph/src/token/fetch/token.ts
+++ b/kit/subgraph/src/token/fetch/token.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../generated/templates";
 import { Token as TokenContract } from "../../../generated/templates/Token/Token";
 import { fetchAccount } from "../../account/fetch/account";
+import { fetchCapped } from "../../capped/fetch/capped";
 import { fetchCollateral } from "../../collateral/fetch/collateral";
 import { fetchCustodian } from "../../custodian/fetch/custodian";
 import { InterfaceIds } from "../../erc165/utils/interfaceids";
@@ -46,6 +47,10 @@ export function fetchToken(address: Address): Token {
     }
     if (tokenContract.supportsInterface(InterfaceIds.ISMARTCollateral)) {
       token.collateral = fetchCollateral(address).id;
+      token.save();
+    }
+    if (tokenContract.supportsInterface(InterfaceIds.ISMARTCapped)) {
+      token.capped = fetchCapped(address).id;
       token.save();
     }
   }

--- a/kit/subgraph/subgraph.yaml
+++ b/kit/subgraph/subgraph.yaml
@@ -357,3 +357,21 @@ templates:
         - event: CheckpointUpdated(indexed address,indexed address,uint256,uint256)
           handler: handleCheckpointUpdated
       file: ./src/historical-balances/historical-balances.ts
+  - kind: ethereum
+    name: Capped
+    network: settlemint
+    source:
+      abi: Capped
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - CapSet
+      abis:
+        - name: Capped
+          file: ../contracts/artifacts/contracts/extensions/capped/ISMARTCapped.sol/ISMARTCapped.json
+      eventHandlers:
+        - event: CapSet(indexed address,uint256)
+          handler: handleCapSet
+      file: ./src/capped/capped.ts


### PR DESCRIPTION
## Summary by Sourcery

Introduce and index the capped token extension by defining a CapSet event, emitting it in the capped logic, extending the schema with a TokenCapped entity, and adding subgraph templates and mappings to capture cap changes. Also unify event fetching for checkpoint updates.

New Features:
- Define and emit a new CapSet event in the ISMARTCapped interface and capped logic initializer
- Add a TokenCapped entity to the schema and create a Capped subgraph template to index cap updates
- Extend the token fetcher to detect capped tokens and link them to TokenCapped entities
- Implement fetchCapped and handleCapSet mappings to initialize and update cap values on CapSet events

Enhancements:
- Invoke fetchEvent for CheckpointUpdated in historical-balances handler