### PR TITLE
fix: harbor script skip empty images

### DIFF
--- a/kit/charts/atk/charts/support/values.yaml
+++ b/kit/charts/atk/charts/support/values.yaml
@@ -316,6 +316,17 @@ reloader:
 
 minio:
   enabled: true
+  global:
+    security:
+      allowInsecureImages: true
+    imagePullSecrets:
+      - image-pull-secret-docker
+      - image-pull-secret-ghcr
+      - image-pull-secret-harbor
+  image:
+    registry: docker.io
+    repository: bitnami/minio
+    tag: 2025.5.24-debian-12-r7
   fullnameOverride: 'minio'
   # defaultBuckets: atk
   auth:
@@ -334,3 +345,13 @@ minio:
         echo "Adding atk-service user"
         mc admin user svcacct add provisioning "admin" --access-key "atk-service" --secret-key "atk-service-secret"
       fi
+  console:
+    image:
+      registry: docker.io
+      repository: bitnami/minio-object-browser
+      tag: 2.0.1-debian-12-r3
+  defaultInitContainers:
+    image:
+      registry: docker.io
+      repository: bitnami/os-shell
+      tag: 12-debian-12-r47

--- a/kit/charts/atk/charts/txsigner/values.yaml
+++ b/kit/charts/atk/charts/txsigner/values.yaml
@@ -19,7 +19,7 @@ commonAnnotations: {}
 # -- TxSigner image
 image:
   # -- TxSigner image registry
-  registry: "ghcr.io"
+  registry: ghcr.io
   # -- TxSigner image repository
   repository: settlemint/btp-signer
   # -- TxSigner image tag (immutable tags are recommended)

--- a/kit/charts/tools/package-harbor.ts
+++ b/kit/charts/tools/package-harbor.ts
@@ -168,7 +168,7 @@ async function processFile(filePath: string): Promise<{ modified: boolean; chang
         // Clean up corrupted values like harbor.settlemint.com/""
         if (line.includes(`${HARBOR_PROXY}/""`)) {
           line = line.replace(`${HARBOR_PROXY}/""`, '""');
-        } else if (line.includes(`${HARBOR_PROXY}/"''"`)) {
+        } else if (line.includes(`${HARBOR_PROXY}/''`)) {
           line = line.replace(`${HARBOR_PROXY}/''`, "''");
         }
         // Process normal values (but not if already has harbor proxy)
@@ -196,8 +196,10 @@ async function processFile(filePath: string): Promise<{ modified: boolean; chang
         // Clean up corrupted values like harbor.settlemint.com/""
         if (line.includes(`${HARBOR_PROXY}/""`)) {
           line = line.replace(`${HARBOR_PROXY}/""`, '""');
-        } else if (line.includes(`${HARBOR_PROXY}/"''"`)) {
+        } else if (line.includes(`${HARBOR_PROXY}/''`)) {
           line = line.replace(`${HARBOR_PROXY}/''`, "''");
+        } else if (line.includes(`${HARBOR_PROXY}/"''"`)) {
+          line = line.replace(`${HARBOR_PROXY}/"''"`, '""');
         }
         // Process normal values (but not if already has harbor proxy)
         else if (!line.includes(`${HARBOR_PROXY}/`)) {

--- a/kit/charts/tools/package-harbor.ts
+++ b/kit/charts/tools/package-harbor.ts
@@ -164,37 +164,58 @@ async function processFile(filePath: string): Promise<{ modified: boolean; chang
       const originalLine = line;
 
       // Process registry: values
-      if (line.includes("registry:") && !line.includes(`${HARBOR_PROXY}/`)) {
-        const registryMatch = line.match(/(\s+registry:\s+)([^\s\n]+)/);
-        if (
-          registryMatch &&
-          registryMatch[2] &&
-          registryMatch[2] !== HARBOR_PROXY &&
-          !registryMatch[2].startsWith(`${HARBOR_PROXY}/`)
-        ) {
-          line = line.replace(
-            /(\s+registry:\s+)([^\s\n]+)/,
-            `$1${HARBOR_PROXY}/$2`
-          );
+      if (line.includes("registry:")) {
+        // Clean up corrupted values like harbor.settlemint.com/""
+        if (line.includes(`${HARBOR_PROXY}/""`)) {
+          line = line.replace(`${HARBOR_PROXY}/""`, '""');
+        } else if (line.includes(`${HARBOR_PROXY}/"''"`)) {
+          line = line.replace(`${HARBOR_PROXY}/''`, "''");
+        }
+        // Process normal values (but not if already has harbor proxy)
+        else if (!line.includes(`${HARBOR_PROXY}/`)) {
+          const registryMatch = line.match(/(\s+registry:\s+)([^\s\n]+)/);
+          if (
+            registryMatch &&
+            registryMatch[2] &&
+            registryMatch[2] !== HARBOR_PROXY &&
+            !registryMatch[2].startsWith(`${HARBOR_PROXY}/`) &&
+            registryMatch[2] !== '""' &&  // Skip empty string values
+            registryMatch[2] !== "''" &&  // Skip empty string values with single quotes
+            registryMatch[2].trim() !== ""  // Skip actual empty values
+          ) {
+            line = line.replace(
+              /(\s+registry:\s+)([^\s\n]+)/,
+              `$1${HARBOR_PROXY}/$2`
+            );
+          }
         }
       }
 
       // Process imageRegistry: values
-      if (
-        line.includes("imageRegistry:") &&
-        !line.includes(`${HARBOR_PROXY}/`)
-      ) {
-        const registryMatch = line.match(/(\s+imageRegistry:\s+)([^\s\n]+)/);
-        if (
-          registryMatch &&
-          registryMatch[2] &&
-          registryMatch[2] !== HARBOR_PROXY &&
-          !registryMatch[2].startsWith(`${HARBOR_PROXY}/`)
-        ) {
-          line = line.replace(
-            /(\s+imageRegistry:\s+)([^\s\n]+)/,
-            `$1${HARBOR_PROXY}/$2`
-          );
+      if (line.includes("imageRegistry:")) {
+        // Clean up corrupted values like harbor.settlemint.com/""
+        if (line.includes(`${HARBOR_PROXY}/""`)) {
+          line = line.replace(`${HARBOR_PROXY}/""`, '""');
+        } else if (line.includes(`${HARBOR_PROXY}/"''"`)) {
+          line = line.replace(`${HARBOR_PROXY}/''`, "''");
+        }
+        // Process normal values (but not if already has harbor proxy)
+        else if (!line.includes(`${HARBOR_PROXY}/`)) {
+          const registryMatch = line.match(/(\s+imageRegistry:\s+)([^\s\n]+)/);
+          if (
+            registryMatch &&
+            registryMatch[2] &&
+            registryMatch[2] !== HARBOR_PROXY &&
+            !registryMatch[2].startsWith(`${HARBOR_PROXY}/`) &&
+            registryMatch[2] !== '""' &&  // Skip empty string values
+            registryMatch[2] !== "''" &&  // Skip empty string values with single quotes
+            registryMatch[2].trim() !== ""  // Skip actual empty values
+          ) {
+            line = line.replace(
+              /(\s+imageRegistry:\s+)([^\s\n]+)/,
+              `$1${HARBOR_PROXY}/$2`
+            );
+          }
         }
       }
 

--- a/kit/charts/tools/values-orbstack.1p.yaml
+++ b/kit/charts/tools/values-orbstack.1p.yaml
@@ -17,7 +17,7 @@ imagePullCredentials:
       # -- Enable this if you want this chart to create an image pull secret for you
       enabled: true
       # -- The registry hosting the packages, e.g docker.io or ghcr.io
-      registry: "ghcr.io"
+      registry: ghcr.io
       # -- The username to access the registry
       username: "op://platform/github-commit-pat/username"
       # -- The password or access token to access the registry


### PR DESCRIPTION
## Summary by Sourcery

Refine the Harbor packaging script to ignore empty registry values and sanitize malformed proxy prefixes, update chart configurations for MinIO with security settings, pull secrets, and additional images, and normalize registry field quoting across multiple Helm value files.

Enhancements:
- Skip empty string registry and imageRegistry values in the Harbor proxy script and clean up malformed proxy prefixes

Chores:
- Enable insecure images and add imagePullSecrets, console image, and default init containers to the MinIO support chart
- Remove unnecessary quotes around registry values in TxSigner and Orbstack Helm value files