### PR TITLE
fix: resolve portal service and txsigner deployment issues

### DIFF
--- a/kit/charts/atk/charts/portal/templates/service.yaml
+++ b/kit/charts/atk/charts/portal/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- include "common.tplvalues.render" (dict "value" .Values.service.loadBalancerSourceRanges "context" $) | nindent 4 }}
   {{- end }}
-  {{- if .Values.service.externalTrafficPolicy }}
+  {{- if and .Values.service.externalTrafficPolicy (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if .Values.service.sessionAffinity }}

--- a/kit/charts/atk/charts/txsigner/README.md
+++ b/kit/charts/atk/charts/txsigner/README.md
@@ -90,7 +90,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | autoscaling.minReplicas | int | `1` | Minimum number of TxSigner replicas |
 | commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
 | commonLabels | object | `{}` | Labels to add to all deployed objects |
-| config | object | `{"allowedContracts":[],"allowedMethods":[],"audit":{"enabled":true,"retentionDays":30},"chainId":"53771311147","cors":{"enabled":false,"headers":["Content-Type","Authorization"],"methods":["GET","POST"],"origins":[]},"debug":false,"envSecret":{"create":false,"data":{}},"existingSecret":"","existingSecretKey":"private-key","gas":{"fixedPrice":20,"limit":3000000,"multiplier":1.1,"priceStrategy":"estimator"},"hsm":{"module":"","pin":"","slot":""},"kms":{"keyId":"","provider":"","region":""},"logLevel":"info","metricsPort":3001,"nonce":{"maxPending":10,"strategy":"sequential"},"port":3000,"privateKey":"","queue":{"maxSize":1000,"processingInterval":1000},"rateLimit":{"enabled":true,"maxRequestsPerHour":1000,"maxRequestsPerMinute":60},"rpcUrl":"http://besu-node-rpc-1:8545","signingStrategy":"local"}` | TxSigner configuration |
+| config | object | `{"allowedContracts":[],"allowedMethods":[],"audit":{"enabled":true,"retentionDays":30},"chainId":"53771311147","cors":{"enabled":false,"headers":["Content-Type","Authorization"],"methods":["GET","POST"],"origins":[]},"debug":false,"derivationPath":"","existingSecret":"","existingSecretKey":"private-key","extraSecretEnv":{},"gas":{"fixedPrice":20,"limit":3000000,"multiplier":1.1,"priceStrategy":"estimator"},"hsm":{"module":"","pin":"","slot":""},"kms":{"keyId":"","provider":"","region":""},"logLevel":"info","metricsPort":3001,"mnemonic":"","mode":"standalone","nonce":{"maxPending":10,"strategy":"sequential"},"port":3000,"privateKey":"","queue":{"maxSize":1000,"processingInterval":1000},"rateLimit":{"enabled":true,"maxRequestsPerHour":1000,"maxRequestsPerMinute":60},"rpcUrl":"http://erpc:4000","signingStrategy":"local"}` | TxSigner configuration |
 | config.allowedContracts | list | `[]` | Allowed contracts for interaction |
 | config.allowedMethods | list | `[]` | Allowed methods for execution |
 | config.audit | object | `{"enabled":true,"retentionDays":30}` | Audit logging |
@@ -103,11 +103,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | config.cors.methods | list | `["GET","POST"]` | Allowed methods |
 | config.cors.origins | list | `[]` | Allowed origins |
 | config.debug | bool | `false` | Enable debug mode |
-| config.envSecret | object | `{"create":false,"data":{}}` | Environment secret configuration |
-| config.envSecret.create | bool | `false` | Create environment secret |
-| config.envSecret.data | object | `{}` | Additional secret data |
+| config.derivationPath | string | `""` | Derivation path to use for the private key |
 | config.existingSecret | string | `""` | Use existing secret for private key |
 | config.existingSecretKey | string | `"private-key"` | Key within the existing secret |
+| config.extraSecretEnv | object | `{}` | Additional secret environment variables to add to the txsigner |
 | config.gas | object | `{"fixedPrice":20,"limit":3000000,"multiplier":1.1,"priceStrategy":"estimator"}` | Gas configuration |
 | config.gas.fixedPrice | int | `20` | Fixed gas price in Gwei (if priceStrategy is fixed) |
 | config.gas.limit | int | `3000000` | Gas limit |
@@ -123,6 +122,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | config.kms.region | string | `""` | KMS region |
 | config.logLevel | string | `"info"` | Log level for TxSigner |
 | config.metricsPort | int | `3001` | Port for the metrics server |
+| config.mnemonic | string | `""` | Mnemonic to use for the private key |
+| config.mode | string | `"standalone"` | Operation mode (standalone or integrated) |
 | config.nonce | object | `{"maxPending":10,"strategy":"sequential"}` | Nonce management |
 | config.nonce.maxPending | int | `10` | Maximum pending transactions |
 | config.nonce.strategy | string | `"sequential"` | Nonce management strategy (sequential, parallel) |
@@ -135,7 +136,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | config.rateLimit.enabled | bool | `true` | Enable rate limiting |
 | config.rateLimit.maxRequestsPerHour | int | `1000` | Maximum requests per hour |
 | config.rateLimit.maxRequestsPerMinute | int | `60` | Maximum requests per minute |
-| config.rpcUrl | string | `"http://besu-node-rpc-1:8545"` | RPC endpoint URL |
+| config.rpcUrl | string | `"http://erpc:4000"` | RPC endpoint URL |
 | config.signingStrategy | string | `"local"` | Signing strategy (local, kms, hsm) |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":false,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context configuration |
 | containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Set container's Security Context allowPrivilegeEscalation |
@@ -151,20 +152,20 @@ The command removes all the Kubernetes components associated with the chart and 
 | extraEnvVars | list | `[]` | Array with extra environment variables to add to TxSigner nodes |
 | extraEnvVarsCM | string | `""` | Name of existing ConfigMap containing extra env vars for TxSigner nodes |
 | extraEnvVarsSecret | string | `""` | Name of existing Secret containing extra env vars for TxSigner nodes |
-| extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts for the TxSigner container(s) |
-| extraVolumes | list | `[]` | Optionally specify extra list of additional volumes for the TxSigner pod(s) |
+| extraVolumeMounts | list | `[{"mountPath":"/signer/.cache","name":"tx-signer-cache"}]` | Optionally specify extra list of additional volumeMounts for the TxSigner container(s) |
+| extraVolumes | list | `[{"emptyDir":{},"name":"tx-signer-cache"}]` | Optionally specify extra list of additional volumes for the TxSigner pod(s) |
 | fullnameOverride | string | `"txsigner"` | String to fully override common.names.fullname |
 | global | object | `{"imagePullSecrets":[],"imageRegistry":"","storageClass":""}` | Global Docker image registry |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
 | global.imageRegistry | string | `""` | Global Docker image registry |
 | global.storageClass | string | `""` | Global StorageClass for Persistent Volume(s) |
-| image | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"","repository":"ghcr.io/settlemint/starterkit-asset-tokenization-txsigner","tag":"latest"}` | TxSigner image |
+| image | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"ghcr.io","repository":"settlemint/btp-signer","tag":"7.13.0"}` | TxSigner image |
 | image.digest | string | `""` | TxSigner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag |
 | image.pullPolicy | string | `"IfNotPresent"` | TxSigner image pull policy |
 | image.pullSecrets | list | `[]` | TxSigner image pull secrets |
-| image.registry | string | `""` | TxSigner image registry |
-| image.repository | string | `"ghcr.io/settlemint/starterkit-asset-tokenization-txsigner"` | TxSigner image repository |
-| image.tag | string | `"latest"` | TxSigner image tag (immutable tags are recommended) |
+| image.registry | string | `"ghcr.io"` | TxSigner image registry |
+| image.repository | string | `"settlemint/btp-signer"` | TxSigner image repository |
+| image.tag | string | `"7.13.0"` | TxSigner image tag (immutable tags are recommended) |
 | ingress | object | `{"annotations":{},"apiVersion":"","enabled":false,"extraHosts":[],"extraPaths":[],"extraRules":[],"extraTls":[],"hostname":"txsigner.k8s.orb.local","ingressClassName":"settlemint-nginx","path":"/","pathType":"ImplementationSpecific","secrets":[],"selfSigned":false,"tls":false}` | Ingress parameters |
 | ingress.annotations | object | `{}` | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. |
 | ingress.apiVersion | string | `""` | Force Ingress API version (automatically detected if not set) |
@@ -180,16 +181,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingress.secrets | list | `[]` | Custom TLS certificates as secrets |
 | ingress.selfSigned | bool | `false` | Create a TLS secret for this ingress record using self-signed certificates generated by Helm |
 | ingress.tls | bool | `false` | Enable TLS configuration for the host defined at `ingress.hostname` parameter |
+| initContainers | list | `[{"command":["/usr/bin/wait-for-it","postgresql-pgpool:5432","-t","0"],"image":"ghcr.io/settlemint/btp-waitforit:v7.7.5","name":"wait-for-postgres"}]` | Init containers configuration |
 | lifecycleHooks | object | `{}` | lifecycleHooks for the TxSigner container(s) to automate configuration before or after startup |
-| livenessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Configure TxSigner containers' liveness probe |
+| livenessProbe | object | `{"enabled":true,"failureThreshold":30,"initialDelaySeconds":1,"periodSeconds":10,"successThreshold":1,"tcpSocket":{"port":"http"},"timeoutSeconds":5}` | Configure TxSigner containers' liveness probe |
 | livenessProbe.enabled | bool | `true` | Enable livenessProbe on TxSigner containers |
-| livenessProbe.failureThreshold | int | `3` | Failure threshold for livenessProbe |
-| livenessProbe.httpGet | object | `{"path":"/health","port":"http"}` | HTTP get parameters for livenessProbe |
-| livenessProbe.httpGet.path | string | `"/health"` | Path for httpGet livenessProbe |
-| livenessProbe.httpGet.port | string | `"http"` | Port for httpGet livenessProbe |
-| livenessProbe.initialDelaySeconds | int | `10` | Initial delay seconds for livenessProbe |
+| livenessProbe.failureThreshold | int | `30` | Failure threshold for livenessProbe |
+| livenessProbe.initialDelaySeconds | int | `1` | Initial delay seconds for livenessProbe |
 | livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe |
 | livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe |
+| livenessProbe.tcpSocket | object | `{"port":"http"}` | TCP socket parameters for livenessProbe |
+| livenessProbe.tcpSocket.port | string | `"http"` | Port for tcpSocket livenessProbe |
 | livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe |
 | networkPolicy | object | `{"addExternalClientAccess":true,"allowExternal":true,"allowExternalEgress":true,"enabled":false,"extraEgress":[{"ports":[{"port":53,"protocol":"UDP"}],"to":[{"namespaceSelector":{},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}}}]},{"ports":[{"port":8545,"protocol":"TCP"}],"to":[{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"besu-statefulset"}}}]},{"ports":[{"port":443,"protocol":"TCP"}],"to":[{"namespaceSelector":{}}]}],"extraIngress":[{"from":[{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"dapp"}}},{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"portal"}}},{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"ingress-nginx"}}},{"podSelector":{}}],"ports":[{"port":3000,"protocol":"TCP"},{"port":3001,"protocol":"TCP"}]}],"ingressRules":{"accessOnlyFrom":{"enabled":false,"namespaceSelector":{},"podSelector":{}}}}` | Network policies configuration |
 | networkPolicy.addExternalClientAccess | bool | `true` | Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true. |
@@ -223,16 +224,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | podSecurityContext.enabled | bool | `true` | Enabled TxSigner pods' Security Context |
 | podSecurityContext.fsGroup | int | `1001` | Set TxSigner pod's Security Context fsGroup |
 | podSecurityContext.sysctls | list | `[]` | Set kernel settings using the sysctl interface |
+| postgresql | string | `"postgresql://txsigner:atk@postgresql-pgpool:5432/txsigner?sslmode=disable"` | PostgreSQL connection string |
 | priorityClassName | string | `""` | TxSigner pods' priority class name |
-| readinessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Configure TxSigner containers' readiness probe |
+| readinessProbe | object | `{"enabled":true,"failureThreshold":60,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":"http"},"timeoutSeconds":5}` | Configure TxSigner containers' readiness probe |
 | readinessProbe.enabled | bool | `true` | Enable readinessProbe on TxSigner containers |
-| readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe |
-| readinessProbe.httpGet | object | `{"path":"/health","port":"http"}` | HTTP get parameters for readinessProbe |
-| readinessProbe.httpGet.path | string | `"/health"` | Path for httpGet readinessProbe |
-| readinessProbe.httpGet.port | string | `"http"` | Port for httpGet readinessProbe |
-| readinessProbe.initialDelaySeconds | int | `5` | Initial delay seconds for readinessProbe |
-| readinessProbe.periodSeconds | int | `10` | Period seconds for readinessProbe |
+| readinessProbe.failureThreshold | int | `60` | Failure threshold for readinessProbe |
+| readinessProbe.initialDelaySeconds | int | `1` | Initial delay seconds for readinessProbe |
+| readinessProbe.periodSeconds | int | `5` | Period seconds for readinessProbe |
 | readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
+| readinessProbe.tcpSocket | object | `{"port":"http"}` | TCP socket parameters for readinessProbe |
+| readinessProbe.tcpSocket.port | string | `"http"` | Port for tcpSocket readinessProbe |
 | readinessProbe.timeoutSeconds | int | `5` | Timeout seconds for readinessProbe |
 | replicaCount | int | `1` | Number of TxSigner replicas to deploy |
 | resources | object | `{}` | TxSigner containers resource requests and limits |

--- a/kit/charts/atk/charts/txsigner/templates/deployment.yaml
+++ b/kit/charts/atk/charts/txsigner/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
       - name: txsigner
         image: {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
@@ -77,6 +80,10 @@ spec:
           value: {{ .Values.config.debug | quote }}
         - name: TX_SIGNER_SIGNING_STRATEGY
           value: {{ .Values.config.signingStrategy | quote }}
+        {{- if .Values.postgresql }}
+        - name: DATABASE_URL
+          value: {{ .Values.postgresql | quote }}
+        {{- end }}
         {{- if eq .Values.config.signingStrategy "local" }}
         {{- if .Values.config.existingSecret }}
         - name: TX_SIGNER_PRIVATE_KEY
@@ -84,12 +91,28 @@ spec:
             secretKeyRef:
               name: {{ .Values.config.existingSecret }}
               key: {{ .Values.config.existingSecretKey }}
-        {{- else if .Values.config.privateKey }}
+        {{- else if or .Values.config.privateKey .Values.config.mnemonic }}
+        {{- if .Values.config.privateKey }}
         - name: TX_SIGNER_PRIVATE_KEY
           valueFrom:
             secretKeyRef:
               name: {{ include "common.names.fullname" . }}-private-key
               key: private-key
+        {{- end }}
+        {{- if .Values.config.mnemonic }}
+        - name: PRIVATE_KEY_MNEMONIC
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.names.fullname" . }}-private-key
+              key: PRIVATE_KEY_MNEMONIC
+        {{- end }}
+        {{- if .Values.config.derivationPath }}
+        - name: PRIVATE_KEY_DERIVATION_PATH
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.names.fullname" . }}-private-key
+              key: PRIVATE_KEY_DERIVATION_PATH
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if eq .Values.config.signingStrategy "kms" }}
@@ -159,8 +182,9 @@ spec:
         {{- if .Values.extraEnvVars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 8 }}
         {{- end }}
-        {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
         envFrom:
+          - secretRef:
+              name: {{ include "common.names.fullname" . }}-env
           {{- if .Values.extraEnvVarsCM }}
           - configMapRef:
               name: {{ .Values.extraEnvVarsCM }}
@@ -169,7 +193,6 @@ spec:
           - secretRef:
               name: {{ .Values.extraEnvVarsSecret }}
           {{- end }}
-        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.config.port }}
@@ -178,10 +201,24 @@ spec:
           containerPort: {{ .Values.config.metricsPort }}
           protocol: TCP
         {{- if .Values.livenessProbe.enabled }}
-        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 10 }}
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.livenessProbe.tcpSocket.port }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
-        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 10 }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.readinessProbe.tcpSocket.port }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
         {{- end }}
         {{- if .Values.startupProbe.enabled }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 10 }}

--- a/kit/charts/atk/charts/txsigner/templates/secret-env.yaml
+++ b/kit/charts/atk/charts/txsigner/templates/secret-env.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.config.envSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,8 +9,10 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
-  # Add any additional environment variables that need to be kept secret
-  {{- if .Values.config.envSecret.data }}
-  {{- toYaml .Values.config.envSecret.data | nindent 2 }}
+  MODE: {{ .Values.config.mode | quote }}
+  RPC_ENDPOINT: {{ .Values.config.rpcUrl | quote }}
+  DB_CONNECTION_STRING: {{ .Values.postgresql | quote }}
+  {{- if .Values.config.extraSecretEnv }}
+  # Additional secret environment variables
+  {{- toYaml .Values.config.extraSecretEnv | nindent 2 }}
   {{- end }}
-{{- end }}

--- a/kit/charts/atk/charts/txsigner/templates/secret-private-key.yaml
+++ b/kit/charts/atk/charts/txsigner/templates/secret-private-key.yaml
@@ -1,4 +1,5 @@
-{{- if and (eq .Values.config.signingStrategy "local") .Values.config.privateKey (not .Values.config.existingSecret) }}
+{{- if and (eq .Values.config.signingStrategy "local") (not .Values.config.existingSecret) }}
+{{- if or .Values.config.privateKey .Values.config.mnemonic }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,15 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
-data:
-  private-key: {{ .Values.config.privateKey | b64enc | quote }}
+stringData:
+  {{- if .Values.config.privateKey }}
+  private-key: {{ .Values.config.privateKey | quote }}
+  {{- end }}
+  {{- if .Values.config.mnemonic }}
+  PRIVATE_KEY_MNEMONIC: {{ .Values.config.mnemonic | quote }}
+  {{- end }}
+  {{- if .Values.config.derivationPath }}
+  PRIVATE_KEY_DERIVATION_PATH: {{ .Values.config.derivationPath | quote }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/kit/charts/atk/charts/txsigner/values.yaml
+++ b/kit/charts/atk/charts/txsigner/values.yaml
@@ -19,11 +19,11 @@ commonAnnotations: {}
 # -- TxSigner image
 image:
   # -- TxSigner image registry
-  registry: ""
+  registry: "ghcr.io"
   # -- TxSigner image repository
-  repository: ghcr.io/settlemint/starterkit-asset-tokenization-txsigner
+  repository: settlemint/btp-signer
   # -- TxSigner image tag (immutable tags are recommended)
-  tag: "latest"
+  tag: "7.13.0"
   # -- TxSigner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   digest: ""
   # -- TxSigner image pull policy
@@ -119,7 +119,8 @@ containerSecurityContext:
     type: "RuntimeDefault"
 
 # -- TxSigner containers resource requests and limits
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -132,20 +133,18 @@ livenessProbe:
   # -- Enable livenessProbe on TxSigner containers
   enabled: true
   # -- Initial delay seconds for livenessProbe
-  initialDelaySeconds: 10
+  initialDelaySeconds: 1
   # -- Period seconds for livenessProbe
   periodSeconds: 10
   # -- Timeout seconds for livenessProbe
   timeoutSeconds: 5
   # -- Failure threshold for livenessProbe
-  failureThreshold: 3
+  failureThreshold: 30
   # -- Success threshold for livenessProbe
   successThreshold: 1
-  # -- HTTP get parameters for livenessProbe
-  httpGet:
-    # -- Path for httpGet livenessProbe
-    path: /health
-    # -- Port for httpGet livenessProbe
+  # -- TCP socket parameters for livenessProbe
+  tcpSocket:
+    # -- Port for tcpSocket livenessProbe
     port: http
 
 # -- Configure TxSigner containers' readiness probe
@@ -153,20 +152,18 @@ readinessProbe:
   # -- Enable readinessProbe on TxSigner containers
   enabled: true
   # -- Initial delay seconds for readinessProbe
-  initialDelaySeconds: 5
+  initialDelaySeconds: 1
   # -- Period seconds for readinessProbe
-  periodSeconds: 10
+  periodSeconds: 5
   # -- Timeout seconds for readinessProbe
   timeoutSeconds: 5
   # -- Failure threshold for readinessProbe
-  failureThreshold: 3
+  failureThreshold: 60
   # -- Success threshold for readinessProbe
   successThreshold: 1
-  # -- HTTP get parameters for readinessProbe
-  httpGet:
-    # -- Path for httpGet readinessProbe
-    path: /health
-    # -- Port for httpGet readinessProbe
+  # -- TCP socket parameters for readinessProbe
+  tcpSocket:
+    # -- Port for tcpSocket readinessProbe
     port: http
 
 # -- Configure TxSigner containers' startup probe
@@ -188,10 +185,14 @@ startupProbe:
 lifecycleHooks: {}
 
 # -- Optionally specify extra list of additional volumes for the TxSigner pod(s)
-extraVolumes: []
+extraVolumes:
+  - name: tx-signer-cache
+    emptyDir: {}
 
 # -- Optionally specify extra list of additional volumeMounts for the TxSigner container(s)
-extraVolumeMounts: []
+extraVolumeMounts:
+  - name: tx-signer-cache
+    mountPath: /signer/.cache
 
 # -- Array with extra environment variables to add to TxSigner nodes
 extraEnvVars: []
@@ -331,12 +332,12 @@ networkPolicy:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: ingress-nginx
-        - podSelector: {}  # Same namespace
+        - podSelector: {} # Same namespace
       ports:
         - protocol: TCP
-          port: 3000  # HTTP port
+          port: 3000 # HTTP port
         - protocol: TCP
-          port: 3001  # Metrics port
+          port: 3001 # Metrics port
   # -- Add extra egress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
   extraEgress:
     # Allow DNS resolution
@@ -355,7 +356,7 @@ networkPolicy:
               app.kubernetes.io/name: besu-statefulset
       ports:
         - protocol: TCP
-          port: 8545  # RPC
+          port: 8545 # RPC
     # Allow access to external HTTPS APIs (for signing services)
     - to:
         - namespaceSelector: {}
@@ -388,12 +389,14 @@ tests:
 
 # -- TxSigner configuration
 config:
+  # -- Operation mode (standalone or integrated)
+  mode: "standalone"
   # -- Enable debug mode
   debug: false
   # -- Log level for TxSigner
   logLevel: info
   # -- RPC endpoint URL
-  rpcUrl: "http://besu-node-rpc-1:8545"
+  rpcUrl: "http://erpc:4000"
   # -- Chain ID for the network
   chainId: "53771311147"
   # -- Port for the HTTP server
@@ -404,6 +407,10 @@ config:
   signingStrategy: "local"
   # -- Private key for local signing (use with caution, prefer secrets)
   privateKey: ""
+  # -- Mnemonic to use for the private key
+  mnemonic: ""
+  # -- Derivation path to use for the private key
+  derivationPath: ""
   # -- Use existing secret for private key
   existingSecret: ""
   # -- Key within the existing secret
@@ -474,9 +481,14 @@ config:
     methods: ["GET", "POST"]
     # -- Allowed headers
     headers: ["Content-Type", "Authorization"]
-  # -- Environment secret configuration
-  envSecret:
-    # -- Create environment secret
-    create: false
-    # -- Additional secret data
-    data: {}
+  # -- Additional secret environment variables to add to the txsigner
+  extraSecretEnv: {}
+
+# -- PostgreSQL connection string
+postgresql: "postgresql://txsigner:atk@postgresql-pgpool:5432/txsigner?sslmode=disable"
+
+# -- Init containers configuration
+initContainers:
+  - name: wait-for-postgres
+    image: ghcr.io/settlemint/btp-waitforit:v7.7.5
+    command: ["/usr/bin/wait-for-it", "postgresql-pgpool:5432", "-t", "0"]


### PR DESCRIPTION
## Summary

- Fix portal service externalTrafficPolicy error by adding service type validation
- Update txsigner chart with stable image version and restore missing functionality
- Resolve pod restart issues with proper health probe configuration

## Changes

### Portal Service Fix
- Added conditional check for externalTrafficPolicy to only apply for LoadBalancer/NodePort services
- Prevents "Service 'portal' is invalid: spec.externalTrafficPolicy: Invalid value: 'Cluster': may only be set for externally-accessible services" error

### TxSigner Improvements
- Updated image tag from "latest" to "7.13.0" for stable deployment
- Restored PostgreSQL support with connection string and init containers
- Added mnemonic-based private key configuration for standalone mode
- Changed health probes from HTTP to TCP socket to prevent restart loops
- Added required environment variables (DATABASE_URL, PRIVATE_KEY_MNEMONIC, PRIVATE_KEY_DERIVATION_PATH)
- Fixed secret generation to always create env secret and support mnemonic configuration
- Added volume mounts for txsigner cache directory

## Test Results

- ✅ Portal service deploys without externalTrafficPolicy errors
- ✅ TxSigner pod runs successfully with stable image version
- ✅ Private key secrets are properly generated and mounted
- ✅ PostgreSQL connectivity established via init containers
- ✅ Health probes use TCP socket checks preventing restart loops

## Test plan

- [x] Helm template generation validates without errors
- [x] Portal service deploys correctly with ClusterIP type
- [x] TxSigner pod starts and maintains Running status
- [x] All required secrets are created and mounted
- [x] Environment variables are properly configured
- [x] Database connectivity is established