### PR TITLE
feat: add environment configuration to ATK helm chart notes

### DIFF
--- a/kit/charts/atk/templates/NOTES.txt
+++ b/kit/charts/atk/templates/NOTES.txt
@@ -5,10 +5,68 @@
 The following endpoints are now available:
 
   Blockchain JSON-RPC: https://{{ (index .Values.erpc.ingress.hosts 0).host | default "rpc.k8s.orb.local" }}
-   Blockchain Exlorer: https://{{ (index .Values "blockscout" "blockscout-stack" "frontend" "ingress" "hostname" ) | default "explorer.k8s.orb.local" }}
-            The Graph: https://{{ (index .Values "thegraph" "graph-node" "ingress" "hosts" 0).host | default "graph.k8s.orb.local" }}
-               Hasura: https://{{ (index .Values "hasura" "graphql-engine" "ingress" "hostName" ) | default "hasura.k8s.orb.local" }}
-              Grafana: https://{{ (index .Values "observability" "grafana" "ingress" "hosts" 0 ) | default "grafana.k8s.orb.local" }}
+   Blockchain Explorer: https://{{ (index .Values "blockscout" "blockscout-stack" "frontend" "ingress" "hostname" ) | default "explorer.k8s.orb.local" }}
+             The Graph: https://{{ (index .Values "thegraph" "graph-node" "ingress" "hosts" 0).host | default "graph.k8s.orb.local" }}
+                Hasura: https://{{ (index .Values "hasura" "graphql-engine" "ingress" "hostName" ) | default "hasura.k8s.orb.local" }}
+               Grafana: https://{{ (index .Values "observability" "grafana" "ingress" "hosts" 0 ) | default "grafana.k8s.orb.local" }}
 {{- if .Values.dapp.enabled }}
-                 DApp: https://{{ (index .Values.dapp.ingress.hosts 0).host | default "dapp.k8s.orb.local" }}
+                  DApp: https://{{ (index .Values.dapp.ingress.hosts 0).host | default "dapp.k8s.orb.local" }}
+{{- end }}
+
+========================================================================
+                      Environment Configuration
+========================================================================
+
+To connect your development environment to this deployment, you need
+to configure the following environment variables:
+
+Configuration Details:
+  Instance Type: standalone
+  Blockchain RPC: {{- if and .Values.txsigner.enabled .Values.txsigner.ingress.enabled }} https://{{ .Values.txsigner.ingress.hostname | default "txsigner.k8s.orb.local" }}{{- else }} https://{{ (index .Values.erpc.ingress.hosts 0).host | default "rpc.k8s.orb.local" }}{{- end }}
+  Load Balancer: https://{{ (index .Values.erpc.ingress.hosts 0).host | default "rpc.k8s.orb.local" }}
+  Hasura GraphQL: https://{{ (index .Values "hasura" "graphql-engine" "ingress" "hostName" ) | default "hasura.k8s.orb.local" }}/v1/graphql
+  Hasura Admin Secret: {{ .Values.dapp.secretEnv.SETTLEMINT_HASURA_ADMIN_SECRET | default "atk" }}
+  Database URL: {{ .Values.dapp.secretEnv.SETTLEMINT_HASURA_DATABASE_URL | default "postgresql://hasura:atk@postgresql-pgpool:5432/hasura" }}
+  The Graph Endpoint: https://{{ (index .Values "thegraph" "graph-node" "ingress" "hosts" 0).host | default "graph.k8s.orb.local" }}
+  Subgraph Names: kit
+  Portal GraphQL: https://{{ .Values.portal.ingress.hostname | default "portal.k8s.orb.local" }}/graphql
+  MinIO Endpoint: s3://minio.k8s.orb.local
+  MinIO Access Key: <MINIO_ACCESS_KEY>
+  MinIO Secret Key: <MINIO_SECRET_KEY>
+  IPFS Endpoint: https://ipfs.console.settlemint.com
+  Blockscout GraphQL: https://{{ (index .Values "blockscout" "blockscout-stack" "frontend" "ingress" "hostname" ) | default "explorer.k8s.orb.local" }}/api/v1/graphql
+
+========================================================================
+                    Environment Variable Files
+========================================================================
+
+Create the following files in your project root directory:
+
+=== .env ===
+SETTLEMINT_BLOCKCHAIN_NODE_JSON_RPC_ENDPOINT={{- if and .Values.txsigner.enabled .Values.txsigner.ingress.enabled }}https://{{ .Values.txsigner.ingress.hostname | default "txsigner.k8s.orb.local" }}{{- else }}https://{{ (index .Values.erpc.ingress.hosts 0).host | default "rpc.k8s.orb.local" }}{{- end }}
+SETTLEMINT_BLOCKCHAIN_NODE_OR_LOAD_BALANCER_JSON_RPC_ENDPOINT=https://{{ (index .Values.erpc.ingress.hosts 0).host | default "rpc.k8s.orb.local" }}
+SETTLEMINT_BLOCKSCOUT_GRAPHQL_ENDPOINT=https://{{ (index .Values "blockscout" "blockscout-stack" "frontend" "ingress" "hostname" ) | default "explorer.k8s.orb.local" }}/api/v1/graphql
+SETTLEMINT_HASURA_ENDPOINT=https://{{ (index .Values "hasura" "graphql-engine" "ingress" "hostName" ) | default "hasura.k8s.orb.local" }}/v1/graphql
+SETTLEMINT_INSTANCE=standalone
+SETTLEMINT_IPFS_API_ENDPOINT=https://ipfs.console.settlemint.com
+SETTLEMINT_MINIO_ACCESS_KEY=<MINIO_ACCESS_KEY>
+SETTLEMINT_MINIO_ENDPOINT=s3://minio.k8s.orb.local
+SETTLEMINT_PORTAL_GRAPHQL_ENDPOINT=https://{{ .Values.portal.ingress.hostname | default "portal.k8s.orb.local" }}/graphql
+SETTLEMINT_THEGRAPH_DEFAULT_SUBGRAPH=kit
+SETTLEMINT_THEGRAPH_SUBGRAPHS_ENDPOINTS=["https://{{ (index .Values "thegraph" "graph-node" "ingress" "hosts" 0).host | default "graph.k8s.orb.local" }}/subgraphs/name/kit"]
+
+=== .env.local ===
+SETTLEMINT_HASURA_ADMIN_SECRET={{ .Values.dapp.secretEnv.SETTLEMINT_HASURA_ADMIN_SECRET | default "atk" }}
+SETTLEMINT_HASURA_DATABASE_URL={{ .Values.dapp.secretEnv.SETTLEMINT_HASURA_DATABASE_URL | default "postgresql://hasura:atk@postgresql-pgpool:5432/hasura" }}
+SETTLEMINT_MINIO_SECRET_KEY=<MINIO_SECRET_KEY>
+
+========================================================================
+
+Notes:
+- Replace <MINIO_ACCESS_KEY> and <MINIO_SECRET_KEY> with your actual
+  MinIO credentials when MinIO is configured in your deployment.
+{{- if and .Values.txsigner.enabled (not .Values.txsigner.ingress.enabled) }}
+- Transaction Signer is enabled but not exposed via ingress. To use it
+  for signing transactions, either enable ingress for txsigner or use
+  the regular RPC endpoint which will handle transactions internally.
 {{- end }}

--- a/kit/charts/tools/extract-env.ts
+++ b/kit/charts/tools/extract-env.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+import { existsSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+interface ExtractOptions {
+  releaseName?: string;
+  namespace?: string;
+  outputDir?: string;
+}
+
+async function extractEnvFromHelmNotes(options: ExtractOptions = {}) {
+  const {
+    releaseName = "atk",
+    namespace = "atk",
+    outputDir = resolve(process.cwd(), "../../"),
+  } = options;
+
+  try {
+    // Get the helm notes output
+    console.log(
+      `📋 Extracting environment configuration from Helm release '${releaseName}' in namespace '${namespace}'...`
+    );
+
+    const notesResult =
+      await $`helm get notes ${releaseName} -n ${namespace}`.text();
+
+    if (!notesResult) {
+      throw new Error("No notes found for the specified release");
+    }
+
+    // Find the .env section
+    const envStartMarker = "=== .env ===";
+    const envLocalStartMarker = "=== .env.local ===";
+    const sectionEndMarker =
+      "========================================================================";
+
+    const envStart = notesResult.indexOf(envStartMarker);
+    const envLocalStart = notesResult.indexOf(envLocalStartMarker);
+
+    if (envStart === -1 || envLocalStart === -1) {
+      throw new Error(
+        "Could not find environment variable sections in helm notes"
+      );
+    }
+
+    // Extract .env content
+    const envEndSearch = notesResult.indexOf("\n\n", envStart);
+    const envContent = notesResult
+      .substring(envStart + envStartMarker.length, envEndSearch)
+      .trim();
+
+    // Extract .env.local content
+    const envLocalEndSearch = notesResult.indexOf(
+      sectionEndMarker,
+      envLocalStart
+    );
+    const envLocalContent = notesResult
+      .substring(envLocalStart + envLocalStartMarker.length, envLocalEndSearch)
+      .trim();
+
+    // Ensure output directory exists
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Write .env file
+    const envPath = join(outputDir, ".env");
+    await Bun.write(envPath, envContent + "\n");
+    console.log(`✅ Created ${envPath}`);
+
+    // Write .env.local file
+    const envLocalPath = join(outputDir, ".env.local");
+    await Bun.write(envLocalPath, envLocalContent + "\n");
+    console.log(`✅ Created ${envLocalPath}`);
+
+    // Display a summary
+    console.log("\n📝 Environment files created successfully!");
+    console.log("\n⚠️  Important notes:");
+    console.log(
+      "   - Review and update the MinIO credentials (marked with <MINIO_ACCESS_KEY> and <MINIO_SECRET_KEY>)"
+    );
+    console.log(
+      "   - These files contain sensitive information - do not commit them to version control"
+    );
+    console.log(
+      "   - Add .env and .env.local to your .gitignore if not already present"
+    );
+  } catch (error) {
+    console.error("❌ Error extracting environment configuration:", error);
+    if (error instanceof Error && error.message.includes("not found")) {
+      console.error("\n💡 Make sure:");
+      console.error("   - Helm is installed and available in your PATH");
+      console.error("   - The release name and namespace are correct");
+      console.error(
+        "   - You have the necessary permissions to access the release"
+      );
+    }
+    process.exit(1);
+  }
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const options: ExtractOptions = {};
+
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
+    case "--release":
+    case "-r":
+      options.releaseName = args[++i];
+      break;
+    case "--namespace":
+    case "-n":
+      options.namespace = args[++i];
+      break;
+    case "--output":
+    case "-o":
+      options.outputDir = args[++i];
+      break;
+    case "--help":
+    case "-h":
+      console.log(`
+Usage: bun run extract-env.ts [options]
+
+Options:
+  -r, --release <name>      Helm release name (default: atk)
+  -n, --namespace <name>    Kubernetes namespace (default: atk)
+  -o, --output <dir>        Output directory for env files (default: ../../)
+  -h, --help                Show this help message
+
+Example:
+  bun run extract-env.ts --release my-atk --namespace production --output ./config
+`);
+      process.exit(0);
+  }
+}
+
+// Run the extraction
+await extractEnvFromHelmNotes(options);

--- a/kit/charts/tools/values-orbstack.1p.yaml
+++ b/kit/charts/tools/values-orbstack.1p.yaml
@@ -52,3 +52,8 @@ observability:
 blockscout:
   enabled: false
 
+txsigner:
+  ingress:
+    enabled: true
+    hostname: txsigner.k8s.orb.local
+

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "test:e2e:ui:debug": "bun run --cwd kit/e2e playwright test --config=playwright.ui.config.ts --project=ui-tests --ui",
     "test:e2e:api": "bun run --cwd kit/e2e playwright test --config=playwright.api.config.ts --project=api-tests",
     "test:e2e:api:debug": "bun run --cwd kit/e2e playwright test --config=playwright.api.config.ts --project=api-tests --ui",
-    "helm": "turbo run helm"
+    "helm": "turbo run helm",
+    "extract-env": "bun run tools/extract-env.ts"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Added environment variable configuration sections to Helm chart NOTES.txt
- Created extract-env.ts tool to automatically extract environment configuration from deployed releases

## Test plan
1. Deploy the ATK helm chart: `helm install atk ./kit/charts/atk -n atk -f ./kit/charts/tools/values-orbstack.1p.yaml`
2. View the notes: `helm get notes atk -n atk`
3. Extract environment files: `bun run extract-env`
4. Verify `.env` and `.env.local` files are created with correct values