### PR TITLE
fix: prevent simultaneous minAvailable and maxUnavailable in ERPC PodDisruptionBudget

### DIFF
--- a/kit/charts/atk/charts/erpc/templates/poddisruptionbudget.yaml
+++ b/kit/charts/atk/charts/erpc/templates/poddisruptionbudget.yaml
@@ -11,9 +11,10 @@ metadata:
 spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
-  {{- end }}
-  {{- if or .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- else if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  maxUnavailable: 1
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 6 }}

--- a/kit/charts/atk/charts/portal/Chart.lock
+++ b/kit/charts/atk/charts/portal/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.31.1
+digest: sha256:5b439fb794cf7398ff455aea918cfa09f0e0812c880fb81338680730c84e4fec
+generated: "2025-06-05T12:08:24.281526+02:00"

--- a/kit/charts/atk/charts/portal/Chart.yaml
+++ b/kit/charts/atk/charts/portal/Chart.yaml
@@ -1,24 +1,39 @@
 apiVersion: v2
 name: portal
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+description: |
+  Portal is a comprehensive blockchain data management and querying service that provides
+  real-time access to on-chain data through GraphQL APIs. It serves as the central data
+  access layer for the Asset Tokenization Kit, offering high-performance queries, data
+  synchronization, and API endpoints for frontend applications and external integrations.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "8.5.5"
+icon: https://console.settlemint.com/android-chrome-512x512.png
+home: https://settlemint.com/
+sources:
+  - https://github.com/settlemint/starterkit-asset-tokenization
+deprecated: false
+kubeVersion: ">=1.21.0-0"
+engine: gotpl
+keywords:
+  - portal
+  - graphql
+  - api
+  - blockchain
+  - data
+  - query
+  - web3
+  - infrastructure
+  - asset-tokenization
+  - defi
+  - settlemint
+  - postgresql
+  - redis
+maintainers:
+  - name: SettleMint
+    email: support@settlemint.com
+    url: https://settlemint.com
+dependencies:
+  - name: common
+    version: 2.31.1
+    repository: oci://registry-1.docker.io/bitnamicharts

--- a/kit/charts/atk/charts/portal/README.md
+++ b/kit/charts/atk/charts/portal/README.md
@@ -1,95 +1,396 @@
 # portal
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.5.5](https://img.shields.io/badge/AppVersion-8.5.5-informational?style=flat-square)
 
-A Helm chart for Kubernetes
+Portal is a comprehensive blockchain data management and querying service that provides
+real-time access to on-chain data through GraphQL APIs. It serves as the central data
+access layer for the Asset Tokenization Kit, offering high-performance queries, data
+synchronization, and API endpoints for frontend applications and external integrations.
+
+## Introduction
+
+Portal is a powerful blockchain data management and querying service designed specifically for the Asset Tokenization Kit. It provides a comprehensive GraphQL API layer that enables real-time access to on-chain data, making it easy for frontend applications and external integrations to interact with blockchain data.
+
+## Features
+
+- **GraphQL API**: Modern, flexible API for querying blockchain data with precise field selection
+- **Real-time Data Sync**: Automatic synchronization with blockchain events and state changes
+- **High Performance**: Optimized queries with Redis caching for fast response times
+- **PostgreSQL Backend**: Reliable data storage with full ACID compliance
+- **Multi-Asset Support**: Handles all asset types in the Asset Tokenization Kit (bonds, equity, stablecoins, etc.)
+- **Scalable Architecture**: Horizontal scaling support with built-in autoscaling
+- **Enterprise Security**: Network policies, pod security contexts, and RBAC support
+- **Monitoring Ready**: Integrated health checks and readiness probes
+
+## Benefits
+
+- **Simplified Integration**: Single GraphQL endpoint for all blockchain data queries
+- **Reduced Complexity**: No need to directly interact with blockchain nodes
+- **Better Performance**: Cached queries and optimized database indexes
+- **Developer Friendly**: Self-documenting GraphQL schema with introspection
+- **Production Ready**: Battle-tested with enterprise-grade reliability
+
+## Use Cases
+
+- **Frontend Applications**: Power web and mobile apps with real-time blockchain data
+- **Analytics Dashboards**: Build comprehensive analytics and reporting tools
+- **External Integrations**: Connect blockchain data to external systems via API
+- **Data Aggregation**: Combine on-chain and off-chain data in a single query
+- **Event Processing**: React to blockchain events with webhooks and subscriptions
+
+**Homepage:** <https://settlemint.com/>
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Helm 3.2.0+
+- PostgreSQL database (can use Bitnami PostgreSQL chart)
+- Redis cache (can use Bitnami Redis chart)
+- Access to a blockchain RPC endpoint (e.g., through txsigner)
+
+## Installing the Chart
+
+To install the chart with the release name `my-portal`:
+
+```bash
+helm repo add settlemint https://charts.settlemint.com
+helm install my-portal settlemint/portal
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-portal` deployment:
+
+```bash
+helm delete my-portal
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Portal chart and their default values.
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| fullnameOverride | string | `"portal"` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/settlemint/btp-scs-portal"` |  |
-| image.tag | string | `"8.5.5"` |  |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.className | string | `"settlemint-nginx"` |  |
-| ingress.enabled | bool | `true` |  |
-| ingress.hosts[0].host | string | `"portal.k8s.orb.local"` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
-| ingress.hosts[0].paths[0].port | int | `3000` |  |
-| ingress.hosts[0].paths[1].path | string | `"/graphql"` |  |
-| ingress.hosts[0].paths[1].pathType | string | `"ImplementationSpecific"` |  |
-| ingress.hosts[0].paths[1].port | int | `3001` |  |
-| ingress.tls | list | `[]` |  |
-| initContainers | string | `nil` |  |
-| livenessProbe.tcpSocket.port | string | `"http"` |  |
-| nameOverride | string | `""` |  |
-| network.networkId | string | `"53771311147"` |  |
-| network.networkName | string | `"ATK"` |  |
-| network.nodeRpcUrl | string | `"http://txsigner:3000"` |  |
-| networkPolicy.egress[0].ports[0].port | int | `53` |  |
-| networkPolicy.egress[0].ports[0].protocol | string | `"UDP"` |  |
-| networkPolicy.egress[0].to[0].namespaceSelector | object | `{}` |  |
-| networkPolicy.egress[0].to[0].podSelector.matchLabels.k8s-app | string | `"kube-dns"` |  |
-| networkPolicy.egress[1].ports[0].port | int | `5432` |  |
-| networkPolicy.egress[1].ports[0].protocol | string | `"TCP"` |  |
-| networkPolicy.egress[1].to[0].podSelector.matchLabels."app.kubernetes.io/name" | string | `"postgresql-ha"` |  |
-| networkPolicy.egress[2].ports[0].port | int | `6379` |  |
-| networkPolicy.egress[2].ports[0].protocol | string | `"TCP"` |  |
-| networkPolicy.egress[2].to[0].podSelector.matchLabels."app.kubernetes.io/name" | string | `"redis"` |  |
-| networkPolicy.egress[3].ports[0].port | int | `443` |  |
-| networkPolicy.egress[3].ports[0].protocol | string | `"TCP"` |  |
-| networkPolicy.egress[3].to[0].namespaceSelector | object | `{}` |  |
-| networkPolicy.enabled | bool | `false` |  |
-| networkPolicy.ingress[0].from[0].namespaceSelector.matchLabels."kubernetes.io/metadata.name" | string | `"ingress-nginx"` |  |
-| networkPolicy.ingress[0].ports[0].port | int | `3000` |  |
-| networkPolicy.ingress[0].ports[0].protocol | string | `"TCP"` |  |
-| networkPolicy.ingress[0].ports[1].port | int | `3001` |  |
-| networkPolicy.ingress[0].ports[1].protocol | string | `"TCP"` |  |
-| networkPolicy.ingress[1].from[0].podSelector.matchLabels."app.kubernetes.io/name" | string | `"dapp"` |  |
-| networkPolicy.ingress[1].ports[0].port | int | `3000` |  |
-| networkPolicy.ingress[1].ports[0].protocol | string | `"TCP"` |  |
-| networkPolicy.ingress[1].ports[1].port | int | `3001` |  |
-| networkPolicy.ingress[1].ports[1].protocol | string | `"TCP"` |  |
-| networkPolicy.ingress[2].from[0].podSelector | object | `{}` |  |
-| networkPolicy.ingress[2].ports[0].port | int | `3000` |  |
-| networkPolicy.ingress[2].ports[0].protocol | string | `"TCP"` |  |
-| networkPolicy.ingress[2].ports[1].port | int | `3001` |  |
-| networkPolicy.ingress[2].ports[1].protocol | string | `"TCP"` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podDisruptionBudget.enabled | bool | `false` |  |
-| podDisruptionBudget.minAvailable | int | `1` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
-| postgresql | string | `"postgresql://portal:atk@postgresql-pgpool:5432/portal?sslmode=disable"` |  |
-| readinessProbe.tcpSocket.port | string | `"http"` |  |
-| redis.host | string | `"redis-master"` |  |
-| redis.password | string | `"atk"` |  |
-| redis.port | int | `6379` |  |
-| redis.username | string | `"default"` |  |
-| replicaCount | int | `1` |  |
-| resources | object | `{}` |  |
-| securityContext | object | `{}` |  |
-| service.graphqlPort | int | `3001` |  |
-| service.port | int | `3000` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.automount | bool | `false` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| tests.image.pullPolicy | string | `"IfNotPresent"` |  |
-| tests.image.registry | string | `"docker.io"` |  |
-| tests.image.repository | string | `"busybox"` |  |
-| tests.image.tag | string | `"1.37.0"` |  |
-| tolerations | list | `[]` |  |
-| volumeMounts | list | `[]` |  |
-| volumes | list | `[]` |  |
+| affinity | object | `{}` | Affinity for pod assignment |
+| autoscaling | object | `{"builtInMetrics":[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"customMetrics":[],"enabled":false,"maxReplicas":3,"minReplicas":1}` | Autoscaling configuration for Portal |
+| autoscaling.builtInMetrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Built-in metrics configuration |
+| autoscaling.customMetrics | list | `[]` | Custom metrics configuration |
+| autoscaling.enabled | bool | `false` | Enable autoscaling for Portal |
+| autoscaling.maxReplicas | int | `3` | Maximum number of Portal replicas |
+| autoscaling.minReplicas | int | `1` | Minimum number of Portal replicas |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| config | object | `{"network":{"networkId":"53771311147","networkName":"ATK","nodeRpcUrl":"http://txsigner:3000"},"postgresql":"postgresql://portal:atk@postgresql-pgpool:5432/portal?sslmode=disable","redis":{"host":"redis-master","password":"atk","port":6379,"username":"default"}}` | Portal configuration |
+| config.network | object | `{"networkId":"53771311147","networkName":"ATK","nodeRpcUrl":"http://txsigner:3000"}` | Network configuration |
+| config.network.networkId | string | `"53771311147"` | Network ID |
+| config.network.networkName | string | `"ATK"` | Network name |
+| config.network.nodeRpcUrl | string | `"http://txsigner:3000"` | Node RPC URL |
+| config.postgresql | string | `"postgresql://portal:atk@postgresql-pgpool:5432/portal?sslmode=disable"` | PostgreSQL connection string |
+| config.redis | object | `{"host":"redis-master","password":"atk","port":6379,"username":"default"}` | Redis configuration |
+| config.redis.host | string | `"redis-master"` | Redis host |
+| config.redis.password | string | `"atk"` | Redis password |
+| config.redis.port | int | `6379` | Redis port |
+| config.redis.username | string | `"default"` | Redis username |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":false,"readOnlyRootFilesystem":false,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context configuration |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Set container's Security Context allowPrivilegeEscalation |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Linux capabilities configuration |
+| containerSecurityContext.capabilities.drop | list | `["ALL"]` | Set container's Security Context drop capabilities |
+| containerSecurityContext.enabled | bool | `false` | Enable container Security Context |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `false` | Set container's Security Context readOnlyRootFilesystem |
+| containerSecurityContext.runAsGroup | int | `1001` | Set container's Security Context runAsGroup |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Set container's Security Context runAsNonRoot |
+| containerSecurityContext.runAsUser | int | `1001` | Set container's Security Context runAsUser |
+| containerSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | Seccomp profile configuration |
+| containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Set container's Security Context seccomp profile |
+| extraEnvVars | list | `[]` | Array with extra environment variables to add to Portal nodes |
+| extraEnvVarsCM | string | `""` | Name of existing ConfigMap containing extra env vars for Portal nodes |
+| extraEnvVarsSecret | string | `""` | Name of existing Secret containing extra env vars for Portal nodes |
+| extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts for the Portal container(s) |
+| extraVolumes | list | `[]` | Optionally specify extra list of additional volumes for the Portal pod(s) |
+| fullnameOverride | string | `"portal"` | String to fully override common.names.fullname |
+| global | object | `{"imagePullSecrets":[],"imageRegistry":"","labels":{},"storageClass":""}` | Global Docker image registry |
+| global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
+| global.imageRegistry | string | `""` | Global Docker image registry |
+| global.labels | object | `{}` | Global labels to add to all objects |
+| global.storageClass | string | `""` | Global StorageClass for Persistent Volume(s) |
+| image | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"ghcr.io","repository":"settlemint/btp-scs-portal","tag":"8.5.5"}` | Portal image |
+| image.digest | string | `""` | Portal image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag |
+| image.pullPolicy | string | `"IfNotPresent"` | Portal image pull policy |
+| image.pullSecrets | list | `[]` | Portal image pull secrets |
+| image.registry | string | `"ghcr.io"` | Portal image registry |
+| image.repository | string | `"settlemint/btp-scs-portal"` | Portal image repository |
+| image.tag | string | `"8.5.5"` | Portal image tag (immutable tags are recommended) |
+| ingress | object | `{"annotations":{},"apiVersion":"","enabled":true,"extraHosts":[],"extraPaths":[],"extraRules":[],"extraTls":[],"graphqlPath":"/graphql","hostname":"portal.k8s.orb.local","ingressClassName":"settlemint-nginx","path":"/","pathType":"ImplementationSpecific","secrets":[],"selfSigned":false,"tls":false}` | Ingress parameters |
+| ingress.annotations | object | `{}` | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. |
+| ingress.apiVersion | string | `""` | Force Ingress API version (automatically detected if not set) |
+| ingress.enabled | bool | `true` | Enable ingress record generation for Portal |
+| ingress.extraHosts | list | `[]` | An array with additional hostname(s) to be covered with the ingress record |
+| ingress.extraPaths | list | `[]` | An array with additional arbitrary paths that may need to be added to the ingress under the main host |
+| ingress.extraRules | list | `[]` | Additional rules to be covered with this ingress record |
+| ingress.extraTls | list | `[]` | TLS configuration for additional hostname(s) to be covered with this ingress record |
+| ingress.graphqlPath | string | `"/graphql"` | Additional path for GraphQL endpoint |
+| ingress.hostname | string | `"portal.k8s.orb.local"` | Default host for the ingress record |
+| ingress.ingressClassName | string | `"settlemint-nginx"` | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+) |
+| ingress.path | string | `"/"` | Default path for the ingress record |
+| ingress.pathType | string | `"ImplementationSpecific"` | Ingress path type |
+| ingress.secrets | list | `[]` | Custom TLS certificates as secrets |
+| ingress.selfSigned | bool | `false` | Create a TLS secret for this ingress record using self-signed certificates generated by Helm |
+| ingress.tls | bool | `false` | Enable TLS configuration for the host defined at `ingress.hostname` parameter |
+| initContainers | list | `[]` | Init containers |
+| lifecycleHooks | object | `{}` | lifecycleHooks for the Portal container(s) to automate configuration before or after startup |
+| livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"tcpSocket":{"port":"http"},"timeoutSeconds":5}` | Configure Portal containers' liveness probe |
+| livenessProbe.enabled | bool | `true` | Enable livenessProbe on Portal containers |
+| livenessProbe.failureThreshold | int | `3` | Failure threshold for livenessProbe |
+| livenessProbe.initialDelaySeconds | int | `10` | Initial delay seconds for livenessProbe |
+| livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe |
+| livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe |
+| livenessProbe.tcpSocket | object | `{"port":"http"}` | TCP socket parameters for livenessProbe |
+| livenessProbe.tcpSocket.port | string | `"http"` | Port for tcpSocket livenessProbe |
+| livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe |
+| nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
+| networkPolicy | object | `{"addExternalClientAccess":true,"allowExternal":true,"allowExternalEgress":true,"enabled":false,"extraEgress":[{"ports":[{"port":53,"protocol":"UDP"}],"to":[{"namespaceSelector":{},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}}}]},{"ports":[{"port":5432,"protocol":"TCP"}],"to":[{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"postgresql-ha"}}}]},{"ports":[{"port":6379,"protocol":"TCP"}],"to":[{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"redis"}}}]},{"ports":[{"port":443,"protocol":"TCP"}],"to":[{"namespaceSelector":{}}]}],"extraIngress":[{"from":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"ingress-nginx"}}},{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"dapp"}}},{"podSelector":{}}],"ports":[{"port":3000,"protocol":"TCP"},{"port":3001,"protocol":"TCP"}]}],"ingressRules":{"accessOnlyFrom":{"enabled":false,"namespaceSelector":{},"podSelector":{}}}}` | Network policies configuration |
+| networkPolicy.addExternalClientAccess | bool | `true` | Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true. |
+| networkPolicy.allowExternal | bool | `true` | The Policy model to apply |
+| networkPolicy.allowExternalEgress | bool | `true` | Allow the pod to access any range of port and all destinations. |
+| networkPolicy.enabled | bool | `false` | Enable creation of NetworkPolicy resources |
+| networkPolicy.extraEgress | list | `[{"ports":[{"port":53,"protocol":"UDP"}],"to":[{"namespaceSelector":{},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}}}]},{"ports":[{"port":5432,"protocol":"TCP"}],"to":[{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"postgresql-ha"}}}]},{"ports":[{"port":6379,"protocol":"TCP"}],"to":[{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"redis"}}}]},{"ports":[{"port":443,"protocol":"TCP"}],"to":[{"namespaceSelector":{}}]}]` | Add extra egress rules to the NetworkPolicy (ignored if allowExternalEgress=true) |
+| networkPolicy.extraIngress | list | `[{"from":[{"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"ingress-nginx"}}},{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"dapp"}}},{"podSelector":{}}],"ports":[{"port":3000,"protocol":"TCP"},{"port":3001,"protocol":"TCP"}]}]` | Add extra ingress rules to the NetworkPolicy |
+| networkPolicy.ingressRules | object | `{"accessOnlyFrom":{"enabled":false,"namespaceSelector":{},"podSelector":{}}}` | Ingress rules configuration |
+| networkPolicy.ingressRules.accessOnlyFrom | object | `{"enabled":false,"namespaceSelector":{},"podSelector":{}}` | Access restrictions configuration |
+| networkPolicy.ingressRules.accessOnlyFrom.enabled | bool | `false` | Enable ingress rule that makes Portal only accessible from a particular origin. |
+| networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector | object | `{}` | Namespace selector label that is allowed to access Portal. This label will be used to identified allowed namespace(s). |
+| networkPolicy.ingressRules.accessOnlyFrom.podSelector | object | `{}` | Pods selector label that is allowed to access Portal. This label will be used to identified allowed pod(s). |
+| nodeAffinityPreset | object | `{"key":"","type":"","values":[]}` | Node affinity preset configuration |
+| nodeAffinityPreset.key | string | `""` | Node label key to match. Ignored if `affinity` is set |
+| nodeAffinityPreset.type | string | `""` | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` |
+| nodeAffinityPreset.values | list | `[]` | Node label values to match. Ignored if `affinity` is set |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| pdb | object | `{"enabled":false,"maxUnavailable":"","minAvailable":""}` | Pod disruption budget configuration |
+| pdb.enabled | bool | `false` | If true, create a pod disruption budget for pods. |
+| pdb.maxUnavailable | string | `""` | Maximum number/percentage of pods that may be made unavailable. Defaults to 1 if both pdb.minAvailable and pdb.maxUnavailable are empty. |
+| pdb.minAvailable | string | `""` | Minimum number/percentage of pods that should remain scheduled |
+| podAffinityPreset | string | `""` | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` |
+| podAnnotations | object | `{}` | Annotations for Portal pods |
+| podAntiAffinityPreset | string | `"soft"` | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` |
+| podLabels | object | `{}` | Extra labels for Portal pods |
+| podSecurityContext | object | `{"enabled":false,"fsGroup":1001,"sysctls":[]}` | Pod Security Context configuration |
+| podSecurityContext.enabled | bool | `false` | Enabled Portal pods' Security Context |
+| podSecurityContext.fsGroup | int | `1001` | Set Portal pod's Security Context fsGroup |
+| podSecurityContext.sysctls | list | `[]` | Set kernel settings using the sysctl interface |
+| priorityClassName | string | `""` | Portal pods' priority class name |
+| readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"tcpSocket":{"port":"http"},"timeoutSeconds":5}` | Configure Portal containers' readiness probe |
+| readinessProbe.enabled | bool | `true` | Enable readinessProbe on Portal containers |
+| readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe |
+| readinessProbe.initialDelaySeconds | int | `5` | Initial delay seconds for readinessProbe |
+| readinessProbe.periodSeconds | int | `10` | Period seconds for readinessProbe |
+| readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
+| readinessProbe.tcpSocket | object | `{"port":"http"}` | TCP socket parameters for readinessProbe |
+| readinessProbe.tcpSocket.port | string | `"http"` | Port for tcpSocket readinessProbe |
+| readinessProbe.timeoutSeconds | int | `5` | Timeout seconds for readinessProbe |
+| replicaCount | int | `1` | Number of Portal replicas to deploy |
+| resources | object | `{}` | Portal containers resource requests and limits |
+| schedulerName | string | `""` | Alternate scheduler |
+| service | object | `{"annotations":{},"clusterIP":"","externalTrafficPolicy":"Cluster","extraPorts":[],"graphqlNodePort":"","graphqlPort":3001,"loadBalancerIP":"","loadBalancerSourceRanges":[],"nodePort":"","port":3000,"sessionAffinity":"None","sessionAffinityConfig":{},"type":"ClusterIP"}` | Service parameters |
+| service.annotations | object | `{}` | Additional custom annotations for Portal service |
+| service.clusterIP | string | `""` | Portal service Cluster IP |
+| service.externalTrafficPolicy | string | `"Cluster"` | Portal service external traffic policy |
+| service.extraPorts | list | `[]` | Extra ports to expose in the Portal service (normally used with the `sidecar` value) |
+| service.graphqlNodePort | string | `""` | Node port for GraphQL |
+| service.graphqlPort | int | `3001` | Portal service GraphQL port |
+| service.loadBalancerIP | string | `""` | Portal service Load Balancer IP |
+| service.loadBalancerSourceRanges | list | `[]` | Portal service Load Balancer sources |
+| service.nodePort | string | `""` | Node port for HTTP |
+| service.port | int | `3000` | Portal service HTTP port |
+| service.sessionAffinity | string | `"None"` | Session Affinity for Kubernetes service, can be "None" or "ClientIP" |
+| service.sessionAffinityConfig | object | `{}` | Additional settings for the sessionAffinity |
+| service.type | string | `"ClusterIP"` | Portal service type |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"create":true,"labels":{},"name":""}` | Service account for Portal pods |
+| serviceAccount.annotations | object | `{}` | Annotations for service account. Evaluated as a template. Only used if `create` is `true`. |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount service account token for the deployment controller service account |
+| serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created |
+| serviceAccount.labels | object | `{}` | Extra labels to be added to the service account |
+| serviceAccount.name | string | `""` | The name of the ServiceAccount to use. |
+| startupProbe | object | `{"enabled":false,"failureThreshold":10,"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Configure Portal containers' startup probe |
+| startupProbe.enabled | bool | `false` | Enable startupProbe on Portal containers |
+| startupProbe.failureThreshold | int | `10` | Failure threshold for startupProbe |
+| startupProbe.initialDelaySeconds | int | `30` | Initial delay seconds for startupProbe |
+| startupProbe.periodSeconds | int | `10` | Period seconds for startupProbe |
+| startupProbe.successThreshold | int | `1` | Success threshold for startupProbe |
+| startupProbe.timeoutSeconds | int | `5` | Timeout seconds for startupProbe |
+| tests | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"busybox","tag":"1.37.0"}}` | Test parameters |
+| tests.image | object | `{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"busybox","tag":"1.37.0"}` | Image for test pods |
+| tests.image.pullPolicy | string | `"IfNotPresent"` | Test image pull policy |
+| tests.image.registry | string | `"docker.io"` | Test image registry |
+| tests.image.repository | string | `"busybox"` | Test image repository |
+| tests.image.tag | string | `"1.37.0"` | Test image tag |
+| tolerations | list | `[]` | Tolerations for pod assignment |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment |
+| updateStrategy | object | `{"rollingUpdate":{},"type":"RollingUpdate"}` | Update strategy configuration for Portal deployment |
+| updateStrategy.rollingUpdate | object | `{}` | Portal deployment rolling update configuration parameters |
+| updateStrategy.type | string | `"RollingUpdate"` | Portal deployment strategy type |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install my-portal \
+  --set config.network.networkId="1" \
+  --set config.network.networkName="Mainnet" \
+  settlemint/portal
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```bash
+helm install my-portal -f values.yaml settlemint/portal
+```
+
+## Configuration Examples
+
+### Basic Configuration
+
+```yaml
+config:
+  network:
+    networkId: "53771311147"
+    networkName: "ATK"
+    nodeRpcUrl: "http://txsigner:3000"
+  postgresql: "postgresql://portal:password@postgresql:5432/portal?sslmode=disable"
+  redis:
+    host: "redis-master"
+    port: 6379
+    username: "default"
+    password: "redis-password"
+```
+
+### Production Configuration with Security
+
+```yaml
+replicaCount: 3
+
+podSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  fsGroup: 1001
+
+containerSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
+networkPolicy:
+  enabled: true
+  allowExternal: false
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+
+pdb:
+  enabled: true
+  minAvailable: 2
+```
+
+### External Database Configuration
+
+```yaml
+config:
+  postgresql: "postgresql://portal:password@external-db.example.com:5432/portal?sslmode=require"
+  redis:
+    host: "external-redis.example.com"
+    port: 6379
+    username: "portal"
+    password: "secure-password"
+```
+
+## Troubleshooting
+
+### Portal Pod Not Starting
+
+1. Check the pod logs:
+   ```bash
+   kubectl logs -l app.kubernetes.io/name=portal
+   ```
+
+2. Verify database connectivity:
+   ```bash
+   kubectl exec -it deploy/portal -- nc -zv postgresql-pgpool 5432
+   ```
+
+3. Check Redis connectivity:
+   ```bash
+   kubectl exec -it deploy/portal -- nc -zv redis-master 6379
+   ```
+
+### GraphQL Endpoint Not Responding
+
+1. Check service endpoints:
+   ```bash
+   kubectl get endpoints portal
+   ```
+
+2. Test internal connectivity:
+   ```bash
+   kubectl run test --rm -it --image=busybox -- wget -qO- portal:3001/graphql
+   ```
+
+3. Verify ingress configuration:
+   ```bash
+   kubectl describe ingress portal
+   ```
+
+### Performance Issues
+
+1. Enable autoscaling:
+   ```yaml
+   autoscaling:
+     enabled: true
+     minReplicas: 2
+     maxReplicas: 10
+   ```
+
+2. Increase resource limits:
+   ```yaml
+   resources:
+     requests:
+       cpu: 500m
+       memory: 1Gi
+     limits:
+       cpu: 1000m
+       memory: 2Gi
+   ```
+
+3. Check database performance and indexes
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| SettleMint | <support@settlemint.com> | <https://settlemint.com> |
+
+## Source Code
+
+* <https://github.com/settlemint/starterkit-asset-tokenization>
+
+## Requirements
+
+Kubernetes: `>=1.21.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://registry-1.docker.io/bitnamicharts | common | 2.31.1 |

--- a/kit/charts/atk/charts/portal/README.md.gotmpl
+++ b/kit/charts/atk/charts/portal/README.md.gotmpl
@@ -1,0 +1,222 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+## Introduction
+
+Portal is a powerful blockchain data management and querying service designed specifically for the Asset Tokenization Kit. It provides a comprehensive GraphQL API layer that enables real-time access to on-chain data, making it easy for frontend applications and external integrations to interact with blockchain data.
+
+## Features
+
+- **GraphQL API**: Modern, flexible API for querying blockchain data with precise field selection
+- **Real-time Data Sync**: Automatic synchronization with blockchain events and state changes
+- **High Performance**: Optimized queries with Redis caching for fast response times
+- **PostgreSQL Backend**: Reliable data storage with full ACID compliance
+- **Multi-Asset Support**: Handles all asset types in the Asset Tokenization Kit (bonds, equity, stablecoins, etc.)
+- **Scalable Architecture**: Horizontal scaling support with built-in autoscaling
+- **Enterprise Security**: Network policies, pod security contexts, and RBAC support
+- **Monitoring Ready**: Integrated health checks and readiness probes
+
+## Benefits
+
+- **Simplified Integration**: Single GraphQL endpoint for all blockchain data queries
+- **Reduced Complexity**: No need to directly interact with blockchain nodes
+- **Better Performance**: Cached queries and optimized database indexes
+- **Developer Friendly**: Self-documenting GraphQL schema with introspection
+- **Production Ready**: Battle-tested with enterprise-grade reliability
+
+## Use Cases
+
+- **Frontend Applications**: Power web and mobile apps with real-time blockchain data
+- **Analytics Dashboards**: Build comprehensive analytics and reporting tools
+- **External Integrations**: Connect blockchain data to external systems via API
+- **Data Aggregation**: Combine on-chain and off-chain data in a single query
+- **Event Processing**: React to blockchain events with webhooks and subscriptions
+
+{{ template "chart.homepageLine" . }}
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Helm 3.2.0+
+- PostgreSQL database (can use Bitnami PostgreSQL chart)
+- Redis cache (can use Bitnami Redis chart)
+- Access to a blockchain RPC endpoint (e.g., through txsigner)
+
+## Installing the Chart
+
+To install the chart with the release name `my-portal`:
+
+```bash
+helm repo add settlemint https://charts.settlemint.com
+helm install my-portal settlemint/portal
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-portal` deployment:
+
+```bash
+helm delete my-portal
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Portal chart and their default values.
+
+{{ template "chart.valuesSection" . }}
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install my-portal \
+  --set config.network.networkId="1" \
+  --set config.network.networkName="Mainnet" \
+  settlemint/portal
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```bash
+helm install my-portal -f values.yaml settlemint/portal
+```
+
+## Configuration Examples
+
+### Basic Configuration
+
+```yaml
+config:
+  network:
+    networkId: "53771311147"
+    networkName: "ATK"
+    nodeRpcUrl: "http://txsigner:3000"
+  postgresql: "postgresql://portal:password@postgresql:5432/portal?sslmode=disable"
+  redis:
+    host: "redis-master"
+    port: 6379
+    username: "default"
+    password: "redis-password"
+```
+
+### Production Configuration with Security
+
+```yaml
+replicaCount: 3
+
+podSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  fsGroup: 1001
+
+containerSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
+networkPolicy:
+  enabled: true
+  allowExternal: false
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+
+pdb:
+  enabled: true
+  minAvailable: 2
+```
+
+### External Database Configuration
+
+```yaml
+config:
+  postgresql: "postgresql://portal:password@external-db.example.com:5432/portal?sslmode=require"
+  redis:
+    host: "external-redis.example.com"
+    port: 6379
+    username: "portal"
+    password: "secure-password"
+```
+
+## Troubleshooting
+
+### Portal Pod Not Starting
+
+1. Check the pod logs:
+   ```bash
+   kubectl logs -l app.kubernetes.io/name=portal
+   ```
+
+2. Verify database connectivity:
+   ```bash
+   kubectl exec -it deploy/portal -- nc -zv postgresql-pgpool 5432
+   ```
+
+3. Check Redis connectivity:
+   ```bash
+   kubectl exec -it deploy/portal -- nc -zv redis-master 6379
+   ```
+
+### GraphQL Endpoint Not Responding
+
+1. Check service endpoints:
+   ```bash
+   kubectl get endpoints portal
+   ```
+
+2. Test internal connectivity:
+   ```bash
+   kubectl run test --rm -it --image=busybox -- wget -qO- portal:3001/graphql
+   ```
+
+3. Verify ingress configuration:
+   ```bash
+   kubectl describe ingress portal
+   ```
+
+### Performance Issues
+
+1. Enable autoscaling:
+   ```yaml
+   autoscaling:
+     enabled: true
+     minReplicas: 2
+     maxReplicas: 10
+   ```
+
+2. Increase resource limits:
+   ```yaml
+   resources:
+     requests:
+       cpu: 500m
+       memory: 1Gi
+     limits:
+       cpu: 1000m
+       memory: 2Gi
+   ```
+
+3. Check database performance and indexes
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}

--- a/kit/charts/atk/charts/portal/templates/NOTES.txt
+++ b/kit/charts/atk/charts/portal/templates/NOTES.txt
@@ -1,0 +1,81 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.config }}
+Portal Configuration:
+  - Network ID: {{ .Values.config.network.networkId }}
+  - Network Name: {{ .Values.config.network.networkName }}
+  - Node RPC URL: {{ .Values.config.network.nodeRpcUrl }}
+  - PostgreSQL: Connected
+  - Redis: {{ .Values.config.redis.host }}:{{ .Values.config.redis.port }}
+{{- end }}
+
+Portal can be accessed through the following DNS names from within your cluster:
+
+    HTTP API: {{ include "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.cluster.local (port {{ .Values.service.port }})
+    GraphQL API: {{ include "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.cluster.local (port {{ .Values.service.graphqlPort }})
+
+To access Portal from outside the cluster execute the following commands:
+
+{{- if .Values.ingress.enabled }}
+
+1. Get the Portal URL and associate its hostname to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "Portal URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/"
+   echo "GraphQL URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}{{ .Values.ingress.graphqlPath }}"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+1. Get the Portal URL by running these commands:
+
+    export NODE_PORT_HTTP=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+    export NODE_PORT_GRAPHQL=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ include "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "Portal URL: http://$NODE_IP:$NODE_PORT_HTTP/"
+    echo "GraphQL URL: http://$NODE_IP:$NODE_PORT_GRAPHQL/graphql"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+1. Get the Portal URL by running these commands:
+
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get svc --namespace {{ include "common.names.namespace" . }} -w {{ include "common.names.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ include "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    echo "Portal URL: http://$SERVICE_IP:{{ .Values.service.port }}/"
+    echo "GraphQL URL: http://$SERVICE_IP:{{ .Values.service.graphqlPort }}/graphql"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+1. Get the Portal URL by running these commands:
+
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.port }} &
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ include "common.names.fullname" . }} 8081:{{ .Values.service.graphqlPort }} &
+    echo "Portal URL: http://127.0.0.1:8080/"
+    echo "GraphQL URL: http://127.0.0.1:8081/graphql"
+
+{{- end }}
+
+2. Test the GraphQL endpoint:
+
+    You can test Portal is working by sending a GraphQL query:
+    curl -X POST http://[GRAPHQL_URL]/graphql \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{ __typename }"}'
+
+{{- if .Values.networkPolicy.enabled }}
+
+WARNING: Network Policy is enabled. Make sure your client is allowed to access Portal.
+{{- if .Values.networkPolicy.addExternalClientAccess }}
+To allow external access, label your client pod with:
+  kubectl label pod <POD_NAME> {{ include "common.names.fullname" . }}-client=true
+{{- end }}
+{{- end }}
+
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.tests.image }}

--- a/kit/charts/atk/charts/portal/templates/_helpers.tpl
+++ b/kit/charts/atk/charts/portal/templates/_helpers.tpl
@@ -1,90 +1,37 @@
 {{/*
-Expand the name of the chart.
+This file contains custom helpers specific to the portal chart.
+Most naming and labeling functions are now provided by the Bitnami common chart.
 */}}
-{{- define "portal.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "portal.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "portal.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "portal.labels" -}}
-helm.sh/chart: {{ include "portal.chart" . }}
-app.kubernetes.io/name: {{ include "portal.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.global.labels }}
-{{ toYaml .Values.global.labels }}
-{{- end }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "portal.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "portal.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "portal.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "portal.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "common.names.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
-Common image pull secrets for all deployments/statefulsets
+Return true if ingress supports ingressClassName field
 */}}
-{{- define "atk.imagePullSecrets" -}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else }}
-imagePullSecrets:
-  - name: image-pull-secret-docker
-  - name: image-pull-secret-ghcr
-  - name: image-pull-secret-harbor
-{{- end }}
-{{- else }}
-imagePullSecrets:
-  - name: image-pull-secret-docker
-  - name: image-pull-secret-ghcr
-  - name: image-pull-secret-harbor
-{{- end }}
-{{- end }}
+{{- define "common.ingress.supportsIngressClassname" -}}
+{{- if semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if ingress supports pathType field
+*/}}
+{{- define "common.ingress.supportsPathType" -}}
+{{- if semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}

--- a/kit/charts/atk/charts/portal/templates/configmap.yaml
+++ b/kit/charts/atk/charts/portal/templates/configmap.yaml
@@ -1,12 +1,14 @@
 {{- range $path, $_ := .Files.Glob "abis/*.json" }}
 {{- $filename := base $path }}
-{{- $pathParts := splitList "/" $path }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "portal.fullname" $ }}-{{ $filename | trimSuffix ".json" | lower | replace "_" "-" }}
-  labels:
-    {{- include "portal.labels" $ | nindent 4 }}
+  name: {{ include "common.names.fullname" $ }}-{{ $filename | trimSuffix ".json" | lower | replace "_" "-" }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   {{ $filename }}: |
 {{ $.Files.Get $path | indent 4 }}

--- a/kit/charts/atk/charts/portal/templates/deployment.yaml
+++ b/kit/charts/atk/charts/portal/templates/deployment.yaml
@@ -1,46 +1,85 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
-    matchLabels:
-      {{- include "portal.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 8 }}
+      {{- if or .Values.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.podAnnotations .Values.commonAnnotations ) "context" . ) }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-      labels:
-        {{- include "portal.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
     spec:
-      {{- include "atk.imagePullSecrets" . | nindent 6 }}
+      {{- include "common.images.renderPullSecrets" ( dict "images" (list .Values.image) "context" $) | nindent 6 }}
       serviceAccountName: {{ include "portal.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "customLabels" .Values.podLabels "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "customLabels" .Values.podLabels "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.initContainers }}
-      initContainers:
-        {{- toYaml .Values.initContainers | nindent 8 }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
-          {{- with .Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        - name: portal
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "common.names.fullname" . }}
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -48,21 +87,18 @@ spec:
             - name: graphql
               containerPort: {{ .Values.service.graphqlPort }}
               protocol: TCP
-          {{- with .Values.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
-          {{- with .Values.readinessProbe }}
-          readinessProbe:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
           {{- end }}
-          envFrom:
-            - secretRef:
-                name: {{ include "portal.fullname" . }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- range $path, $_ := .Files.Glob "abis/*.json" }}
             {{- $filename := base $path }}
@@ -70,28 +106,16 @@ spec:
               mountPath: /abis/{{ $filename }}
               subPath: {{ $filename }}
             {{- end }}
-          {{- with .Values.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
       volumes:
         {{- range $path, $_ := .Files.Glob "abis/*.json" }}
         {{- $filename := base $path }}
         - name: abi-{{ $filename | trimSuffix ".json" | lower | replace "_" "-" }}
           configMap:
-            name: {{ include "portal.fullname" $ }}-{{ $filename | trimSuffix ".json" | lower | replace "_" "-" }}
+            name: {{ include "common.names.fullname" $ }}-{{ $filename | trimSuffix ".json" | lower | replace "_" "-" }}
         {{- end }}
-      {{- with .Values.volumes }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/kit/charts/atk/charts/portal/templates/hpa.yaml
+++ b/kit/charts/atk/charts/portal/templates/hpa.yaml
@@ -1,32 +1,25 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ include "portal.fullname" . }}
+    name: {{ include "common.names.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.builtInMetrics }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.autoscaling.builtInMetrics "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.autoscaling.customMetrics }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.autoscaling.customMetrics "context" $) | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/kit/charts/atk/charts/portal/templates/ingress.yaml
+++ b/kit/charts/atk/charts/portal/templates/ingress.yaml
@@ -1,43 +1,59 @@
-{{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1
+{{- if .Values.ingress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
-  ingressClassName: {{ . }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
-            backend:
-              service:
-                name: {{ include "portal.fullname" $ }}
-                port:
-                  number: {{ $.Values.service.port }}
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
           {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+          - path: {{ .Values.ingress.graphqlPath }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "graphql" "context" $)  | nindent 14 }}
     {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- if .Values.ingress.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  tls:
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/kit/charts/atk/charts/portal/templates/networkpolicy.yaml
+++ b/kit/charts/atk/charts/portal/templates/networkpolicy.yaml
@@ -1,23 +1,66 @@
-{{- if .Values.networkPolicy.enabled -}}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
-    matchLabels:
-      {{- include "portal.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress
-  {{- if .Values.networkPolicy.ingress }}
-  ingress:
-    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
-  {{- end }}
-  {{- if .Values.networkPolicy.egress }}
+  {{- if (or (not .Values.networkPolicy.allowExternalEgress) (and (eq .Values.networkPolicy.allowExternalEgress false) .Values.networkPolicy.extraEgress)) }}
   egress:
-    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow connection to other portal pods
+    - ports:
+        - port: {{ .Values.service.port }}
+        - port: {{ .Values.service.graphqlPort }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 14 }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.service.port }}
+        - port: {{ .Values.service.graphqlPort }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ include "common.names.fullname" . }}-client: "true"
+        {{- if .Values.networkPolicy.addExternalClientAccess }}
+        - podSelector:
+            matchLabels:
+              {{ template "common.names.name" . }}-client: "true"
+        {{- end }}
+        {{- if .Values.networkPolicy.ingressRules.accessOnlyFrom.enabled }}
+        {{- if .Values.networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector }}
+        - namespaceSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector "context" $) | nindent 14 }}
+          {{- if .Values.networkPolicy.ingressRules.accessOnlyFrom.podSelector }}
+          podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.accessOnlyFrom.podSelector "context" $) | nindent 14 }}
+          {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/kit/charts/atk/charts/portal/templates/poddisruptionbudget.yaml
+++ b/kit/charts/atk/charts/portal/templates/poddisruptionbudget.yaml
@@ -1,18 +1,21 @@
-{{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1
+{{- if .Values.pdb.enabled }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
-spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  maxUnavailable: 1
   {{- end }}
   selector:
-    matchLabels:
-      {{- include "portal.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 6 }}
 {{- end }}

--- a/kit/charts/atk/charts/portal/templates/secret.yaml
+++ b/kit/charts/atk/charts/portal/templates/secret.yaml
@@ -1,18 +1,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
 stringData:
-  CONTRACT_ABI_PATH: /abis
-  BLOCKCHAIN_NETWORK_ID: {{ .Values.network.networkId | quote }}
-  BLOCKCHAIN_NETWORK_NAME: {{ .Values.network.networkName | quote }}
-  BLOCKCHAIN_JSON_RPC_ENDPOINT: {{ .Values.network.nodeRpcUrl | quote }}
-  POSTGRES_CONNECTION_STRING: {{ .Values.postgresql | quote }}
-  REDIS_HOST: {{ .Values.redis.host | quote }}
-  REDIS_PORT: {{ .Values.redis.port | quote }}
-  REDIS_USERNAME: {{ .Values.redis.username | quote }}
-  REDIS_PASSWORD: {{ .Values.redis.password | quote }}
+  CONTRACT_ABI_PATH: "/abis"
+  BLOCKCHAIN_NETWORK_ID: {{ .Values.config.network.networkId | quote }}
+  BLOCKCHAIN_NETWORK_NAME: {{ .Values.config.network.networkName | quote }}
+  BLOCKCHAIN_JSON_RPC_ENDPOINT: {{ .Values.config.network.nodeRpcUrl | quote }}
+  POSTGRES_CONNECTION_STRING: {{ .Values.config.postgresql | quote }}
+  REDIS_HOST: {{ .Values.config.redis.host | quote }}
+  REDIS_PORT: {{ .Values.config.redis.port | quote }}
+  REDIS_USERNAME: {{ .Values.config.redis.username | quote }}
+  REDIS_PASSWORD: {{ .Values.config.redis.password | quote }}
   PORT: {{ .Values.service.port | quote }}
   GRAPHQL_PORT: {{ .Values.service.graphqlPort | quote }}

--- a/kit/charts/atk/charts/portal/templates/service.yaml
+++ b/kit/charts/atk/charts/portal/templates/service.yaml
@@ -1,19 +1,49 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "portal.fullname" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- include "common.tplvalues.render" (dict "value" .Values.service.loadBalancerSourceRanges "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
     - port: {{ .Values.service.graphqlPort }}
       targetPort: graphql
       protocol: TCP
       name: graphql
-  selector:
-    {{- include "portal.selectorLabels" . | nindent 4 }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.graphqlNodePort }}
+      nodePort: {{ .Values.service.graphqlNodePort }}
+      {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 4 }}

--- a/kit/charts/atk/charts/portal/templates/serviceaccount.yaml
+++ b/kit/charts/atk/charts/portal/templates/serviceaccount.yaml
@@ -3,11 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "portal.serviceAccountName" . }}
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if .Values.serviceAccount.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/kit/charts/atk/charts/portal/templates/tests/test-connection.yaml
+++ b/kit/charts/atk/charts/portal/templates/tests/test-connection.yaml
@@ -1,16 +1,25 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "portal.fullname" . }}-test-connection"
-  labels:
-    {{- include "portal.labels" . | nindent 4 }}
+  name: "{{ include "common.names.fullname" . }}-test-connection"
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
+  {{- include "common.images.renderPullSecrets" ( dict "images" (list .Values.tests.image) "context" $) | nindent 2 }}
   containers:
     - name: wget
-      image: "{{ .Values.tests.image.registry }}/{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      image: {{ include "common.images.image" (dict "imageRoot" .Values.tests.image "global" .Values.global) }}
       imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
       command: ['wget']
-      args: ['{{ include "portal.fullname" . }}:{{ .Values.service.port }}']
+      args: 
+        - '-T'
+        - '5'
+        - '-t'
+        - '1'
+        - '{{ include "common.names.fullname" . }}:{{ .Values.service.port }}'
   restartPolicy: Never

--- a/kit/charts/atk/charts/portal/values.yaml
+++ b/kit/charts/atk/charts/portal/values.yaml
@@ -1,164 +1,338 @@
-# Default values for portal.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# -- Global Docker image registry
+global:
+  # -- Global Docker image registry
+  imageRegistry: ""
+  # -- Global Docker registry secret names as an array
+  imagePullSecrets: []
+  # -- Global StorageClass for Persistent Volume(s)
+  storageClass: ""
+  # -- Global labels to add to all objects
+  labels: {}
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
-replicaCount: 1
-
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
-image:
-  repository: ghcr.io/settlemint/btp-scs-portal
-  # This sets the pull policy for images.
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "8.5.5"
-
-# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets: []
-# This is to override the chart name.
-nameOverride: ""
+# -- String to fully override common.names.fullname
 fullnameOverride: "portal"
 
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: false
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
+# -- String to partially override common.names.fullname template (will maintain the release name)
+nameOverride: ""
 
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+# -- Labels to add to all deployed objects
+commonLabels: {}
+
+# -- Annotations to add to all deployed objects
+commonAnnotations: {}
+
+# -- Portal image
+image:
+  # -- Portal image registry
+  registry: ghcr.io
+  # -- Portal image repository
+  repository: settlemint/btp-scs-portal
+  # -- Portal image tag (immutable tags are recommended)
+  tag: "8.5.5"
+  # -- Portal image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  digest: ""
+  # -- Portal image pull policy
+  pullPolicy: IfNotPresent
+  # -- Portal image pull secrets
+  pullSecrets: []
+
+# -- Number of Portal replicas to deploy
+replicaCount: 1
+
+# -- Update strategy configuration for Portal deployment
+updateStrategy:
+  # -- Portal deployment strategy type
+  type: RollingUpdate
+  # -- Portal deployment rolling update configuration parameters
+  rollingUpdate: {}
+
+# -- Alternate scheduler
+schedulerName: ""
+
+# -- Portal pods' priority class name
+priorityClassName: ""
+
+# -- Topology Spread Constraints for pod assignment
+topologySpreadConstraints: []
+
+# -- Extra labels for Portal pods
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# -- Annotations for Portal pods
+podAnnotations: {}
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# -- Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+podAffinityPreset: ""
 
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
-service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-  type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 3000
-  graphqlPort: 3001
+# -- Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+podAntiAffinityPreset: soft
 
-# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-ingress:
-  enabled: true
-  className: "settlemint-nginx"
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: portal.k8s.orb.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-          port: 3000
-        - path: /graphql
-          pathType: ImplementationSpecific
-          port: 3001
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+# -- Node affinity preset configuration
+nodeAffinityPreset:
+  # -- Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  type: ""
+  # -- Node label key to match. Ignored if `affinity` is set
+  key: ""
+  # -- Node label values to match. Ignored if `affinity` is set
+  values: []
 
-resources: {}
-
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  tcpSocket:
-    port: http
-readinessProbe:
-  tcpSocket:
-    port: http
-
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
-# PodDisruptionBudget configuration
-podDisruptionBudget:
-  enabled: false
-  # Minimum number of pods that must be available during disruption
-  minAvailable: 1
-  # Maximum number of pods that can be unavailable during disruption
-  # maxUnavailable: 1
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
-nodeSelector: {}
-
-tolerations: []
-
+# -- Affinity for pod assignment
 affinity: {}
 
-# NetworkPolicy configuration
-networkPolicy:
+# -- Node labels for pod assignment
+nodeSelector: {}
+
+# -- Tolerations for pod assignment
+tolerations: []
+
+# -- Pod Security Context configuration
+podSecurityContext:
+  # -- Enabled Portal pods' Security Context
   enabled: false
-  # Ingress rules
-  ingress:
-    # Allow from ingress controller
+  # -- Set Portal pod's Security Context fsGroup
+  fsGroup: 1001
+  # -- Set kernel settings using the sysctl interface
+  sysctls: []
+
+# -- Container Security Context configuration
+containerSecurityContext:
+  # -- Enable container Security Context
+  enabled: false
+  # -- Set container's Security Context runAsUser
+  runAsUser: 1001
+  # -- Set container's Security Context runAsGroup
+  runAsGroup: 1001
+  # -- Set container's Security Context allowPrivilegeEscalation
+  allowPrivilegeEscalation: false
+  # -- Set container's Security Context readOnlyRootFilesystem
+  readOnlyRootFilesystem: false
+  # -- Set container's Security Context runAsNonRoot
+  runAsNonRoot: true
+  # -- Linux capabilities configuration
+  capabilities:
+    # -- Set container's Security Context drop capabilities
+    drop: ["ALL"]
+  # -- Seccomp profile configuration
+  seccompProfile:
+    # -- Set container's Security Context seccomp profile
+    type: "RuntimeDefault"
+
+# -- Portal containers resource requests and limits
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Configure Portal containers' liveness probe
+livenessProbe:
+  # -- Enable livenessProbe on Portal containers
+  enabled: true
+  # -- Initial delay seconds for livenessProbe
+  initialDelaySeconds: 10
+  # -- Period seconds for livenessProbe
+  periodSeconds: 10
+  # -- Timeout seconds for livenessProbe
+  timeoutSeconds: 5
+  # -- Failure threshold for livenessProbe
+  failureThreshold: 3
+  # -- Success threshold for livenessProbe
+  successThreshold: 1
+  # -- TCP socket parameters for livenessProbe
+  tcpSocket:
+    # -- Port for tcpSocket livenessProbe
+    port: http
+
+# -- Configure Portal containers' readiness probe
+readinessProbe:
+  # -- Enable readinessProbe on Portal containers
+  enabled: true
+  # -- Initial delay seconds for readinessProbe
+  initialDelaySeconds: 5
+  # -- Period seconds for readinessProbe
+  periodSeconds: 10
+  # -- Timeout seconds for readinessProbe
+  timeoutSeconds: 5
+  # -- Failure threshold for readinessProbe
+  failureThreshold: 3
+  # -- Success threshold for readinessProbe
+  successThreshold: 1
+  # -- TCP socket parameters for readinessProbe
+  tcpSocket:
+    # -- Port for tcpSocket readinessProbe
+    port: http
+
+# -- Configure Portal containers' startup probe
+startupProbe:
+  # -- Enable startupProbe on Portal containers
+  enabled: false
+  # -- Initial delay seconds for startupProbe
+  initialDelaySeconds: 30
+  # -- Period seconds for startupProbe
+  periodSeconds: 10
+  # -- Timeout seconds for startupProbe
+  timeoutSeconds: 5
+  # -- Failure threshold for startupProbe
+  failureThreshold: 10
+  # -- Success threshold for startupProbe
+  successThreshold: 1
+
+# -- lifecycleHooks for the Portal container(s) to automate configuration before or after startup
+lifecycleHooks: {}
+
+# -- Optionally specify extra list of additional volumes for the Portal pod(s)
+extraVolumes: []
+
+# -- Optionally specify extra list of additional volumeMounts for the Portal container(s)
+extraVolumeMounts: []
+
+# -- Array with extra environment variables to add to Portal nodes
+extraEnvVars: []
+
+# -- Name of existing ConfigMap containing extra env vars for Portal nodes
+extraEnvVarsCM: ""
+
+# -- Name of existing Secret containing extra env vars for Portal nodes
+extraEnvVarsSecret: ""
+
+# -- Service parameters
+service:
+  # -- Portal service type
+  type: ClusterIP
+  # -- Portal service HTTP port
+  port: 3000
+  # -- Portal service GraphQL port
+  graphqlPort: 3001
+  # -- Node port for HTTP
+  nodePort: ""
+  # -- Node port for GraphQL
+  graphqlNodePort: ""
+  # -- Portal service Cluster IP
+  clusterIP: ""
+  # -- Portal service Load Balancer IP
+  loadBalancerIP: ""
+  # -- Portal service Load Balancer sources
+  loadBalancerSourceRanges: []
+  # -- Portal service external traffic policy
+  externalTrafficPolicy: Cluster
+  # -- Additional custom annotations for Portal service
+  annotations: {}
+  # -- Extra ports to expose in the Portal service (normally used with the `sidecar` value)
+  extraPorts: []
+  # -- Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+  sessionAffinity: None
+  # -- Additional settings for the sessionAffinity
+  sessionAffinityConfig: {}
+
+# -- Ingress parameters
+ingress:
+  # -- Enable ingress record generation for Portal
+  enabled: true
+  # -- Ingress path type
+  pathType: ImplementationSpecific
+  # -- Force Ingress API version (automatically detected if not set)
+  apiVersion: ""
+  # -- Default host for the ingress record
+  hostname: portal.k8s.orb.local
+  # -- IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ingressClassName: "settlemint-nginx"
+  # -- Default path for the ingress record
+  path: /
+  # -- Additional path for GraphQL endpoint
+  graphqlPath: /graphql
+  # -- Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+  annotations: {}
+  # -- Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  tls: false
+  # -- Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  selfSigned: false
+  # -- An array with additional hostname(s) to be covered with the ingress record
+  extraHosts: []
+  # -- An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  extraPaths: []
+  # -- TLS configuration for additional hostname(s) to be covered with this ingress record
+  extraTls: []
+  # -- Custom TLS certificates as secrets
+  secrets: []
+  # -- Additional rules to be covered with this ingress record
+  extraRules: []
+
+# -- Service account for Portal pods
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created
+  create: true
+  # -- The name of the ServiceAccount to use.
+  name: ""
+  # -- Automount service account token for the deployment controller service account
+  automountServiceAccountToken: false
+  # -- Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
+  annotations: {}
+  # -- Extra labels to be added to the service account
+  labels: {}
+
+# -- Autoscaling configuration for Portal
+autoscaling:
+  # -- Enable autoscaling for Portal
+  enabled: false
+  # -- Maximum number of Portal replicas
+  maxReplicas: 3
+  # -- Minimum number of Portal replicas
+  minReplicas: 1
+  # -- Built-in metrics configuration
+  builtInMetrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  # -- Custom metrics configuration
+  customMetrics: []
+
+# -- Pod disruption budget configuration
+pdb:
+  # -- If true, create a pod disruption budget for pods.
+  enabled: false
+  # -- Minimum number/percentage of pods that should remain scheduled
+  minAvailable: ""
+  # -- Maximum number/percentage of pods that may be made unavailable. Defaults to 1 if both pdb.minAvailable and pdb.maxUnavailable are empty.
+  maxUnavailable: ""
+
+# -- Network policies configuration
+networkPolicy:
+  # -- Enable creation of NetworkPolicy resources
+  enabled: false
+  # -- The Policy model to apply
+  allowExternal: true
+  # -- Allow the pod to access any range of port and all destinations.
+  allowExternalEgress: true
+  # -- Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.
+  addExternalClientAccess: true
+  # -- Add extra ingress rules to the NetworkPolicy
+  extraIngress:
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx
-      ports:
-        - protocol: TCP
-          port: 3000
-        - protocol: TCP
-          port: 3001
-    # Allow from dapp
-    - from:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: dapp
+        - podSelector: {}  # Same namespace
       ports:
         - protocol: TCP
-          port: 3000
+          port: 3000  # HTTP port
         - protocol: TCP
-          port: 3001
-    # Allow from same namespace
-    - from:
-        - podSelector: {}
-      ports:
-        - protocol: TCP
-          port: 3000
-        - protocol: TCP
-          port: 3001
-
-  # Egress rules
-  egress:
+          port: 3001  # GraphQL port
+  # -- Add extra egress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+  extraEgress:
     # Allow DNS resolution
     - to:
         - namespaceSelector: {}
@@ -190,29 +364,57 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 443
+  # -- Ingress rules configuration
+  ingressRules:
+    # -- Access restrictions configuration
+    accessOnlyFrom:
+      # -- Enable ingress rule that makes Portal only accessible from a particular origin.
+      enabled: false
+      # -- Namespace selector label that is allowed to access Portal. This label will be used to identified allowed namespace(s).
+      namespaceSelector: {}
+      # -- Pods selector label that is allowed to access Portal. This label will be used to identified allowed pod(s).
+      podSelector: {}
 
+# -- Test parameters
 tests:
+  # -- Image for test pods
   image:
+    # -- Test image registry
     registry: docker.io
+    # -- Test image repository
     repository: busybox
+    # -- Test image tag
     tag: 1.37.0
+    # -- Test image pull policy
     pullPolicy: IfNotPresent
 
-# Define any init containers needed
-initContainers:
+# -- Init containers
+initContainers: []
   # - name: wait-for-postgres
   #   image: ghcr.io/settlemint/btp-waitforit:v7.7.2
   #   command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]
 
-network:
-  networkId: "53771311147"
-  networkName: "ATK"
-  nodeRpcUrl: http://txsigner:3000
+# -- Portal configuration
+config:
+  # -- Network configuration
+  network:
+    # -- Network ID
+    networkId: "53771311147"
+    # -- Network name
+    networkName: "ATK"
+    # -- Node RPC URL
+    nodeRpcUrl: "http://txsigner:3000"
 
-postgresql: postgresql://portal:atk@postgresql-pgpool:5432/portal?sslmode=disable
+  # -- PostgreSQL connection string
+  postgresql: "postgresql://portal:atk@postgresql-pgpool:5432/portal?sslmode=disable"
 
-redis:
-  host: redis-master
-  port: 6379
-  username: default
-  password: atk
+  # -- Redis configuration
+  redis:
+    # -- Redis host
+    host: "redis-master"
+    # -- Redis port
+    port: 6379
+    # -- Redis username
+    username: "default"
+    # -- Redis password
+    password: "atk"


### PR DESCRIPTION
## Summary
- Fixed invalid PodDisruptionBudget configuration in ERPC chart that could render both `minAvailable` and `maxUnavailable` fields simultaneously
- Implemented proper precedence: `minAvailable` takes priority, then `maxUnavailable`, defaulting to `maxUnavailable: 1` if neither is set

## Test plan
- [ ] Verify PDB renders correctly with only `minAvailable` set
- [ ] Verify PDB renders correctly with only `maxUnavailable` set
- [ ] Verify PDB renders correctly with neither value set (should default to `maxUnavailable: 1`)
- [ ] Verify PDB renders correctly with both values set (should only use `minAvailable`)