### PR TITLE
feat: Update better-auth-ui to version 2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "dapp",
       "version": "1.0.6",
       "dependencies": {
-        "@daveyplate/better-auth-ui": "1.7.4",
+        "@daveyplate/better-auth-ui": "2.0.0",
         "@hookform/resolvers": "5.1.1",
         "@next-safe-action/adapter-react-hook-form": "1.0.14",
         "@opentelemetry/api": "1.9.0",
@@ -372,7 +372,7 @@
 
     "@daveyplate/better-auth-tanstack": ["@daveyplate/better-auth-tanstack@1.3.6", "", { "peerDependencies": { "@tanstack/query-core": ">=5.65.0", "@tanstack/react-query": ">=5.65.0", "better-auth": ">=1.2.8", "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-GvIGdbjRMZCEfAffU7LeWpGpie4vSli8V9jmNFCQOziZZMEFbO4cd53HBFmAushC9oEYIyhSNZBgV2ADzW94Ww=="],
 
-    "@daveyplate/better-auth-ui": ["@daveyplate/better-auth-ui@1.7.4", "", { "peerDependencies": { "@better-fetch/fetch": ">=1.1.0", "@daveyplate/better-auth-tanstack": "^1.3.5", "@hcaptcha/react-hcaptcha": ">=1.12.0", "@hookform/resolvers": ">=5.0.0", "@instantdb/react": ">=0.18.0", "@marsidev/react-turnstile": ">=1.1.0", "@radix-ui/react-avatar": ">=1.1.0", "@radix-ui/react-checkbox": ">=1.1.0", "@radix-ui/react-context": ">=1.1.0", "@radix-ui/react-dialog": ">=1.1.0", "@radix-ui/react-dropdown-menu": ">=2.1.0", "@radix-ui/react-label": ">=2.1.0", "@radix-ui/react-primitive": ">=2.0.0", "@radix-ui/react-select": ">=2.2.0", "@radix-ui/react-separator": ">=1.1.0", "@radix-ui/react-slot": ">=1.1.0", "@radix-ui/react-tabs": ">=1.1.0", "@radix-ui/react-use-callback-ref": ">=1.1.0", "@radix-ui/react-use-layout-effect": ">=1.1.0", "@react-email/components": ">=0.0.33", "@tanstack/react-query": ">=5.66.0", "@triplit/client": ">=1.0.0", "@triplit/react": ">=1.0.0", "@wojtekmaj/react-recaptcha-v3": ">=0.1.4", "better-auth": "^1.2.4", "class-variance-authority": ">=0.7.0", "clsx": ">=2.1.0", "input-otp": ">=1.4.0", "lucide-react": ">=0.469.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-google-recaptcha": ">=3.1.0", "react-hook-form": ">=7.55.0", "react-qr-code": ">=2.0.0", "sonner": ">=1.7.0", "tailwind-merge": ">=2.6.0", "tailwindcss": ">=3.0.0", "ua-parser-js": ">=2.0.0", "zod": ">=3.24.0" } }, "sha512-YMlH0jXxZkfi97ibxvPqzYn02hQWOqV2EZ7jXab/NRYC57/KEacRV2ykWnyswzsBnes6LGW6ir8TREPitz2K+Q=="],
+    "@daveyplate/better-auth-ui": ["@daveyplate/better-auth-ui@2.0.0", "", { "dependencies": { "@better-fetch/fetch": "^1.1.18", "@hcaptcha/react-hcaptcha": "^1.12.0", "@react-email/components": "^0.0.42", "@wojtekmaj/react-recaptcha-v3": "^0.1.4", "react-google-recaptcha": "^3.1.0", "react-qr-code": "^2.0.15", "ua-parser-js": "^2.0.3", "vaul": "^1.1.2" }, "peerDependencies": { "@daveyplate/better-auth-tanstack": "^1.3.6", "@hookform/resolvers": ">=5.0.0", "@instantdb/react": ">=0.18.0", "@marsidev/react-turnstile": ">=1.1.0", "@radix-ui/react-avatar": ">=1.1.0", "@radix-ui/react-checkbox": ">=1.1.0", "@radix-ui/react-context": ">=1.1.0", "@radix-ui/react-dialog": ">=1.1.0", "@radix-ui/react-dropdown-menu": ">=2.1.0", "@radix-ui/react-label": ">=2.1.0", "@radix-ui/react-primitive": ">=2.0.0", "@radix-ui/react-select": ">=2.2.0", "@radix-ui/react-separator": ">=1.1.0", "@radix-ui/react-slot": ">=1.1.0", "@radix-ui/react-tabs": ">=1.1.0", "@radix-ui/react-use-callback-ref": ">=1.1.0", "@radix-ui/react-use-layout-effect": ">=1.1.0", "@tanstack/react-query": ">=5.66.0", "@triplit/client": ">=1.0.0", "@triplit/react": ">=1.0.0", "better-auth": "^1.2.9", "class-variance-authority": ">=0.7.0", "clsx": ">=2.1.0", "input-otp": ">=1.4.0", "lucide-react": ">=0.469.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-hook-form": ">=7.55.0", "sonner": ">=1.7.0", "tailwind-merge": ">=2.6.0", "tailwindcss": ">=3.0.0", "zod": ">=3.24.0" } }, "sha512-zd8BksJjRzu+x9Y+JAA91ekmv0nZuXRSSL+IqlAjkgeH9sZFG/NVQt5CGvEhNKi3/OYEu3JCOCwXu4qPz0A3aA=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.44.2", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^16.4.5", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js", "git-dotenvx": "src/cli/dotenvx.js" } }, "sha512-2C44+G2dch4cB6zw7+oGQ9VcFQuuVhc5xOzfVvY7iUEj2PRhiVMIB6SpNMK1V5TvpdqrAqCYFjclK18Mh9vwNQ=="],
 
@@ -4037,6 +4037,8 @@
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@6.0.1", "", {}, "sha512-OaI//3H0J7ZkR1OqlhGA8cA+Cbk/2xFOQpJOt5+s27/ta9eZwpeervh4Mxh4w0im/kdgktowaqVNR7QOrUd7Yg=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/kit/dapp/package.json
+++ b/kit/dapp/package.json
@@ -27,7 +27,7 @@
     "db:generate": "drizzle-kit generate"
   },
   "dependencies": {
-    "@daveyplate/better-auth-ui": "1.7.4",
+    "@daveyplate/better-auth-ui": "2.0.0",
     "@hookform/resolvers": "5.1.1",
     "@next-safe-action/adapter-react-hook-form": "1.0.14",
     "@opentelemetry/api": "1.9.0",

--- a/kit/dapp/src/components/blocks/auth/auth-provider.tsx
+++ b/kit/dapp/src/components/blocks/auth/auth-provider.tsx
@@ -30,7 +30,7 @@ export const AuthProvider = ({
   const router = useRouter();
   const t = useTranslations("private.auth");
 
-  const providers: AuthUIProviderProps["providers"] = [];
+  const providers: AuthUIProviderProps["social"]["providers"] = [];
   if (googleEnabled) {
     providers.push("google");
   }
@@ -47,18 +47,25 @@ export const AuthProvider = ({
         replace={router.replace}
         onSessionChange={() => router.refresh()}
         Link={Link}
-        settingsURL="/portfolio/settings/profile"
+        settings={{
+          url: "/portfolio/settings/profile",
+        }}
         redirectTo="/portfolio"
-        confirmPassword={true}
+        credentials={{
+          confirmPassword: true,
+          rememberMe: true,
+          forgotPassword: emailEnabled,
+        }}
         optimistic={true}
-        rememberMe={true}
-        forgotPassword={emailEnabled}
-        deleteAccountVerification={emailEnabled}
-        deleteUser={true}
+        deleteUser={{
+          verification: emailEnabled ? "email" : undefined,
+        }}
         avatar={false}
         magicLink={emailEnabled}
         passkey={true}
-        providers={providers.length > 0 ? providers : undefined}
+        social={{
+          providers: providers.length > 0 ? providers : undefined,
+        }}
         toast={({ variant, message }) => {
           if (variant === "success") {
             toast.success(message);
@@ -72,353 +79,355 @@ export const AuthProvider = ({
         }}
         localization={{
           /** @default "Account" */
-          account: t("account"),
+          ACCOUNT: t("account"),
           /** @default "Accounts" */
-          accounts: t("accounts"),
+          ACCOUNTS: t("accounts"),
           /** @default "Manage your currently signed in accounts." */
-          accountsDescription: t("accounts-description"),
+          ACCOUNTS_DESCRIPTION: t("accounts-description"),
           /** @default "Sign in to an additional account." */
-          accountsInstructions: t("accounts-instructions"),
+          ACCOUNTS_INSTRUCTIONS: t("accounts-instructions"),
           /** @default "Add Account" */
-          addAccount: t("add-account"),
+          ADD_ACCOUNT: t("add-account"),
           /** @default "Add Passkey" */
-          addPasskey: t("add-passkey"),
+          ADD_PASSKEY: t("add-passkey"),
           /** @default "Already have an account?" */
-          alreadyHaveAnAccount: t("already-have-account"),
+          ALREADY_HAVE_AN_ACCOUNT: t("already-have-account"),
           /** @default "Avatar" */
-          avatar: t("avatar"),
+          AVATAR: t("avatar"),
           /** @default "Click on the avatar to upload a custom one from your files." */
-          avatarDescription: t("avatar-description"),
+          AVATAR_DESCRIPTION: t("avatar-description"),
           /** @default "An avatar is optional but strongly recommended." */
-          avatarInstructions: t("avatar-instructions"),
+          AVATAR_INSTRUCTIONS: t("avatar-instructions"),
           /** @default "Backup code is required" */
-          backupCodeRequired: t("backup-code-required"),
+          BACKUP_CODE_REQUIRED: t("backup-code-required"),
           /** @default "Backup Codes" */
-          backupCodes: t("backup-codes"),
+          BACKUP_CODES: t("backup-codes"),
           /** @default "Save these backup codes in a secure place. You can use them to access your account if you lose your two-factor authentication method." */
-          backupCodesDescription: t("backup-codes-description"),
+          BACKUP_CODES_DESCRIPTION: t("backup-codes-description"),
           /** @default "Enter one of your backup codes. Once used, each code can only be used once and will be invalidated after use." */
-          backupCodePlaceholder: t("backup-code-placeholder"),
+          BACKUP_CODE_PLACEHOLDER: t("backup-code-placeholder"),
           /** @default "Backup Code" */
-          backupCode: t("backup-code"),
+          BACKUP_CODE: t("backup-code"),
           /** @default "Recover account" */
-          backupCodeAction: t("backup-code-action"),
+          BACKUP_CODE_ACTION: t("backup-code-action"),
           /** @default "Cancel" */
-          cancel: t("cancel"),
+          CANCEL: t("cancel"),
           /** @default "Change Password" */
-          changePassword: t("change-password"),
+          CHANGE_PASSWORD: t("change-password"),
           /** @default "Enter your current password and a new password." */
-          changePasswordDescription: t("change-password-description"),
+          CHANGE_PASSWORD_DESCRIPTION: t("change-password-description"),
           /** @default "Please use 8 characters at minimum." */
-          changePasswordInstructions: t("change-password-instructions"),
+          CHANGE_PASSWORD_INSTRUCTIONS: t("change-password-instructions"),
           /** @default "Your password has been changed." */
-          changePasswordSuccess: t("change-password-success"),
+          CHANGE_PASSWORD_SUCCESS: t("change-password-success"),
           /** @default "Confirm Password" */
-          confirmPassword: t("confirm-password"),
+          CONFIRM_PASSWORD: t("confirm-password"),
           /** @default "Confirm Password" */
-          confirmPasswordPlaceholder: t("confirm-password-placeholder"),
+          CONFIRM_PASSWORD_PLACEHOLDER: t("confirm-password-placeholder"),
           /** @default "Confirm password is required" */
-          confirmPasswordRequired: t("confirm-password-required"),
+          CONFIRM_PASSWORD_REQUIRED: t("confirm-password-required"),
           /** @default "Continue with Authenticator" */
-          continueWithAuthenticator: t("continue-with-authenticator"),
+          CONTINUE_WITH_AUTHENTICATOR: t("continue-with-authenticator"),
           /** @default "Copied to clipboard" */
-          copiedToClipboard: t("copied-to-clipboard"),
+          COPIED_TO_CLIPBOARD: t("copied-to-clipboard"),
           /** @default "Copy to clipboard" */
-          copyToClipboard: t("copy-to-clipboard"),
+          COPY_TO_CLIPBOARD: t("copy-to-clipboard"),
           /** @default "Copy all codes" */
-          copyAllCodes: t("copy-all-codes"),
+          COPY_ALL_CODES: t("copy-all-codes"),
           /** @default "Continue" */
-          continue: t("continue"),
+          CONTINUE: t("continue"),
           /** @default "Current Password" */
-          currentPassword: t("current-password"),
+          CURRENT_PASSWORD: t("current-password"),
           /** @default "Current Password" */
-          currentPasswordPlaceholder: t("current-password-placeholder"),
+          CURRENT_PASSWORD_PLACEHOLDER: t("current-password-placeholder"),
           /** @default "Current Session" */
-          currentSession: t("current-session"),
+          CURRENT_SESSION: t("current-session"),
           /** @default "Delete" */
-          delete: t("delete"),
+          DELETE: t("delete"),
           /** @default "Delete Avatar" */
-          deleteAvatar: t("delete-avatar"),
+          DELETE_AVATAR: t("delete-avatar"),
           /** @default "Delete Account" */
-          deleteAccount: t("delete-account"),
+          DELETE_ACCOUNT: t("delete-account"),
           /** @default "Permanently remove your account and all of its contents. This action is not reversible, so please continue with caution." */
-          deleteAccountDescription: t("delete-account-description"),
+          DELETE_ACCOUNT_DESCRIPTION: t("delete-account-description"),
           /** @default "Please confirm the deletion of your account. This action is not reversible, so please continue with caution." */
-          deleteAccountInstructions: t("delete-account-instructions"),
+          DELETE_ACCOUNT_INSTRUCTIONS: t("delete-account-instructions"),
           /** @default "Please check your email to verify the deletion of your account." */
-          deleteAccountVerify: t("delete-account-verify"),
+          DELETE_ACCOUNT_VERIFY: t("delete-account-verify"),
           /** @default "Your account has been deleted." */
-          deleteAccountSuccess: t("delete-account-success"),
+          DELETE_ACCOUNT_SUCCESS: t("delete-account-success"),
           /** @default "You must be recently logged in to delete your account." */
-          deleteAccountNotFresh: t("delete-account-not-fresh"),
+          DELETE_ACCOUNT_NOT_FRESH: t("delete-account-not-fresh"),
           /** @default "Disable" */
-          disable: t("disable"),
+          DISABLE: t("disable"),
           /** @default "Choose a provider to login to your account" */
-          disabledCredentialsDescription: t("disabled-credentials-description"),
+          DISABLED_CREDENTIALS_DESCRIPTION: t(
+            "disabled-credentials-description"
+          ),
           /** @default "Don't have an account?" */
-          dontHaveAnAccount: t("dont-have-account"),
+          DONT_HAVE_AN_ACCOUNT: t("dont-have-account"),
           /** @default "Done" */
-          done: t("done"),
+          DONE: t("done"),
           /** @default "Email" */
-          email: t("email"),
+          EMAIL: t("email"),
           /** @default "Enter the email address you want to use to log in." */
-          emailDescription: t("email-description"),
+          EMAIL_DESCRIPTION: t("email-description"),
           /** @default "Please enter a valid email address." */
-          emailInstructions: t("email-instructions"),
+          EMAIL_INSTRUCTIONS: t("email-instructions"),
           /** @default "Email address is invalid" */
-          emailInvalid: t("email-invalid"),
+          EMAIL_INVALID: t("email-invalid"),
           /** @default "Email is the same" */
-          emailIsTheSame: t("email-is-the-same"),
+          EMAIL_IS_THE_SAME: t("email-is-the-same"),
           /** @default "m@example.com" */
-          emailPlaceholder: t("email-placeholder"),
+          EMAIL_PLACEHOLDER: t("email-placeholder"),
           /** @default "Email address is required" */
-          emailRequired: t("email-required"),
+          EMAIL_REQUIRED: t("email-required"),
           /** @default "Please check your email to verify the change." */
-          emailVerifyChange: t("email-verify-change"),
+          EMAIL_VERIFY_CHANGE: t("email-verify-change"),
           /** @default "Please check your email for the verification link." */
-          emailVerification: t("email-verification"),
+          EMAIL_VERIFICATION: t("email-verification"),
           /** @default "Enable" */
-          enable: t("enable"),
+          ENABLE: t("enable"),
           /** @default "Error" */
-          error: t("error"),
+          ERROR: t("error"),
           /** @default "is invalid" */
-          isInvalid: t("is-invalid"),
+          IS_INVALID: t("is-invalid"),
           /** @default "is required" */
-          isRequired: t("is-required"),
+          IS_REQUIRED: t("is-required"),
           /** @default "is the same" */
-          isTheSame: t("is-the-same"),
+          IS_THE_SAME: t("is-the-same"),
           /** @default "Forgot authenticator?" */
-          forgotAuthenticator: t("forgot-authenticator"),
+          FORGOT_AUTHENTICATOR: t("forgot-authenticator"),
           /** @default "Forgot Password" */
-          forgotPassword: t("forgot-password"),
+          FORGOT_PASSWORD: t("forgot-password"),
           /** @default "Send reset link" */
-          forgotPasswordAction: t("forgot-password-action"),
+          FORGOT_PASSWORD_ACTION: t("forgot-password-action"),
           /** @default "Enter your email to reset your password" */
-          forgotPasswordDescription: t("forgot-password-description"),
+          FORGOT_PASSWORD_DESCRIPTION: t("forgot-password-description"),
           /** @default "Check your email for the password reset link." */
-          forgotPasswordEmail: t("forgot-password-email"),
+          FORGOT_PASSWORD_EMAIL: t("forgot-password-email"),
           /** @default "Forgot your password?" */
-          forgotPasswordLink: t("forgot-password-link"),
+          FORGOT_PASSWORD_LINK: t("forgot-password-link"),
           /** @default "Invalid two factor cookie" */
-          invalidTwoFactorCookie: t("invalid-two-factor-cookie"),
+          INVALID_TWO_FACTOR_COOKIE: t("invalid-two-factor-cookie"),
           /** @default "Link" */
-          link: t("link"),
+          LINK: t("link"),
           /** @default "Magic Link" */
-          magicLink: t("magic-link"),
+          MAGIC_LINK: t("magic-link"),
           /** @default "Send magic link" */
-          magicLinkAction: t("magic-link-action"),
+          MAGIC_LINK_ACTION: t("magic-link-action"),
           /** @default "Enter your email to receive a magic link" */
-          magicLinkDescription: t("magic-link-description"),
+          MAGIC_LINK_DESCRIPTION: t("magic-link-description"),
           /** @default "Check your email for the magic link" */
-          magicLinkEmail: t("magic-link-email"),
+          MAGIC_LINK_EMAIL: t("magic-link-email"),
           /** @default "Email Code" */
-          emailOTP: t("email-otp"),
+          EMAIL_OTP: t("email-otp"),
           /** @default "Send code" */
-          emailOTPSendAction: t("email-otp-send-action"),
+          EMAIL_OTP_SEND_ACTION: t("email-otp-send-action"),
           /** @default "Verify code" */
-          emailOTPVerifyAction: t("email-otp-verify-action"),
+          EMAIL_OTP_VERIFY_ACTION: t("email-otp-verify-action"),
           /** @default "Enter your email to receive a code" */
-          emailOTPDescription: t("email-otp-description"),
+          EMAIL_OTP_DESCRIPTION: t("email-otp-description"),
           /** @default "Please check your email for the verification code." */
-          emailOTPVerificationSent: t("email-otp-verification-sent"),
+          EMAIL_OTP_VERIFICATION_SENT: t("email-otp-verification-sent"),
           /** @default "Name" */
-          name: t("name"),
+          NAME: t("name"),
           /** @default "Please enter your full name, or a display name." */
-          nameDescription: t("name-description"),
+          NAME_DESCRIPTION: t("name-description"),
           /** @default "Please use 32 characters at maximum." */
-          nameInstructions: t("name-instructions"),
+          NAME_INSTRUCTIONS: t("name-instructions"),
           /** @default "Name" */
-          namePlaceholder: t("name-placeholder"),
+          NAME_PLACEHOLDER: t("name-placeholder"),
           /** @default "New Password" */
-          newPassword: t("new-password"),
+          NEW_PASSWORD: t("new-password"),
           /** @default "New Password" */
-          newPasswordPlaceholder: t("new-password-placeholder"),
+          NEW_PASSWORD_PLACEHOLDER: t("new-password-placeholder"),
           /** @default "New password is required" */
-          newPasswordRequired: t("new-password-required"),
+          NEW_PASSWORD_REQUIRED: t("new-password-required"),
           /** @default "One-Time Password" */
-          oneTimePassword: t("one-time-password"),
+          ONE_TIME_PASSWORD: t("one-time-password"),
           /** @default "Or continue with" */
-          orContinueWith: t("or-continue-with"),
+          OR_CONTINUE_WITH: t("or-continue-with"),
           /** @default "Passkey" */
-          passkey: t("passkey"),
+          PASSKEY: t("passkey"),
           /** @default "Passkeys" */
-          passkeys: t("passkeys"),
+          PASSKEYS: t("passkeys"),
           /** @default "Manage your passkeys for secure access." */
-          passkeysDescription: t("passkeys-description"),
+          PASSKEYS_DESCRIPTION: t("passkeys-description"),
           /** @default "Securely access your account without a password." */
-          passkeysInstructions: t("passkeys-instructions"),
+          PASSKEYS_INSTRUCTIONS: t("passkeys-instructions"),
           /** @default "API Keys" */
-          apiKeys: t("api-keys"),
+          API_KEYS: t("api-keys"),
           /** @default "Manage your API keys for secure access." */
-          apiKeysDescription: t("api-keys-description"),
+          API_KEYS_DESCRIPTION: t("api-keys-description"),
           /** @default "Generate API keys to access your account programmatically." */
-          apiKeysInstructions: t("api-keys-instructions"),
+          API_KEYS_INSTRUCTIONS: t("api-keys-instructions"),
           /** @default "Create API Key" */
-          createApiKey: t("create-api-key"),
+          CREATE_API_KEY: t("create-api-key"),
           /** @default "Enter a unique name for your API key to differentiate it from other keys." */
-          createApiKeyDescription: t("create-api-key-description"),
+          CREATE_API_KEY_DESCRIPTION: t("create-api-key-description"),
           /** @default "New API Key" */
-          apiKeyNamePlaceholder: t("api-key-name-placeholder"),
+          API_KEY_NAME_PLACEHOLDER: t("api-key-name-placeholder"),
           /** @default "API Key Created" */
-          apiKeyCreated: t("api-key-created"),
+          API_KEY_CREATED: t("api-key-created"),
           /** @default "Please copy your API key and store it in a safe place. For security reasons we cannot show it again." */
-          apiKeyCreatedDescription: t("api-key-created-description"),
+          API_KEY_CREATED_DESCRIPTION: t("api-key-created-description"),
           /** @default "Never Expires" */
-          neverExpires: t("never-expires"),
+          NEVER_EXPIRES: t("never-expires"),
           /** @default "Expires" */
-          expires: t("expires"),
+          EXPIRES: t("expires"),
           /** @default "No Expiration" */
-          noExpiration: t("no-expiration"),
+          NO_EXPIRATION: t("no-expiration"),
           /** @default "Create" */
-          create: t("create"),
+          CREATE: t("create"),
           /** @default "Password" */
-          password: t("password"),
+          PASSWORD: t("password"),
           /** @default "Password" */
-          passwordPlaceholder: t("password-placeholder"),
+          PASSWORD_PLACEHOLDER: t("password-placeholder"),
           /** @default "Password is required" */
-          passwordRequired: t("password-required"),
+          PASSWORD_REQUIRED: t("password-required"),
           /** @default "Passwords do not match" */
-          passwordsDoNotMatch: t("passwords-do-not-match"),
+          PASSWORDS_DO_NOT_MATCH: t("passwords-do-not-match"),
           /** @default "Providers" */
-          providers: t("providers"),
+          PROVIDERS: t("providers"),
           /** @default "Connect your account with a third-party service." */
-          providersDescription: t("providers-description"),
+          PROVIDERS_DESCRIPTION: t("providers-description"),
           /** @default "Recover Account" */
-          recoverAccount: t("recover-account"),
+          RECOVER_ACCOUNT: t("recover-account"),
           /** @default "Recover account" */
-          recoverAccountAction: t("recover-account-action"),
+          RECOVER_ACCOUNT_ACTION: t("recover-account-action"),
           /** @default "Please enter a backup code to access your account" */
-          recoverAccountDescription: t("recover-account-description"),
+          RECOVER_ACCOUNT_DESCRIPTION: t("recover-account-description"),
           /** @default "Remember me" */
-          rememberMe: t("remember-me"),
+          REMEMBER_ME: t("remember-me"),
           /** @default "Resend code" */
-          resendCode: t("resend-code"),
+          RESEND_CODE: t("resend-code"),
           /** @default "Resend verification email" */
-          resendVerificationEmail: t("resend-verification-email"),
+          RESEND_VERIFICATION_EMAIL: t("resend-verification-email"),
           /** @default "Reset Password" */
-          resetPassword: t("reset-password"),
+          RESET_PASSWORD: t("reset-password"),
           /** @default "Save new password" */
-          resetPasswordAction: t("reset-password-action"),
+          RESET_PASSWORD_ACTION: t("reset-password-action"),
           /** @default "Enter your new password below" */
-          resetPasswordDescription: t("reset-password-description"),
+          RESET_PASSWORD_DESCRIPTION: t("reset-password-description"),
           /** @default "Invalid reset password link" */
-          resetPasswordInvalidToken: t("reset-password-invalid-token"),
+          RESET_PASSWORD_INVALID_TOKEN: t("reset-password-invalid-token"),
           /** @default "Password reset successfully" */
-          resetPasswordSuccess: t("reset-password-success"),
+          RESET_PASSWORD_SUCCESS: t("reset-password-success"),
           /** @default "Request failed" */
-          requestFailed: t("request-failed"),
+          REQUEST_FAILED: t("request-failed"),
           /** @default "Revoke" */
-          revoke: t("revoke"),
+          REVOKE: t("revoke"),
           /** @default "Delete API Key" */
-          deleteApiKey: t("delete-api-key"),
+          DELETE_API_KEY: t("delete-api-key"),
           /** @default "Are you sure you want to delete this API key?" */
-          deleteApiKeyConfirmation: t("delete-api-key-confirmation"),
+          DELETE_API_KEY_CONFIRMATION: t("delete-api-key-confirmation"),
           /** @default "API Key" */
-          apiKey: t("api-key"),
+          API_KEY: t("api-key"),
           /** @default "Sign In" */
-          signIn: t("sign-in"),
+          SIGN_IN: t("sign-in"),
           /** @default "Login" */
-          signInAction: t("sign-in-action"),
+          SIGN_IN_ACTION: t("sign-in-action"),
           /** @default "Enter your email below to login to your account" */
-          signInDescription: t("sign-in-description"),
+          SIGN_IN_DESCRIPTION: t("sign-in-description"),
           /** @default "Enter your username or email below to login to your account" */
-          signInUsernameDescription: t("sign-in-username-description"),
+          SIGN_IN_USERNAME_DESCRIPTION: t("sign-in-username-description"),
           /** @default "Sign in with" */
-          signInWith: t("sign-in-with"),
+          SIGN_IN_WITH: t("sign-in-with"),
           /** @default "Sign Out" */
-          signOut: t("sign-out"),
+          SIGN_OUT: t("sign-out"),
           /** @default "Sign Up" */
-          signUp: t("sign-up"),
+          SIGN_UP: t("sign-up"),
           /** @default "Create an account" */
-          signUpAction: t("sign-up-action"),
+          SIGN_UP_ACTION: t("sign-up-action"),
           /** @default "Enter your information to create an account" */
-          signUpDescription: t("sign-up-description"),
+          SIGN_UP_DESCRIPTION: t("sign-up-description"),
           /** @default "Check your email for the verification link." */
-          signUpEmail: t("sign-up-email"),
+          SIGN_UP_EMAIL: t("sign-up-email"),
           /** @default "Sessions" */
-          sessions: t("sessions"),
+          SESSIONS: t("sessions"),
           /** @default "Manage your active sessions and revoke access." */
-          sessionsDescription: t("sessions-description"),
+          SESSIONS_DESCRIPTION: t("sessions-description"),
           /** @default "Set Password" */
-          setPassword: t("set-password"),
+          SET_PASSWORD: t("set-password"),
           /** @default "Click the button below to receive an email to set up a password for your account." */
-          setPasswordDescription: t("set-password-description"),
+          SET_PASSWORD_DESCRIPTION: t("set-password-description"),
           /** @default "Settings" */
-          settings: t("settings"),
+          SETTINGS: t("settings"),
           /** @default "Save" */
-          save: t("save"),
+          SAVE: t("save"),
           /** @default "Security" */
-          security: t("security"),
+          SECURITY: t("security"),
           /** @default "Switch Account" */
-          switchAccount: t("switch-account"),
+          SWITCH_ACCOUNT: t("switch-account"),
           /** @default "Trust this device" */
-          trustDevice: t("trust-device"),
+          TRUST_DEVICE: t("trust-device"),
           /** @default "Two-Factor" */
-          twoFactor: t("two-factor"),
+          TWO_FACTOR: t("two-factor"),
           /** @default "Verify code" */
-          twoFactorAction: t("two-factor-action"),
+          TWO_FACTOR_ACTION: t("two-factor-action"),
           /** @default "Please enter your one-time password to continue" */
-          twoFactorDescription: t("two-factor-description"),
+          TWO_FACTOR_DESCRIPTION: t("two-factor-description"),
           /** @default "Add an extra layer of security to your account." */
-          twoFactorCardDescription: t("two-factor-card-description"),
+          TWO_FACTOR_CARD_DESCRIPTION: t("two-factor-card-description"),
           /** @default "Please enter your password to disable 2FA." */
-          twoFactorDisableInstructions: t("two-factor-disable-instructions"),
+          TWO_FACTOR_DISABLE_INSTRUCTIONS: t("two-factor-disable-instructions"),
           /** @default "Please enter your password to enable 2FA" */
-          twoFactorEnableInstructions: t("two-factor-enable-instructions"),
+          TWO_FACTOR_ENABLE_INSTRUCTIONS: t("two-factor-enable-instructions"),
           /** @default "Two-factor authentication has been enabled" */
-          twoFactorEnabled: t("two-factor-enabled"),
+          TWO_FACTOR_ENABLED: t("two-factor-enabled"),
           /** @default "Two-Factor Authentication has been disabled" */
-          twoFactorDisabled: t("two-factor-disabled"),
+          TWO_FACTOR_DISABLED: t("two-factor-disabled"),
           /** @default "Two-Factor Authentication" */
-          twoFactorPrompt: t("two-factor-prompt"),
+          TWO_FACTOR_PROMPT: t("two-factor-prompt"),
           /** @default "Scan the QR Code with your Authenticator" */
-          twoFactorTotpLabel: t("two-factor-totp-label"),
+          TWO_FACTOR_TOTP_LABEL: t("two-factor-totp-label"),
           /** @default "Send verification code" */
-          sendVerificationCode: t("send-verification-code"),
+          SEND_VERIFICATION_CODE: t("send-verification-code"),
           /** @default "Unlink" */
-          unlink: t("unlink"),
+          UNLINK: t("unlink"),
           /** @default "Updated successfully" */
-          updatedSuccessfully: t("updated-successfully"),
+          UPDATED_SUCCESSFULLY: t("updated-successfully"),
           /** @default "Username" */
-          username: t("username"),
+          USERNAME: t("username"),
           /** @default "Enter the username you want to use to log in." */
-          usernameDescription: t("username-description"),
+          USERNAME_DESCRIPTION: t("username-description"),
           /** @default "Please use 32 characters at maximum." */
-          usernameInstructions: t("username-instructions"),
+          USERNAME_INSTRUCTIONS: t("username-instructions"),
           /** @default "Username" */
-          usernamePlaceholder: t("username-placeholder"),
+          USERNAME_PLACEHOLDER: t("username-placeholder"),
           /** @default "Username or email" */
-          signInUsernamePlaceholder: t("sign-in-username-placeholder"),
+          SIGN_IN_USERNAME_PLACEHOLDER: t("sign-in-username-placeholder"),
           /** @default "Verify Your Email" */
-          verifyYourEmail: t("verify-your-email"),
+          VERIFY_YOUR_EMAIL: t("verify-your-email"),
           /** @default "Please verify your email address. Check your inbox for the verification email. If you haven't received the email, click the button below to resend." */
-          verifyYourEmailDescription: t("verify-your-email-description"),
+          VERIFY_YOUR_EMAIL_DESCRIPTION: t("verify-your-email-description"),
           /** @default "Go back" */
-          goBack: t("go-back"),
+          GO_BACK: t("go-back"),
           /** @default "Invalid email or password" */
-          invalidEmailOrPassword: t("invalid-email-or-password"),
+          INVALID_EMAIL_OR_PASSWORD: t("invalid-email-or-password"),
           /** @default "Invalid password" */
-          passwordInvalid: t("password-invalid"),
+          PASSWORD_INVALID: t("password-invalid"),
           /** @default "Your session is not fresh. Please sign in again." */
-          sessionNotFresh: t("session-not-fresh"),
+          SESSION_NOT_FRESH: t("session-not-fresh"),
           /** @default "Session Expired" */
-          sessionExpired: t("session-expired"),
+          SESSION_EXPIRED: t("session-expired"),
           /** @default "Password too short" */
-          passwordTooShort: t("password-too-short"),
+          PASSWORD_TOO_SHORT: t("password-too-short"),
           /** @default "Password too long" */
-          passwordTooLong: t("password-too-long"),
+          PASSWORD_TOO_LONG: t("password-too-long"),
           /** @default "Upload Avatar" */
-          uploadAvatar: t("upload-avatar"),
+          UPLOAD_AVATAR: t("upload-avatar"),
           /** @default "Privacy Policy" */
-          privacyPolicy: t("privacy-policy"),
+          PRIVACY_POLICY: t("privacy-policy"),
           /** @default "Terms of Service" */
-          termsOfService: t("terms-of-service"),
+          TERMS_OF_SERVICE: t("terms-of-service"),
           /** @default "This site is protected by reCAPTCHA." */
-          protectedByRecaptcha: t("protected-by-recaptcha"),
+          PROTECTED_BY_RECAPTCHA: t("protected-by-recaptcha"),
           /** @default "By continuing, you agree to the" */
-          byContinuingYouAgree: t("by-continuing-you-agree"),
+          BY_CONTINUING_YOU_AGREE: t("by-continuing-you-agree"),
           /** @default "Missing CAPTCHA response" */
-          missingCaptchaResponse: t("missing-captcha-response"),
+          MISSING_CAPTCHA_RESPONSE: t("missing-captcha-response"),
         }}
       >
         <div className="AuthProvider">{children}</div>


### PR DESCRIPTION
The `@daveyplate/better-auth-ui` package was updated to v2.0.0 in `bun.lock` and `kit/dapp/package.json`.

This update necessitated changes in `kit/dapp/src/components/blocks/auth/auth-provider.tsx` to align with the v2 migration guide:
*   `AuthUIProvider` props were refactored:
    *   `providers` moved to `social.providers`.
    *   `settingsURL` moved to `settings.url`.
    *   `confirmPassword`, `rememberMe`, and `forgotPassword` were grouped under a new `credentials` object.
    *   `deleteAccountVerification` moved to `deleteUser.verification`.
*   All localization keys within the `localization` prop were converted from lowercase to uppercase (e.g., `account` became `ACCOUNT`).

Unit tests passed successfully after these changes. A new branch, `chore/update-better-auth-ui-v2`, was created for further CI validation.