### PR TITLE
feat: expose pgpool service as LoadBalancer

### DIFF
--- a/kit/charts/atk/charts/observability/README.md
+++ b/kit/charts/atk/charts/observability/README.md
@@ -19,7 +19,7 @@ A Helm chart for the observability components
 | https://grafana.github.io/helm-charts | loki | 6.30.1 |
 | https://grafana.github.io/helm-charts | tempo | 1.21.1 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.12.2 |
-| https://prometheus-community.github.io/helm-charts | kube-state-metrics | 5.35.0 |
+| https://prometheus-community.github.io/helm-charts | kube-state-metrics | 5.36.0 |
 | https://prometheus-community.github.io/helm-charts | prometheus-node-exporter | 4.47.0 |
 | https://victoriametrics.github.io/helm-charts/ | victoria-metrics-single | 0.20.0 |
 

--- a/kit/charts/atk/charts/support/README.md
+++ b/kit/charts/atk/charts/support/README.md
@@ -157,6 +157,14 @@ A Helm chart for the supporting components
 | postgresql-ha.postgresql.repmgrUsername | string | `"repmgr"` |  |
 | postgresql-ha.postgresql.resourcesPreset | string | `"none"` |  |
 | postgresql-ha.postgresql.username | string | `"postgres"` |  |
+| postgresql-ha.service.annotations."service.beta.kubernetes.io/aws-load-balancer-backend-protocol" | string | `"tcp"` |  |
+| postgresql-ha.service.annotations."service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" | string | `"ip"` |  |
+| postgresql-ha.service.annotations."service.beta.kubernetes.io/aws-load-balancer-scheme" | string | `"internet-facing"` |  |
+| postgresql-ha.service.annotations."service.beta.kubernetes.io/aws-load-balancer-type" | string | `"nlb"` |  |
+| postgresql-ha.service.annotations."service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset" | string | `"true"` |  |
+| postgresql-ha.service.annotations."service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout" | string | `"30"` |  |
+| postgresql-ha.service.externalTrafficPolicy | string | `"Local"` |  |
+| postgresql-ha.service.type | string | `"LoadBalancer"` |  |
 | redis.auth.password | string | `"atk"` |  |
 | redis.commonLabels."app.kubernetes.io/managed-by" | string | `"helm"` |  |
 | redis.commonLabels."kots.io/app-slug" | string | `"settlemint-atk"` |  |

--- a/kit/charts/atk/charts/support/values.yaml
+++ b/kit/charts/atk/charts/support/values.yaml
@@ -65,6 +65,21 @@ postgresql-ha:
     logConnections: true
     resourcesPreset: none
     pullSecrets: []
+  service:
+    # Change the service type from ClusterIP to LoadBalancer
+    type: LoadBalancer
+    # External traffic policy - use Local for better performance and client IP preservation
+    externalTrafficPolicy: Local
+    # Cloud-specific annotations
+    annotations:
+      # AWS Network Load Balancer configuration
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+      # Azure Load Balancer configuration
+      service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset: "true"
+      service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout: "30"
 
 # https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
 redis:


### PR DESCRIPTION
## Summary
- Enable external access to PostgreSQL database cluster by exposing pgpool as a LoadBalancer service
- Add cloud-specific optimizations for AWS Network Load Balancer and Azure Load Balancer configurations

## Test plan
- [ ] Deploy the updated Helm chart to a test cluster
- [ ] Verify the pgpool service is accessible externally via the LoadBalancer IP
- [ ] Test database connectivity from external clients
- [ ] Confirm cloud-specific annotations are applied correctly (AWS NLB or Azure LB)
- [ ] Validate that existing internal connections continue to work