### PR TITLE
fix: use same deployment id as atk deployer

### DIFF
--- a/kit/contracts/scripts/hardhat/addons/airdrop/vesting-airdrop.ts
+++ b/kit/contracts/scripts/hardhat/addons/airdrop/vesting-airdrop.ts
@@ -41,6 +41,5 @@ export const createVestingAirdrop = async (
   ]);
 
   await vestingAirdrop.waitUntilDeployed(transactionHash);
-
   return vestingAirdrop;
 };

--- a/kit/contracts/scripts/hardhat/entities/airdrop/vesting-airdrop.ts
+++ b/kit/contracts/scripts/hardhat/entities/airdrop/vesting-airdrop.ts
@@ -1,7 +1,7 @@
 import hre from "hardhat";
 import { Address, type Hex } from "viem";
 import ATKLinearVestingStrategy from "../../../../ignition/modules/atk/addons/airdrop/linear-vesting-strategy";
-import { ATKOnboardingContracts } from "../../services/deployer";
+import { atkDeployer, ATKOnboardingContracts } from "../../services/deployer";
 import { waitForEvent } from "../../utils/wait-for-event";
 import { Asset } from "../asset";
 
@@ -65,9 +65,10 @@ export class VestingAirdrop {
     vestingDuration: number;
     cliffDuration: number;
   }) {
-    const { atkLinearVestingStrategy } = await hre.ignition.deploy(
+    const { atkLinearVestingStrategy } = (await hre.ignition.deploy(
       ATKLinearVestingStrategy,
       {
+        deploymentId: atkDeployer.getDeploymentId(),
         parameters: {
           ATKLinearVestingStrategy: {
             vestingDuration,
@@ -75,7 +76,7 @@ export class VestingAirdrop {
           },
         },
       }
-    );
+    )) as { atkLinearVestingStrategy: { address: Address } };
 
     return atkLinearVestingStrategy.address;
   }


### PR DESCRIPTION
Ran publish twice, worked: 


![CleanShot 2025-06-20 at 09 26 57@2x](https://github.com/user-attachments/assets/ed9e3e01-7802-47d6-9f5f-e70be887fca2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved deployment process for vesting airdrop strategies by introducing a deployment identifier for greater clarity and traceability. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->