### PR TITLE
chore: configure Renovate to auto-merge GitHub Actions updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,13 @@
       "groupName": "Next Safe Action",
       "groupSlug": "next-safe-action",
       "matchPackageNames": ["next-safe-action", "/^@next-safe-action//"]
+    },
+    {
+      "description": "Automerge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "platformAutomerge": true,
+      "schedule": ["at any time"]
     }
   ],
   "hostRules": [


### PR DESCRIPTION
## Summary

This PR configures Renovate to automatically merge GitHub Actions dependency updates.

## Changes

Added a new package rule in `.github/renovate.json` that:
- Targets all GitHub Actions updates (`matchManagers: ["github-actions"]`)
- Enables auto-merge when all status checks pass
- Uses `platformAutomerge` for immediate merging (no waiting period)
- Allows updates at any time (not restricted to non-office hours like other dependencies)

## Benefits

- Reduces manual work for routine Actions updates
- Keeps workflows using the latest secure and stable versions
- Actions updates are typically low-risk (semantic versioning)
- All updates still go through CI/CD checks before merging

## Example

With this configuration, PRs like #2532 (`chore(deps): update namespace-actions/upload-artifact action to v1`) will be automatically merged once all status checks pass.

## Test Plan

- [ ] Merge this PR
- [ ] Wait for next Renovate run with Actions updates
- [ ] Verify PRs are created with auto-merge enabled
- [ ] Confirm PRs merge automatically after checks pass