### PR TITLE
fix: correct PR labeling for dependency updates

### DIFF
--- a/.github/actions/pr-labeler/action.yml
+++ b/.github/actions/pr-labeler/action.yml
@@ -114,18 +114,18 @@ runs:
           
           const labelsToAdd = [];
           
-          // Check conventional commit type from title
-          const typeMatch = pr_title.match(/^(feat|fix|docs|style|refactor|perf|test|build|ci|revert)(\(.+\))?:/);
-          if (typeMatch) {
-            labelsToAdd.push(typeMatch[1]);
-          } else {
-            // If no conventional commit format, add chore
-            labelsToAdd.push('chore');
-          }
-          
-          // Check for dependencies
+          // Check for dependencies first (takes precedence)
           if (pr_title.match(/^(chore|fix|build)\(deps\):/)) {
             labelsToAdd.push('dependencies');
+          } else {
+            // Check conventional commit type from title
+            const typeMatch = pr_title.match(/^(feat|fix|docs|style|refactor|perf|test|build|ci|revert)(\(.+\))?:/);
+            if (typeMatch) {
+              labelsToAdd.push(typeMatch[1]);
+            } else {
+              // If no conventional commit format, add chore
+              labelsToAdd.push('chore');
+            }
           }
           
           // Check for breaking changes


### PR DESCRIPTION
## Summary

This PR fixes the labeling logic for dependency update PRs (like those created by Renovate) to ensure they only receive the "dependencies" label.

## Problem

Currently, PRs with titles like `chore(deps): update package` receive both labels:
- `chore` (from the conventional commit type)
- `dependencies` (from the deps scope)

This is incorrect - dependency PRs should only have the "dependencies" label.

## Solution

Modified the pr-labeler action to check for dependency patterns first. If a PR title matches the pattern `(chore|fix|build)(deps):`, it will only add the "dependencies" label and skip the conventional commit type labeling.

## Example

Before this fix:
- PR title: `chore(deps): update namespace-actions/upload-artifact action to v1`
- Labels applied: `chore`, `dependencies` ❌

After this fix:
- PR title: `chore(deps): update namespace-actions/upload-artifact action to v1`
- Labels applied: `dependencies` ✅

## Test Plan

- [ ] Create a test PR with title `chore(deps): test update`
- [ ] Verify it only gets the "dependencies" label
- [ ] Create a regular PR with title `chore: regular update`
- [ ] Verify it gets the "chore" label

## Summary by Sourcery

Bug Fixes:
- Prioritize dependency pattern matching in the pr-labeler action to prevent adding conventional commit labels on dependency update PRs