### PR TITLE
fix: session invalidation on wallet creation

### DIFF
--- a/kit/dapp/src/routes/_private/onboarding.tsx
+++ b/kit/dapp/src/routes/_private/onboarding.tsx
@@ -30,6 +30,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useBlockchainMutation } from "@/hooks/use-blockchain-mutation";
+import { authClient } from "@/lib/auth/auth.client";
 import { queryClient } from "@/lib/query.client";
 import { cn } from "@/lib/utils";
 import { orpc } from "@/orpc";
@@ -69,8 +70,13 @@ function OnboardingComponent() {
 
   const { mutate: generateWallet } = useMutation(
     orpc.account.create.mutationOptions({
-      onSuccess: () => {
+      onSuccess: async () => {
         toast.success("Wallet generated");
+        await authClient.getSession({
+          query: {
+            disableCookieCache: true,
+          },
+        });
         void queryClient.invalidateQueries({
           queryKey: sessionKey,
           refetchType: "all",


### PR DESCRIPTION
## Summary
- Fixed session invalidation issue when creating a new wallet during onboarding
- Ensures the session is properly refreshed after wallet generation to reflect the new wallet address

## Problem
When a user generated a new wallet during the onboarding process, the session was not being properly invalidated and refreshed. This could lead to the UI showing stale session data that didn't include the newly created wallet address.

## Solution
Added a call to `authClient.getSession()` with `disableCookieCache: true` immediately after successful wallet generation. This forces a fresh session fetch from the server, ensuring the session state is updated with the new wallet information before invalidating the React Query cache.

## Test plan
- [x] Navigate to the onboarding page
- [x] Generate a new wallet
- [x] Verify that the session is immediately updated with the new wallet address
- [x] Confirm that subsequent navigation reflects the updated session state