### PR TITLE
feat: add ORPC service middleware for external service integration

### DIFF
--- a/kit/dapp/src/lib/orpc/middlewares/services/hasura.middleware.ts
+++ b/kit/dapp/src/lib/orpc/middlewares/services/hasura.middleware.ts
@@ -1,0 +1,33 @@
+import { br } from "@/lib/orpc/routes/procedures/base.router";
+import { hasuraClient } from "@/lib/settlemint/hasura";
+
+/**
+ * ORPC middleware that injects the Hasura GraphQL client into the procedure context.
+ * 
+ * This middleware ensures that all procedures have access to the Hasura client
+ * for executing GraphQL queries and mutations against the Hasura endpoint.
+ * 
+ * @remarks
+ * - Uses dependency injection pattern to allow overriding in tests
+ * - Falls back to the default hasuraClient if none provided in context
+ * - Essential for procedures that need to interact with Hasura's GraphQL API
+ * 
+ * @example
+ * ```typescript
+ * const myProcedure = pr
+ *   .use(hasuraMiddleware)
+ *   .query(async ({ context }) => {
+ *     // context.hasuraClient is now available
+ *     const result = await context.hasuraClient.query({...});
+ *   });
+ * ```
+ */
+export const hasuraMiddleware = br.middleware(async ({ context, next }) => {
+  return next({
+    context: {
+      // Use existing Hasura client if available (e.g., for testing),
+      // otherwise inject the default Hasura client instance
+      hasuraClient: context.hasuraClient ?? hasuraClient,
+    },
+  });
+});

--- a/kit/dapp/src/lib/orpc/middlewares/services/minio.middleware.ts
+++ b/kit/dapp/src/lib/orpc/middlewares/services/minio.middleware.ts
@@ -1,0 +1,33 @@
+import { br } from "@/lib/orpc/routes/procedures/base.router";
+import { client as minioClient } from "@/lib/settlemint/minio";
+
+/**
+ * ORPC middleware that injects the MinIO client into the procedure context.
+ * 
+ * This middleware provides access to MinIO object storage functionality,
+ * enabling procedures to upload, download, and manage files in S3-compatible storage.
+ * 
+ * @remarks
+ * - Uses dependency injection pattern to allow overriding in tests
+ * - Falls back to the default minioClient if none provided in context
+ * - Essential for procedures that handle file uploads, document storage, or media management
+ * 
+ * @example
+ * ```typescript
+ * const uploadProcedure = pr
+ *   .use(minioMiddleware)
+ *   .mutation(async ({ context, input }) => {
+ *     // context.minioClient is now available
+ *     await context.minioClient.putObject('bucket', 'file.pdf', buffer);
+ *   });
+ * ```
+ */
+export const minioMiddleware = br.middleware(async ({ context, next }) => {
+  return next({
+    context: {
+      // Use existing MinIO client if available (e.g., for testing),
+      // otherwise inject the default MinIO client instance
+      minioClient: context.minioClient ?? minioClient,
+    },
+  });
+});

--- a/kit/dapp/src/lib/orpc/middlewares/services/portal.middleware.ts
+++ b/kit/dapp/src/lib/orpc/middlewares/services/portal.middleware.ts
@@ -1,0 +1,33 @@
+import { br } from "@/lib/orpc/routes/procedures/base.router";
+import { portalClient } from "@/lib/settlemint/portal";
+
+/**
+ * ORPC middleware that injects the SettleMint Portal client into the procedure context.
+ * 
+ * This middleware enables procedures to interact with the SettleMint Portal API,
+ * providing access to platform-level services such as deployments, networks, and configurations.
+ * 
+ * @remarks
+ * - Uses dependency injection pattern to allow overriding in tests
+ * - Falls back to the default portalClient if none provided in context
+ * - Required for procedures that interact with SettleMint platform features
+ * 
+ * @example
+ * ```typescript
+ * const deploymentProcedure = pr
+ *   .use(portalMiddleware)
+ *   .query(async ({ context }) => {
+ *     // context.portalClient is now available
+ *     const deployments = await context.portalClient.getDeployments();
+ *   });
+ * ```
+ */
+export const portalMiddleware = br.middleware(async ({ context, next }) => {
+  return next({
+    context: {
+      // Use existing Portal client if available (e.g., for testing),
+      // otherwise inject the default Portal client instance
+      portalClient: context.portalClient ?? portalClient,
+    },
+  });
+});

--- a/kit/dapp/src/lib/orpc/middlewares/services/the-graph.middleware.ts
+++ b/kit/dapp/src/lib/orpc/middlewares/services/the-graph.middleware.ts
@@ -1,0 +1,45 @@
+import { br } from "@/lib/orpc/routes/procedures/base.router";
+import { theGraphClient } from "@/lib/settlemint/the-graph";
+
+/**
+ * ORPC middleware that injects The Graph client into the procedure context.
+ * 
+ * This middleware provides access to The Graph protocol for querying indexed blockchain data,
+ * enabling efficient retrieval of on-chain events, transactions, and state changes.
+ * 
+ * @remarks
+ * - Uses dependency injection pattern to allow overriding in tests
+ * - Falls back to the default theGraphClient if none provided in context
+ * - Essential for procedures that need to query historical blockchain data or events
+ * 
+ * @example
+ * ```typescript
+ * const tokenHistoryProcedure = pr
+ *   .use(theGraphMiddleware)
+ *   .query(async ({ context, input }) => {
+ *     // context.theGraphClient is now available
+ *     const transfers = await context.theGraphClient.query({
+ *       query: gql`
+ *         query GetTransfers($tokenId: ID!) {
+ *           transfers(where: { token: $tokenId }) {
+ *             id
+ *             from
+ *             to
+ *             value
+ *           }
+ *         }
+ *       `,
+ *       variables: { tokenId: input.tokenId }
+ *     });
+ *   });
+ * ```
+ */
+export const theGraphMiddleware = br.middleware(async ({ context, next }) => {
+  return next({
+    context: {
+      // Use existing Graph client if available (e.g., for testing),
+      // otherwise inject the default Graph client instance
+      theGraphClient: context.theGraphClient ?? theGraphClient,
+    },
+  });
+});

--- a/kit/dapp/src/lib/orpc/routes/context.ts
+++ b/kit/dapp/src/lib/orpc/routes/context.ts
@@ -1,5 +1,9 @@
 import { auth } from "@/lib/auth/auth";
 import type { db } from "@/lib/db";
+import type { hasuraClient } from "@/lib/settlemint/hasura";
+import type { client as minioClient } from "@/lib/settlemint/minio";
+import type { portalClient } from "@/lib/settlemint/portal";
+import type { theGraphClient } from "@/lib/settlemint/the-graph";
 
 /**
  * ORPC procedure context type definition.
@@ -55,4 +59,36 @@ export type Context = {
    * @see {@link @/lib/db} - Database configuration and connection
    */
   db?: typeof db;
+
+  /**
+   * The Graph client instance for querying blockchain data.
+   * Injected by theGraphMiddleware for procedures that need to query indexed blockchain events.
+   * @optional
+   * @see {@link @/lib/settlemint/the-graph} - The Graph client configuration
+   */
+  theGraphClient?: typeof theGraphClient;
+
+  /**
+   * Portal client instance for interacting with the SettleMint Portal API.
+   * Injected by portalMiddleware for procedures that need to interact with Portal services.
+   * @optional
+   * @see {@link @/lib/settlemint/portal} - Portal client configuration
+   */
+  portalClient?: typeof portalClient;
+
+  /**
+   * MinIO client instance for object storage operations.
+   * Injected by minioMiddleware for procedures that need to store/retrieve files.
+   * @optional
+   * @see {@link @/lib/settlemint/minio} - MinIO client configuration
+   */
+  minioClient?: typeof minioClient;
+
+  /**
+   * Hasura GraphQL client instance for querying and mutating data.
+   * Injected by hasuraMiddleware for procedures that need to interact with Hasura.
+   * @optional
+   * @see {@link @/lib/settlemint/hasura} - Hasura client configuration
+   */
+  hasuraClient?: typeof hasuraClient;
 };


### PR DESCRIPTION
## Summary
- Implements service middleware for Hasura, MinIO, Portal, and The Graph clients
- Extends ORPC context type with optional service client properties
- Adds comprehensive TSDoc documentation with usage examples for each middleware

## Description
This PR introduces a set of ORPC middleware that inject external service clients into the procedure context. This follows the dependency injection pattern, making procedures more testable and modular.

### New Middleware:
- **hasuraMiddleware**: Injects Hasura GraphQL client for database queries
- **minioMiddleware**: Injects MinIO client for object storage operations  
- **portalMiddleware**: Injects Portal client for SettleMint platform interactions
- **theGraphMiddleware**: Injects The Graph client for blockchain data queries

### Changes to Context:
Extended the ORPC context type to include optional properties for each service client, with detailed JSDoc documentation explaining their purpose and usage.

## Test plan
- [ ] Verify middleware correctly injects clients into context
- [ ] Test that procedures can access injected clients
- [ ] Confirm dependency injection works for test mocking
- [ ] Check that TSDoc documentation renders correctly