### PR TITLE
feat: capture subgraph IPFS hash in build artifacts

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -119,6 +119,7 @@ jobs:
           path: |
             kit/contracts/tools/genesis-output.json
             kit/contracts/portal/*.json
+            kit/subgraph/subgraph-output.txt
 
   secret-scanning:
     name: Secret Scanning

--- a/kit/subgraph/package.json
+++ b/kit/subgraph/package.json
@@ -11,7 +11,7 @@
     "codegen": "settlemint scs subgraph codegen",
     "codegen:interfaceid": "bun run tools/interfaceid.ts",
     "format": "prettier --write .",
-    "build": "settlemint scs subgraph build",
+    "build": "bunx graph build --ipfs=https://ipfs.console.settlemint.com | tee /dev/tty | grep -o 'Qm[a-zA-Z0-9]*' | tail -1 > subgraph-output.txt",
     "publish": "bun run tools/graph-deploy.ts --local",
     "publish:remote": "bun run tools/graph-deploy.ts --remote"
   },


### PR DESCRIPTION
## Summary
- Capture subgraph IPFS hash during build process
- Store hash as build artifact in CI/CD pipeline

## Test plan
- [ ] Build process continues to work as expected
- [ ] IPFS hash is correctly captured in subgraph-output.txt
- [ ] QA workflow successfully collects the artifact

## Summary by Sourcery

Capture the IPFS hash from the subgraph build output and store it as a build artifact in the CI/CD pipeline

New Features:
- Capture subgraph IPFS hash during build and save it to subgraph-output.txt

CI:
- Include subgraph-output.txt in QA workflow artifact collection