### PR TITLE
fix: push airdrop distribution limit not visible in summary

### DIFF
--- a/kit/dapp/messages/en.json
+++ b/kit/dapp/messages/en.json
@@ -1570,7 +1570,8 @@
             "description": "Configuration parameters for the airdrop distribution.",
             "distribution-cap-label": "Distribution Cap",
             "distribution-recipients-label": "Number of Recipients",
-            "total-distribution-amount-label": "Total Distribution Amount"
+            "total-distribution-amount-label": "Total Distribution Amount",
+            "distribution-limit-label": "Distribution Limit"
           },
           "recipients": {
             "title": "Distribution Recipients",

--- a/kit/dapp/src/components/blocks/airdrop/design-dialog/create-forms/common/summary.tsx
+++ b/kit/dapp/src/components/blocks/airdrop/design-dialog/create-forms/common/summary.tsx
@@ -140,6 +140,20 @@ export function Summary({
                 : "-"
             }
           />
+          {"distributionCap" in formValues && (
+            <FormSummaryDetailItem
+              label={t("configuration.distribution-limit-label")}
+              value={
+                formValues.distributionCap
+                  ? formatNumber(formValues.distributionCap, {
+                      decimals: formValues.asset?.decimals,
+                      token: formValues.asset?.symbol,
+                      locale,
+                    })
+                  : "-"
+              }
+            />
+          )}
         </FormSummaryDetailCard>
 
         {/* Disclaimer */}


### PR DESCRIPTION
Not the most type-safe fix, but this form has been changed in main where we can pass in cards for the summary component, and can be fixed better there.

<img width="1760" alt="image" src="https://github.com/user-attachments/assets/4fc2f626-622b-40bf-adc1-b57502def765" />
