### PR TITLE
feat: add deployedInTransaction field to track entity creation transactions

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -131,9 +131,9 @@ jobs:
             kit/subgraph/subgraph-output.txt
 
       - name: Auto-commit artifacts
-        if:
-          github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
-          && github.event_name != 'pull_request'
+        if: |
+          github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' &&
+          github.event_name != 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "chore: update artifacts [skip ci]"

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -131,7 +131,9 @@ jobs:
             kit/subgraph/subgraph-output.txt
 
       - name: Auto-commit artifacts
-        if: ${{ github.event_name != 'pull_request' }}
+        if:
+          github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+          && github.event_name != 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "chore: update artifacts [skip ci]"

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -59,6 +59,7 @@ type AccessControl @entity(immutable: false) {
 
 type System @entity(immutable: false) {
   id: Bytes!
+  deployedInTransaction: Bytes!
   accessControl: AccessControl!
   account: Account
   compliance: Compliance
@@ -72,6 +73,7 @@ type System @entity(immutable: false) {
 
 type SystemAddon @entity(immutable: false) {
   id: Bytes!
+  deployedInTransaction: Bytes!
   accessControl: AccessControl!
   name: String!
   typeId: Bytes!
@@ -92,12 +94,14 @@ type IdentityRegistryStorage @entity(immutable: false) {
   id: Bytes!
   accessControl: AccessControl!
   account: Account!
+  deployedInTransaction: Bytes!
 }
 
 type IdentityFactory @entity(immutable: false) {
   id: Bytes!
   accessControl: AccessControl!
   account: Account!
+  deployedInTransaction: Bytes!
 }
 
 type IdentityRegistry @entity(immutable: false) {
@@ -108,12 +112,14 @@ type IdentityRegistry @entity(immutable: false) {
   trustedIssuersRegistry: TrustedIssuersRegistry
   topicSchemeRegistry: TopicSchemeRegistry
   identityRegistryStorage: IdentityRegistryStorage
+  deployedInTransaction: Bytes!
 }
 
 type TrustedIssuersRegistry @entity(immutable: false) {
   id: Bytes!
   accessControl: AccessControl!
   account: Account!
+  deployedInTransaction: Bytes!
 }
 
 type TopicSchemeRegistry @entity(immutable: false) {
@@ -121,6 +127,7 @@ type TopicSchemeRegistry @entity(immutable: false) {
   accessControl: AccessControl!
   account: Account!
   schemes: [TopicScheme!]! @derivedFrom(field: "registry")
+  deployedInTransaction: Bytes!
 }
 
 type TopicScheme @entity(immutable: false) {
@@ -129,6 +136,7 @@ type TopicScheme @entity(immutable: false) {
   name: String!
   signature: String!
   enabled: Boolean!
+  deployedInTransaction: Bytes!
 }
 
 type Identity @entity(immutable: false) {
@@ -137,6 +145,7 @@ type Identity @entity(immutable: false) {
   claims: [IdentityClaim!]! @derivedFrom(field: "identity")
   account: Account
   token: Token
+  deployedInTransaction: Bytes!
 }
 
 type IdentityClaim @entity(immutable: false) {
@@ -147,6 +156,7 @@ type IdentityClaim @entity(immutable: false) {
   uri: String
   revoked: Boolean!
   values: [IdentityClaimValue!]! @derivedFrom(field: "claim")
+  deployedInTransaction: Bytes!
 }
 
 type IdentityClaimValue @entity(immutable: false) {
@@ -196,6 +206,7 @@ type Token @entity(immutable: false) {
   fund: TokenFund
   # Price
   basePriceClaim: IdentityClaim
+  deployedInTransaction: Bytes!
 }
 
 type TokenBalance @entity(immutable: false) {
@@ -285,6 +296,7 @@ type TokenFixedYieldSchedule @entity(immutable: false) {
   currentPeriod: TokenFixedYieldSchedulePeriod
   nextPeriod: TokenFixedYieldSchedulePeriod
   periods: [TokenFixedYieldSchedulePeriod!]! @derivedFrom(field: "schedule")
+  deployedInTransaction: Bytes!
 }
 
 type TokenFixedYieldSchedulePeriod @entity(immutable: false) {
@@ -298,6 +310,7 @@ type TokenFixedYieldSchedulePeriod @entity(immutable: false) {
   totalUnclaimedYieldExact: BigInt!
   totalYield: BigDecimal!
   totalYieldExact: BigInt!
+  deployedInTransaction: Bytes!
 }
 
 # ==================================================

--- a/kit/subgraph/src/identity-factory/fetch/identity-factory.ts
+++ b/kit/subgraph/src/identity-factory/fetch/identity-factory.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { IdentityFactory } from "../../../generated/schema";
 import { IdentityFactory as IdentityFactoryTemplate } from "../../../generated/templates";
 import { fetchAccessControl } from "../../access-control/fetch/accesscontrol";
@@ -11,6 +11,7 @@ export function fetchIdentityFactory(address: Address): IdentityFactory {
     identityFactory = new IdentityFactory(address);
     identityFactory.accessControl = fetchAccessControl(address).id;
     identityFactory.account = fetchAccount(address).id;
+    identityFactory.deployedInTransaction = Bytes.empty();
     identityFactory.save();
     IdentityFactoryTemplate.create(address);
   }

--- a/kit/subgraph/src/identity-factory/identity-factory.ts
+++ b/kit/subgraph/src/identity-factory/identity-factory.ts
@@ -1,3 +1,4 @@
+import { Bytes } from "@graphprotocol/graph-ts";
 import {
   IdentityCreated,
   TokenIdentityCreated,
@@ -9,6 +10,9 @@ import { fetchToken } from "../token/fetch/token";
 
 export function handleIdentityCreated(event: IdentityCreated): void {
   const identity = fetchIdentity(event.params.identity);
+  if (identity.deployedInTransaction == Bytes.empty()) {
+    identity.deployedInTransaction = event.transaction.hash;
+  }
   const account = fetchAccount(event.params.wallet);
   account.identity = identity.id;
   account.save();
@@ -21,6 +25,9 @@ export function handleIdentityCreated(event: IdentityCreated): void {
 
 export function handleTokenIdentityCreated(event: TokenIdentityCreated): void {
   const identity = fetchIdentity(event.params.identity);
+  if (identity.deployedInTransaction == Bytes.empty()) {
+    identity.deployedInTransaction = event.transaction.hash;
+  }
   const token = fetchToken(event.params.token);
   token.identity = identity.id;
   token.save();

--- a/kit/subgraph/src/identity-factory/identity-factory.ts
+++ b/kit/subgraph/src/identity-factory/identity-factory.ts
@@ -10,7 +10,7 @@ import { fetchToken } from "../token/fetch/token";
 
 export function handleIdentityCreated(event: IdentityCreated): void {
   const identity = fetchIdentity(event.params.identity);
-  if (identity.deployedInTransaction == Bytes.empty()) {
+  if (identity.deployedInTransaction.equals(Bytes.empty())) {
     identity.deployedInTransaction = event.transaction.hash;
   }
   const account = fetchAccount(event.params.wallet);
@@ -25,7 +25,7 @@ export function handleIdentityCreated(event: IdentityCreated): void {
 
 export function handleTokenIdentityCreated(event: TokenIdentityCreated): void {
   const identity = fetchIdentity(event.params.identity);
-  if (identity.deployedInTransaction == Bytes.empty()) {
+  if (identity.deployedInTransaction.equals(Bytes.empty())) {
     identity.deployedInTransaction = event.transaction.hash;
   }
   const token = fetchToken(event.params.token);

--- a/kit/subgraph/src/identity-registry/fetch/identity-registry-storage.ts
+++ b/kit/subgraph/src/identity-registry/fetch/identity-registry-storage.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { IdentityRegistryStorage } from "../../../generated/schema";
 import { fetchAccessControl } from "../../access-control/fetch/accesscontrol";
 import { fetchAccount } from "../../account/fetch/account";
@@ -12,6 +12,7 @@ export function fetchIdentityRegistryStorage(
     identityRegistryStorage = new IdentityRegistryStorage(address);
     identityRegistryStorage.accessControl = fetchAccessControl(address).id;
     identityRegistryStorage.account = fetchAccount(address).id;
+    identityRegistryStorage.deployedInTransaction = Bytes.empty();
     identityRegistryStorage.save();
     // IdentityRegistryStorageTemplate.create(address);
   }

--- a/kit/subgraph/src/identity-registry/fetch/identity-registry.ts
+++ b/kit/subgraph/src/identity-registry/fetch/identity-registry.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { IdentityRegistry } from "../../../generated/schema";
 import { IdentityRegistry as IdentityRegistryTemplate } from "../../../generated/templates";
 import { fetchAccessControl } from "../../access-control/fetch/accesscontrol";
@@ -11,6 +11,7 @@ export function fetchIdentityRegistry(address: Address): IdentityRegistry {
     identityRegistry = new IdentityRegistry(address);
     identityRegistry.accessControl = fetchAccessControl(address).id;
     identityRegistry.account = fetchAccount(address).id;
+    identityRegistry.deployedInTransaction = Bytes.empty();
     identityRegistry.save();
     IdentityRegistryTemplate.create(address);
   }

--- a/kit/subgraph/src/identity/fetch/identity-claim.ts
+++ b/kit/subgraph/src/identity/fetch/identity-claim.ts
@@ -14,6 +14,7 @@ export function fetchIdentityClaim(
     identityClaim.identity = identity.id;
     identityClaim.name = "";
     identityClaim.revoked = false;
+    identityClaim.deployedInTransaction = Bytes.empty();
     identityClaim.save();
   }
 

--- a/kit/subgraph/src/identity/fetch/identity.ts
+++ b/kit/subgraph/src/identity/fetch/identity.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { Identity } from "../../../generated/schema";
 import { Identity as IdentityTemplate } from "../../../generated/templates";
 
@@ -8,6 +8,7 @@ export function fetchIdentity(address: Address): Identity {
   if (!identity) {
     identity = new Identity(address);
     identity.registry = Address.zero();
+    identity.deployedInTransaction = Bytes.empty();
     identity.save();
     IdentityTemplate.create(address);
   }

--- a/kit/subgraph/src/identity/identity.ts
+++ b/kit/subgraph/src/identity/identity.ts
@@ -1,3 +1,4 @@
+import { Bytes } from "@graphprotocol/graph-ts";
 import {
   Approved,
   ClaimAdded,
@@ -28,6 +29,9 @@ export function handleClaimAdded(event: ClaimAdded): void {
   fetchEvent(event, "ClaimAdded");
   const identity = fetchIdentity(event.address);
   const identityClaim = fetchIdentityClaim(identity, event.params.claimId);
+  if (identityClaim.deployedInTransaction == Bytes.empty()) {
+    identityClaim.deployedInTransaction = event.transaction.hash;
+  }
   identityClaim.issuer = fetchIdentity(event.params.issuer).id;
   identityClaim.uri = event.params.uri;
   identityClaim.save();

--- a/kit/subgraph/src/identity/identity.ts
+++ b/kit/subgraph/src/identity/identity.ts
@@ -29,7 +29,7 @@ export function handleClaimAdded(event: ClaimAdded): void {
   fetchEvent(event, "ClaimAdded");
   const identity = fetchIdentity(event.address);
   const identityClaim = fetchIdentityClaim(identity, event.params.claimId);
-  if (identityClaim.deployedInTransaction == Bytes.empty()) {
+  if (identityClaim.deployedInTransaction.equals(Bytes.empty())) {
     identityClaim.deployedInTransaction = event.transaction.hash;
   }
   identityClaim.issuer = fetchIdentity(event.params.issuer).id;

--- a/kit/subgraph/src/system-factory/system-factory.ts
+++ b/kit/subgraph/src/system-factory/system-factory.ts
@@ -6,8 +6,8 @@ import { fetchSystem } from "../system/fetch/system";
 export function handleATKSystemCreated(event: ATKSystemCreated): void {
   fetchEvent(event, "SystemCreated");
   const system = fetchSystem(event.params.systemAddress);
-  if (system.deployedInTransaction == Bytes.empty()) {
+  if (system.deployedInTransaction.equals(Bytes.empty())) {
     system.deployedInTransaction = event.transaction.hash;
-    system.save();
   }
+  system.save();
 }

--- a/kit/subgraph/src/system-factory/system-factory.ts
+++ b/kit/subgraph/src/system-factory/system-factory.ts
@@ -1,8 +1,13 @@
+import { Bytes } from "@graphprotocol/graph-ts";
 import { ATKSystemCreated } from "../../generated/SystemFactory/SystemFactory";
 import { fetchEvent } from "../event/fetch/event";
 import { fetchSystem } from "../system/fetch/system";
 
 export function handleATKSystemCreated(event: ATKSystemCreated): void {
   fetchEvent(event, "SystemCreated");
-  fetchSystem(event.params.systemAddress);
+  const system = fetchSystem(event.params.systemAddress);
+  if (system.deployedInTransaction == Bytes.empty()) {
+    system.deployedInTransaction = event.transaction.hash;
+    system.save();
+  }
 }

--- a/kit/subgraph/src/system/fetch/system-addon.ts
+++ b/kit/subgraph/src/system/fetch/system-addon.ts
@@ -12,6 +12,7 @@ export function fetchSystemAddon(address: Address): SystemAddon {
     systemAddon.account = fetchAccount(address).id;
     systemAddon.name = "unknown";
     systemAddon.typeId = Bytes.fromHexString("0x00");
+    systemAddon.deployedInTransaction = Bytes.empty();
     systemAddon.save();
     // FixedYieldScheduleFactoryTemplate.create(address);
   }

--- a/kit/subgraph/src/system/fetch/system.ts
+++ b/kit/subgraph/src/system/fetch/system.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { System } from "../../../generated/schema";
 import { System as SystemTemplate } from "../../../generated/templates";
 import { fetchAccessControl } from "../../access-control/fetch/accesscontrol";
@@ -11,6 +11,7 @@ export function fetchSystem(address: Address): System {
     system = new System(address);
     system.accessControl = fetchAccessControl(address).id;
     system.account = fetchAccount(address).id;
+    system.deployedInTransaction = Bytes.empty();
     system.save();
     SystemTemplate.create(address);
   }

--- a/kit/subgraph/src/system/fetch/trusted-issuers-registry.ts
+++ b/kit/subgraph/src/system/fetch/trusted-issuers-registry.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { TrustedIssuersRegistry } from "../../../generated/schema";
 import { fetchAccessControl } from "../../access-control/fetch/accesscontrol";
 import { fetchAccount } from "../../account/fetch/account";
@@ -12,6 +12,7 @@ export function fetchTrustedIssuersRegistry(
     trustedIssuersRegistry = new TrustedIssuersRegistry(address);
     trustedIssuersRegistry.accessControl = fetchAccessControl(address).id;
     trustedIssuersRegistry.account = fetchAccount(address).id;
+    trustedIssuersRegistry.deployedInTransaction = Bytes.empty();
     trustedIssuersRegistry.save();
     // TrustedIssuersRegistryTemplate.create(address);
   }

--- a/kit/subgraph/src/system/system.ts
+++ b/kit/subgraph/src/system/system.ts
@@ -33,38 +33,48 @@ import { fetchTrustedIssuersRegistry } from "./fetch/trusted-issuers-registry";
 export function handleBootstrapped(event: Bootstrapped): void {
   fetchEvent(event, "Bootstrapped");
   const system = fetchSystem(event.address);
-  
+
   // Set deployedInTransaction for all entities created during bootstrap
-  const identityRegistry = fetchIdentityRegistry(event.params.identityRegistryProxy);
-  if (identityRegistry.deployedInTransaction == Bytes.empty()) {
+  const identityRegistry = fetchIdentityRegistry(
+    event.params.identityRegistryProxy
+  );
+  if (identityRegistry.deployedInTransaction.equals(Bytes.empty())) {
     identityRegistry.deployedInTransaction = event.transaction.hash;
-    identityRegistry.save();
   }
-  
-  const identityRegistryStorage = fetchIdentityRegistryStorage(event.params.identityRegistryStorageProxy);
-  if (identityRegistryStorage.deployedInTransaction == Bytes.empty()) {
+  identityRegistry.save();
+
+  const identityRegistryStorage = fetchIdentityRegistryStorage(
+    event.params.identityRegistryStorageProxy
+  );
+  if (identityRegistryStorage.deployedInTransaction.equals(Bytes.empty())) {
     identityRegistryStorage.deployedInTransaction = event.transaction.hash;
-    identityRegistryStorage.save();
   }
-  
-  const trustedIssuersRegistry = fetchTrustedIssuersRegistry(event.params.trustedIssuersRegistryProxy);
-  if (trustedIssuersRegistry.deployedInTransaction == Bytes.empty()) {
+  identityRegistryStorage.save();
+
+  const trustedIssuersRegistry = fetchTrustedIssuersRegistry(
+    event.params.trustedIssuersRegistryProxy
+  );
+  if (trustedIssuersRegistry.deployedInTransaction.equals(Bytes.empty())) {
     trustedIssuersRegistry.deployedInTransaction = event.transaction.hash;
-    trustedIssuersRegistry.save();
   }
-  
-  const identityFactory = fetchIdentityFactory(event.params.identityFactoryProxy);
-  if (identityFactory.deployedInTransaction == Bytes.empty()) {
+  trustedIssuersRegistry.save();
+
+  const identityFactory = fetchIdentityFactory(
+    event.params.identityFactoryProxy
+  );
+  if (identityFactory.deployedInTransaction.equals(Bytes.empty())) {
     identityFactory.deployedInTransaction = event.transaction.hash;
-    identityFactory.save();
   }
-  
-  const topicSchemeRegistry = fetchTopicSchemeRegistry(event.params.topicSchemeRegistryProxy);
-  if (topicSchemeRegistry.deployedInTransaction == Bytes.empty()) {
+  identityFactory.save();
+
+  const topicSchemeRegistry = fetchTopicSchemeRegistry(
+    event.params.topicSchemeRegistryProxy
+  );
+  if (topicSchemeRegistry.deployedInTransaction.equals(Bytes.empty())) {
     topicSchemeRegistry.deployedInTransaction = event.transaction.hash;
-    topicSchemeRegistry.save();
   }
-  
+  topicSchemeRegistry.save();
+
   system.compliance = fetchCompliance(event.params.complianceProxy).id;
   system.identityRegistry = identityRegistry.id;
   system.identityRegistryStorage = identityRegistryStorage.id;
@@ -136,7 +146,7 @@ export function handleTokenFactoryCreated(event: TokenFactoryCreated): void {
 export function handleSystemAddonCreated(event: SystemAddonCreated): void {
   fetchEvent(event, "SystemAddonCreated");
   const systemAddon = fetchSystemAddon(event.params.proxyAddress);
-  if (systemAddon.deployedInTransaction == Bytes.empty()) {
+  if (systemAddon.deployedInTransaction.equals(Bytes.empty())) {
     systemAddon.deployedInTransaction = event.transaction.hash;
   }
   systemAddon.name = event.params.name;

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule-factory/fixed-yield-schedule-factory.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule-factory/fixed-yield-schedule-factory.ts
@@ -1,3 +1,4 @@
+import { Bytes } from "@graphprotocol/graph-ts";
 import { ATKFixedYieldScheduleCreated } from "../../../generated/templates/FixedYieldScheduleFactory/FixedYieldScheduleFactory";
 import { fetchAccount } from "../../account/fetch/account";
 import { fetchEvent } from "../../event/fetch/event";
@@ -8,6 +9,9 @@ export function handleATKFixedYieldScheduleCreated(
 ): void {
   fetchEvent(event, "FixedYieldScheduleCreated");
   const fixedYieldSchedule = fetchFixedYieldSchedule(event.params.schedule);
+  if (fixedYieldSchedule.deployedInTransaction == Bytes.empty()) {
+    fixedYieldSchedule.deployedInTransaction = event.transaction.hash;
+  }
   fixedYieldSchedule.createdAt = event.block.timestamp;
   fixedYieldSchedule.createdBy = fetchAccount(event.transaction.from).id;
   fixedYieldSchedule.save();

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule-factory/fixed-yield-schedule-factory.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule-factory/fixed-yield-schedule-factory.ts
@@ -9,7 +9,7 @@ export function handleATKFixedYieldScheduleCreated(
 ): void {
   fetchEvent(event, "FixedYieldScheduleCreated");
   const fixedYieldSchedule = fetchFixedYieldSchedule(event.params.schedule);
-  if (fixedYieldSchedule.deployedInTransaction == Bytes.empty()) {
+  if (fixedYieldSchedule.deployedInTransaction.equals(Bytes.empty())) {
     fixedYieldSchedule.deployedInTransaction = event.transaction.hash;
   }
   fixedYieldSchedule.createdAt = event.block.timestamp;

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fetch/fixed-yield-schedule-period.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fetch/fixed-yield-schedule-period.ts
@@ -31,6 +31,7 @@ export function fetchFixedYieldSchedulePeriod(
       BigInt.zero(),
       DEFAULT_TOKEN_DECIMALS
     );
+    fixedYieldSchedulePeriod.deployedInTransaction = Bytes.empty();
     fixedYieldSchedulePeriod.save();
   }
 

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fetch/fixed-yield-schedule.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fetch/fixed-yield-schedule.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { TokenFixedYieldSchedule } from "../../../../generated/schema";
 import { FixedYieldSchedule as FixedYieldScheduleTemplate } from "../../../../generated/templates";
 import { fetchAccount } from "../../../account/fetch/account";
@@ -39,6 +39,7 @@ export function fetchFixedYieldSchedule(
       DEFAULT_TOKEN_DECIMALS
     );
     fixedYieldSchedule.underlyingAsset = Address.zero();
+    fixedYieldSchedule.deployedInTransaction = Bytes.empty();
     fixedYieldSchedule.save();
     FixedYieldScheduleTemplate.create(address);
   }

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
@@ -22,7 +22,7 @@ export function handleFixedYieldScheduleSet(
 ): void {
   fetchEvent(event, "FixedYieldScheduleSet");
   const fixedYieldSchedule = fetchFixedYieldSchedule(event.address);
-  if (fixedYieldSchedule.deployedInTransaction == Bytes.empty()) {
+  if (fixedYieldSchedule.deployedInTransaction.equals(Bytes.empty())) {
     fixedYieldSchedule.deployedInTransaction = event.transaction.hash;
   }
   const tokenAddress = Address.fromBytes(fixedYieldSchedule.token);
@@ -64,7 +64,7 @@ export function handleFixedYieldScheduleSet(
   );*/
   for (let i = 1; i <= event.params.periodEndTimestamps.length; i++) {
     const period = fetchFixedYieldSchedulePeriod(getPeriodId(event.address, i));
-    if (period.deployedInTransaction == Bytes.empty()) {
+    if (period.deployedInTransaction.equals(Bytes.empty())) {
       period.deployedInTransaction = event.transaction.hash;
     }
     period.schedule = fixedYieldSchedule.id;

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { TokenFixedYieldSchedulePeriod } from "../../../generated/schema";
 import {
   FixedYieldScheduleSet,
@@ -22,6 +22,9 @@ export function handleFixedYieldScheduleSet(
 ): void {
   fetchEvent(event, "FixedYieldScheduleSet");
   const fixedYieldSchedule = fetchFixedYieldSchedule(event.address);
+  if (fixedYieldSchedule.deployedInTransaction == Bytes.empty()) {
+    fixedYieldSchedule.deployedInTransaction = event.transaction.hash;
+  }
   const tokenAddress = Address.fromBytes(fixedYieldSchedule.token);
   const tokenDecimals = getTokenDecimals(tokenAddress);
   fixedYieldSchedule.startDate = event.params.startDate;
@@ -61,6 +64,9 @@ export function handleFixedYieldScheduleSet(
   );*/
   for (let i = 1; i <= event.params.periodEndTimestamps.length; i++) {
     const period = fetchFixedYieldSchedulePeriod(getPeriodId(event.address, i));
+    if (period.deployedInTransaction == Bytes.empty()) {
+      period.deployedInTransaction = event.transaction.hash;
+    }
     period.schedule = fixedYieldSchedule.id;
     const isFirstPeriod = i == 1;
     period.startDate = isFirstPeriod

--- a/kit/subgraph/src/token-factory/token-factory.ts
+++ b/kit/subgraph/src/token-factory/token-factory.ts
@@ -1,3 +1,4 @@
+import { Bytes } from "@graphprotocol/graph-ts";
 import { Burnable as BurnableTemplate } from "../../generated/templates";
 import {
   TokenAssetCreated,
@@ -23,6 +24,9 @@ export function handleTokenAssetCreated(event: TokenAssetCreated): void {
   fetchEvent(event, "TokenAssetCreated");
   const tokenFactory = fetchTokenFactory(event.address);
   const token = fetchToken(event.params.tokenAddress);
+  if (token.deployedInTransaction == Bytes.empty()) {
+    token.deployedInTransaction = event.transaction.hash;
+  }
   token.tokenFactory = tokenFactory.id;
   token.type = tokenFactory.name;
   token.createdAt = event.block.timestamp;

--- a/kit/subgraph/src/token-factory/token-factory.ts
+++ b/kit/subgraph/src/token-factory/token-factory.ts
@@ -24,7 +24,7 @@ export function handleTokenAssetCreated(event: TokenAssetCreated): void {
   fetchEvent(event, "TokenAssetCreated");
   const tokenFactory = fetchTokenFactory(event.address);
   const token = fetchToken(event.params.tokenAddress);
-  if (token.deployedInTransaction == Bytes.empty()) {
+  if (token.deployedInTransaction.equals(Bytes.empty())) {
     token.deployedInTransaction = event.transaction.hash;
   }
   token.tokenFactory = tokenFactory.id;

--- a/kit/subgraph/src/token/fetch/token.ts
+++ b/kit/subgraph/src/token/fetch/token.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { Token } from "../../../generated/schema";
 import { Token as TokenTemplate } from "../../../generated/templates";
 import { Token as TokenContract } from "../../../generated/templates/Token/Token";
@@ -25,6 +25,7 @@ export function fetchToken(address: Address): Token {
       tokenContract.totalSupply(),
       token.decimals
     );
+    token.deployedInTransaction = Bytes.empty();
 
     token.save();
     TokenTemplate.create(address);

--- a/kit/subgraph/src/topic-scheme-registry/fetch/topic-scheme-registry.ts
+++ b/kit/subgraph/src/topic-scheme-registry/fetch/topic-scheme-registry.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts";
+import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { TopicSchemeRegistry } from "../../../generated/schema";
 import { TopicSchemeRegistry as TopicSchemeRegistryTemplate } from "../../../generated/templates";
 import { fetchAccessControl } from "../../access-control/fetch/accesscontrol";
@@ -13,6 +13,7 @@ export function fetchTopicSchemeRegistry(
     topicSchemeRegistry = new TopicSchemeRegistry(address);
     topicSchemeRegistry.accessControl = fetchAccessControl(address).id;
     topicSchemeRegistry.account = fetchAccount(address).id;
+    topicSchemeRegistry.deployedInTransaction = Bytes.empty();
     topicSchemeRegistry.save();
     TopicSchemeRegistryTemplate.create(address);
   }

--- a/kit/subgraph/src/topic-scheme-registry/fetch/topic-scheme.ts
+++ b/kit/subgraph/src/topic-scheme-registry/fetch/topic-scheme.ts
@@ -11,6 +11,7 @@ export function fetchTopicScheme(topicId: BigInt): TopicScheme {
     topicScheme.name = "";
     topicScheme.signature = "";
     topicScheme.enabled = true;
+    topicScheme.deployedInTransaction = Bytes.empty();
     topicScheme.save();
   }
 

--- a/kit/subgraph/src/topic-scheme-registry/topic-scheme-registry.ts
+++ b/kit/subgraph/src/topic-scheme-registry/topic-scheme-registry.ts
@@ -13,7 +13,7 @@ export function handleTopicSchemeRegistered(
 ): void {
   fetchEvent(event, "TopicSchemeRegistered");
   const topicScheme = fetchTopicScheme(event.params.topicId);
-  if (topicScheme.deployedInTransaction == Bytes.empty()) {
+  if (topicScheme.deployedInTransaction.equals(Bytes.empty())) {
     topicScheme.deployedInTransaction = event.transaction.hash;
   }
   topicScheme.name = event.params.name;
@@ -47,7 +47,7 @@ export function handleTopicSchemesBatchRegistered(
 
   for (let i = 0; i < topicIds.length; i++) {
     const topicScheme = fetchTopicScheme(topicIds[i]);
-    if (topicScheme.deployedInTransaction == Bytes.empty()) {
+    if (topicScheme.deployedInTransaction.equals(Bytes.empty())) {
       topicScheme.deployedInTransaction = event.transaction.hash;
     }
     topicScheme.name = names[i];

--- a/kit/subgraph/src/topic-scheme-registry/topic-scheme-registry.ts
+++ b/kit/subgraph/src/topic-scheme-registry/topic-scheme-registry.ts
@@ -1,3 +1,4 @@
+import { Bytes } from "@graphprotocol/graph-ts";
 import {
   TopicSchemeRegistered,
   TopicSchemeRemoved,
@@ -12,6 +13,9 @@ export function handleTopicSchemeRegistered(
 ): void {
   fetchEvent(event, "TopicSchemeRegistered");
   const topicScheme = fetchTopicScheme(event.params.topicId);
+  if (topicScheme.deployedInTransaction == Bytes.empty()) {
+    topicScheme.deployedInTransaction = event.transaction.hash;
+  }
   topicScheme.name = event.params.name;
   topicScheme.signature = event.params.signature;
   topicScheme.save();
@@ -43,6 +47,9 @@ export function handleTopicSchemesBatchRegistered(
 
   for (let i = 0; i < topicIds.length; i++) {
     const topicScheme = fetchTopicScheme(topicIds[i]);
+    if (topicScheme.deployedInTransaction == Bytes.empty()) {
+      topicScheme.deployedInTransaction = event.transaction.hash;
+    }
     topicScheme.name = names[i];
     topicScheme.signature = signatures[i];
     topicScheme.save();


### PR DESCRIPTION
## Summary

This PR adds the `deployedInTransaction` field to entities in the subgraph to track the transaction hash where each entity was initially deployed. This provides better traceability and audit capabilities for the system.

## Changes

### Schema Updates
- Added `deployedInTransaction: Bytes\!` field to 13 entities:
  - System
  - SystemAddon
  - IdentityRegistryStorage
  - IdentityFactory
  - IdentityRegistry
  - TrustedIssuersRegistry
  - TopicSchemeRegistry
  - TopicScheme
  - Identity
  - IdentityClaim
  - Token
  - TokenFixedYieldSchedule
  - TokenFixedYieldSchedulePeriod

### Code Updates

1. **Fetch Functions**: Updated all entity fetch functions to initialize `deployedInTransaction` with `Bytes.empty()` when creating new entities

2. **Event Handlers**: Modified event handlers to capture and store the transaction hash when entities are first created:
   - `handleATKSystemCreated` - for System entities
   - `handleBootstrapped` - for compliance system entities
   - `handleSystemAddonCreated` - for SystemAddon entities
   - `handleTopicSchemeRegistered` and `handleTopicSchemesBatchRegistered` - for TopicScheme entities
   - `handleIdentityCreated` and `handleTokenIdentityCreated` - for Identity entities
   - `handleClaimAdded` - for IdentityClaim entities
   - `handleTokenAssetCreated` - for Token entities
   - `handleATKFixedYieldScheduleCreated` and `handleFixedYieldScheduleSet` - for FixedYieldSchedule entities

## Test Plan

- [x] Subgraph compiles successfully
- [x] All entities properly initialize deployedInTransaction field
- [x] Transaction hash is captured when entities are created
- [ ] Deploy and verify entities show correct transaction hashes