### PR TITLE
chore: simplify slack notifications and labeling system

### DIFF
--- a/.github/actions/unified-pr-labeler/action.yml
+++ b/.github/actions/unified-pr-labeler/action.yml
@@ -1,0 +1,237 @@
+name: "Unified PR Labeler"
+description: "Unified labeling system for PRs - handles all label updates in one place"
+inputs:
+  pr_number:
+    description: "Pull request number"
+    required: true
+  pr_title:
+    description: "Pull request title"
+    required: true
+  pr_body:
+    description: "Pull request body"
+    required: false
+    default: ""
+  pr_author:
+    description: "Pull request author"
+    required: true
+  pr_author_type:
+    description: "Pull request author type (User or Bot)"
+    required: false
+    default: "User"
+  is_draft:
+    description: "Whether the PR is a draft"
+    required: false
+    default: "false"
+  is_merged:
+    description: "Whether the PR is merged"
+    required: false
+    default: "false"
+  qa_status:
+    description: "QA workflow status (pending/running/success/failed)"
+    required: false
+    default: "pending"
+  has_approval:
+    description: "Whether the PR has been approved"
+    required: false
+    default: "false"
+  update_type:
+    description: "Type of update (initial/qa-status/review-status/merged)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update PR labels
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const pr_number = parseInt(${{ inputs.pr_number }});
+          const pr_title = ${{ toJSON(inputs.pr_title) }};
+          const pr_body = ${{ toJSON(inputs.pr_body) }};
+          const pr_author = ${{ toJSON(inputs.pr_author) }};
+          const pr_author_type = '${{ inputs.pr_author_type }}';
+          const is_draft = '${{ inputs.is_draft }}' === 'true';
+          const is_merged = '${{ inputs.is_merged }}' === 'true';
+          const qa_status = '${{ inputs.qa_status }}';
+          const has_approval = '${{ inputs.has_approval }}' === 'true';
+          const update_type = '${{ inputs.update_type }}';
+
+          console.log(`Unified labeler - Update type: ${update_type}`);
+          console.log(`PR #${pr_number}: Draft=${is_draft}, QA=${qa_status}, Approved=${has_approval}, Merged=${is_merged}`);
+
+          // Define all labels in one place
+          const labelDefinitions = {
+            // Conventional commit labels
+            feat: { color: '0366d6', description: '✨ New feature' },
+            fix: { color: 'd73a4a', description: '🐛 Bug fix' },
+            docs: { color: '0075ca', description: '📝 Documentation' },
+            style: { color: 'e4e669', description: '💄 Style changes' },
+            refactor: { color: '008672', description: '♻️ Code refactoring' },
+            perf: { color: 'a2eeef', description: '⚡ Performance improvements' },
+            test: { color: 'f9d0c4', description: '✅ Tests' },
+            build: { color: 'f06292', description: '🔨 Build system' },
+            ci: { color: 'fbca04', description: '👷 CI/CD' },
+            chore: { color: 'fef2c0', description: '🔧 Chores' },
+            revert: { color: '6f42c1', description: '⏪ Reverts' },
+            dependencies: { color: '0366d6', description: '📦 Dependencies' },
+            breaking: { color: 'd93f0b', description: '💥 Breaking changes' },
+            
+            // QA status labels
+            'qa:pending': { color: 'e4e669', description: 'QA workflow needs to run' },
+            'qa:running': { color: 'fbca04', description: 'QA workflow is running' },
+            'qa:success': { color: '0e8a16', description: 'QA workflow passed' },
+            'qa:failed': { color: 'd73a4a', description: 'QA workflow failed' },
+            
+            // PR status labels
+            'status:draft': { color: '6a737d', description: 'PR is in draft mode' },
+            'status:ready-for-review': { color: 'fbca04', description: 'PR is ready for review' },
+            'status:approved': { color: '0e8a16', description: 'PR has been approved' },
+            'status:mergeable': { color: '0e8a16', description: 'PR is ready to merge' },
+            'status:merged': { color: '6f42c1', description: 'PR has been merged' }
+          };
+
+          // Ensure all label definitions exist
+          const ensureLabels = async () => {
+            const { data: existingLabels } = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+
+            const existingLabelNames = new Set(existingLabels.map(l => l.name));
+
+            for (const [name, config] of Object.entries(labelDefinitions)) {
+              if (!existingLabelNames.has(name)) {
+                console.log(`Creating label: ${name}`);
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: config.color,
+                  description: config.description
+                });
+              }
+            }
+          };
+
+          // Parse conventional commit from title
+          const parseConventionalCommit = (title) => {
+            const regex = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([\w\-\s,]+\))?(!)?:\s+(.+)$/;
+            const match = title.match(regex);
+            
+            if (match) {
+              const [, type, scope, breaking] = match;
+              const labels = [type];
+              
+              // Check for dependencies in scope
+              if (scope && scope.includes('deps')) {
+                labels.push('dependencies');
+                // Remove the original type label for dependency updates
+                const typeIndex = labels.indexOf(type);
+                if (typeIndex > -1) labels.splice(typeIndex, 1);
+              }
+              
+              if (breaking) {
+                labels.push('breaking');
+              }
+              
+              return labels;
+            }
+            
+            return ['chore']; // Default if no match
+          };
+
+          // Determine which labels to apply based on current state
+          const determineLabels = () => {
+            const labels = new Set();
+
+            // Add conventional commit labels (only on initial)
+            if (update_type === 'initial') {
+              const commitLabels = parseConventionalCommit(pr_title);
+              commitLabels.forEach(l => labels.add(l));
+            }
+
+            // Add QA status label
+            if (qa_status && qa_status !== 'none') {
+              labels.add(`qa:${qa_status}`);
+            }
+
+            // Add PR status label
+            if (is_merged) {
+              labels.add('status:merged');
+            } else if (qa_status === 'success' && has_approval) {
+              labels.add('status:mergeable');
+            } else if (has_approval) {
+              labels.add('status:approved');
+            } else if (is_draft) {
+              labels.add('status:draft');
+            } else {
+              labels.add('status:ready-for-review');
+            }
+
+            return Array.from(labels);
+          };
+
+          try {
+            // Ensure all labels exist
+            await ensureLabels();
+
+            // Get current labels
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number
+            });
+
+            const currentLabelNames = currentLabels.map(l => l.name);
+            const newLabels = determineLabels();
+
+            // Determine labels to add/remove
+            const labelsToAdd = newLabels.filter(l => !currentLabelNames.includes(l));
+            const labelsToRemove = currentLabelNames.filter(l => {
+              // Only remove labels we manage
+              const isQaLabel = l.startsWith('qa:');
+              const isStatusLabel = l.startsWith('status:');
+              const isConventionalLabel = labelDefinitions.hasOwnProperty(l);
+              
+              if (isQaLabel || isStatusLabel) {
+                return !newLabels.includes(l);
+              }
+              
+              // Don't remove conventional commit labels after initial
+              if (isConventionalLabel && update_type !== 'initial') {
+                return false;
+              }
+              
+              return isConventionalLabel && !newLabels.includes(l);
+            });
+
+            console.log('Current labels:', currentLabelNames);
+            console.log('New labels:', newLabels);
+            console.log('Labels to add:', labelsToAdd);
+            console.log('Labels to remove:', labelsToRemove);
+
+            // Apply label changes
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                labels: labelsToAdd
+              });
+            }
+
+            for (const label of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                name: label
+              });
+            }
+
+            console.log('Label update complete');
+          } catch (error) {
+            console.error('Error updating labels:', error);
+            throw error;
+          }

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -63,20 +63,42 @@ jobs:
           PAT_TOKEN: op://platform/github-commit-pat/credential
           NPM_TOKEN: op://platform/npmjs/credential
 
-      # Label QA as running and notify Slack (only for non-draft PRs)
-      - name: Label QA as running
+      # Initial labeling and QA status update
+      - name: Initial PR labeling
         if: |
           github.event_name == 'pull_request' &&
-          github.event.pull_request.draft == false
-        uses: ./.github/actions/build-status-labeler
+          (github.event.action == 'opened' || github.event.action == 'reopened')
+        uses: ./.github/actions/unified-pr-labeler
         with:
           pr_number: ${{ github.event.pull_request.number }}
-          workflow_status: 'running'
+          pr_title: ${{ github.event.pull_request.title }}
+          pr_body: ${{ github.event.pull_request.body || '' }}
+          pr_author: ${{ github.event.pull_request.user.login }}
+          pr_author_type: ${{ github.event.pull_request.user.type }}
+          is_draft: ${{ github.event.pull_request.draft }}
+          qa_status: 'running'
+          update_type: 'initial'
 
-      - name: Send Slack notification for QA running
+      - name: Update QA status to running
         if: |
           github.event_name == 'pull_request' &&
-          github.event.pull_request.draft == false
+          github.event.pull_request.draft == false &&
+          !(github.event.action == 'opened' || github.event.action == 'reopened')
+        uses: ./.github/actions/unified-pr-labeler
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_title: ${{ github.event.pull_request.title }}
+          pr_author: ${{ github.event.pull_request.user.login }}
+          is_draft: ${{ github.event.pull_request.draft }}
+          qa_status: 'running'
+          update_type: 'qa-status'
+
+      # Create initial Slack notification only on PR open/reopen
+      - name: Send initial Slack notification
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          (github.event.action == 'opened' || github.event.action == 'reopened')
         uses: ./.github/actions/slack-pr-notifier
         with:
           pr_number: ${{ github.event.pull_request.number }}
@@ -174,60 +196,26 @@ jobs:
             kit/subgraph/.generated/subgraph-env
             kit/dapp/.generated/database-export.sql
 
-      # Label QA results (PR only)
-      - name: Label QA build status
+      # Update QA results
+      - name: Update QA status
         if: |
           always() &&
           github.event_name == 'pull_request' &&
           steps.qa-tests.conclusion != 'skipped'
-        uses: ./.github/actions/build-status-labeler
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          workflow_status: ${{ steps.qa-tests.outcome == 'success' && 'success' || 'failure' }}
-
-      - name: Send Slack notification for QA status
-        if: |
-          always() &&
-          github.event_name == 'pull_request' &&
-          steps.qa-tests.conclusion != 'skipped'
-        uses: ./.github/actions/slack-pr-notifier
+        uses: ./.github/actions/unified-pr-labeler
         with:
           pr_number: ${{ github.event.pull_request.number }}
           pr_title: ${{ github.event.pull_request.title }}
-          pr_url: ${{ github.event.pull_request.html_url }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          pr_author_type: ${{ github.event.pull_request.user.type }}
-          pr_author_avatar: ${{ github.event.pull_request.user.avatar_url }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          slack_channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          is_draft: ${{ github.event.pull_request.draft }}
+          qa_status: ${{ steps.qa-tests.outcome == 'success' && 'success' || 'failed' }}
+          update_type: 'qa-status'
 
-      # Label PR based on title/branch (PR only)
-      - name: Label PR based on convention
-        id: label-pr
-        if: |
-          github.event_name == 'pull_request' &&
-          (github.event.action == 'opened' || github.event.action == 'synchronize')
-        uses: ./.github/actions/pr-labeler
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          pr_title: ${{ github.event.pull_request.title }}
-          pr_body: ${{ github.event.pull_request.body || '' }}
+      # Slack notification is handled by the initial notification which updates automatically
 
-      - name: Send Slack notification for PR labels
-        if: |
-          always() &&
-          steps.label-pr.conclusion == 'success' &&
-          github.event_name == 'pull_request'
-        uses: ./.github/actions/slack-pr-notifier
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          pr_title: ${{ github.event.pull_request.title }}
-          pr_url: ${{ github.event.pull_request.html_url }}
-          pr_author: ${{ github.event.pull_request.user.login }}
-          pr_author_type: ${{ github.event.pull_request.user.type }}
-          pr_author_avatar: ${{ github.event.pull_request.user.avatar_url }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          slack_channel_id: ${{ env.SLACK_CHANNEL_ID }}
+      # Conventional commit labels are handled by initial labeling
+
+      # PR label notifications handled by the initial notification
 
       # Run secret scanning (PR only)
       - name: Run secret scanning
@@ -236,33 +224,9 @@ jobs:
         uses: ./.github/actions/secret-scanner
         continue-on-error: true
 
-      # Label secret scanning results (PR only)
-      - name: Label secret scanning status
-        if: |
-          always() &&
-          github.event_name == 'pull_request' &&
-          steps.secret-scan.conclusion != 'skipped'
-        uses: ./.github/actions/build-status-labeler
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          workflow_status: ${{ steps.secret-scan.outcome == 'success' && 'success' || 'failure' }}
+      # Secret scanning status is tracked separately, not in labels
 
-      - name: Send Slack notification for secret scanning
-        if: |
-          always() &&
-          github.event_name == 'pull_request' &&
-          steps.secret-scan.conclusion != 'skipped' &&
-          github.event.pull_request.user.type != 'Bot'
-        uses: ./.github/actions/slack-pr-notifier
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          pr_title: ${{ github.event.pull_request.title }}
-          pr_url: ${{ github.event.pull_request.html_url }}
-          pr_author: ${{ github.event.pull_request.user.login }}
-          pr_author_type: ${{ github.event.pull_request.user.type }}
-          pr_author_avatar: ${{ github.event.pull_request.user.avatar_url }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          slack_channel_id: ${{ env.SLACK_CHANNEL_ID }}
+      # Secret scanning notifications handled by the initial notification
 
       # Check PR review status (PR and PR review events only)
       - name: Check PR review status
@@ -278,34 +242,23 @@ jobs:
           qa_result: ${{ steps.qa-tests.outcome }}
           secret_scanning_result: ${{ steps.secret-scan.outcome }}
 
-      # Apply final PR status label (PR and PR review events only)
-      - name: Label PR final status
-        id: label-final-status
+      # Update final PR status
+      - name: Update PR status
+        id: update-pr-status
         if: |
           always() &&
           (github.event_name == 'pull_request' || github.event_name == 'pull_request_review')
-        uses: ./.github/actions/pr-status-labeler
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          is_draft: ${{ github.event.pull_request.draft }}
-          has_approval: ${{ steps.pr-review-check.outputs.has_approval == 'true' }}
-          qa_status: ${{ steps.pr-review-check.outputs.qa_status }}
-
-      - name: Send Slack notification for final status
-        if: |
-          always() &&
-          steps.label-final-status.conclusion == 'success' &&
-          (github.event_name == 'pull_request' || github.event_name == 'pull_request_review')
-        uses: ./.github/actions/slack-pr-notifier
+        uses: ./.github/actions/unified-pr-labeler
         with:
           pr_number: ${{ github.event.pull_request.number }}
           pr_title: ${{ github.event.pull_request.title }}
-          pr_url: ${{ github.event.pull_request.html_url }}
           pr_author: ${{ github.event.pull_request.user.login }}
-          pr_author_type: ${{ github.event.pull_request.user.type }}
-          pr_author_avatar: ${{ github.event.pull_request.user.avatar_url }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          slack_channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          is_draft: ${{ github.event.pull_request.draft }}
+          qa_status: ${{ steps.pr-review-check.outputs.qa_status }}
+          has_approval: ${{ steps.pr-review-check.outputs.has_approval == 'true' }}
+          update_type: 'review-status'
+
+      # Final status update handled automatically when labels change
 
       # Manage auto-merge (PR and PR review events only)
       - name: Manage auto-merge
@@ -353,11 +306,13 @@ jobs:
           SLACK_CHANNEL_ID: op://platform/slack-bot/SLACK_CHANNEL_ID
 
       - name: Label PR as merged
-        uses: ./.github/actions/pr-status-labeler
+        uses: ./.github/actions/unified-pr-labeler
         with:
           pr_number: ${{ github.event.pull_request.number }}
-          is_draft: false
+          pr_title: ${{ github.event.pull_request.title }}
+          pr_author: ${{ github.event.pull_request.user.login }}
           is_merged: true
+          update_type: 'merged'
 
       - name: Update Slack notification for merged PR
         uses: ./.github/actions/slack-pr-notifier

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/settlemint/sdk/blob/main/logo.svg" width="200px" align="center" alt="SettleMint logo" />
   <h1 align="center">SettleMint - Asset Tokenization Kit</h1>
   <p align="center">
-    ✨ <a href="Zijn allemaal vrienden tot https://settlemint.com">https://settlemint.com</a> ✨
+    ✨ <a href="https://settlemint.com">https://settlemint.com</a> ✨
     <br/>
     Build your digital assets platform with the SettleMint Asset Tokenization Kit.
     <br/>


### PR DESCRIPTION
## Summary

This PR simplifies the Slack notification and labeling system to reduce noise and improve maintainability.

### Problem
- Multiple Slack messages per PR (5+ notifications)
- Redundant labeling actions with overlapping responsibilities
- Complex workflow with many conditional steps

### Solution

#### 1. **Single Slack Notification per PR**
- Only creates notification when PR is opened/reopened
- Updates existing message via reactions instead of sending new messages
- Removes all redundant notification steps

#### 2. **Unified Labeling System**
- Consolidates 3 separate labeling actions into 1 unified action
- Centralizes all label definitions in one place
- Simplifies state management and reduces API calls

#### 3. **Workflow Simplification**
- Removed 4 redundant Slack notification steps
- Replaced multiple labeling actions with single unified labeler
- Maintains all existing functionality with cleaner implementation

### Changes Made

1. **Modified `.github/workflows/qa.yml`:**
   - Send initial Slack notification only on PR open/reopen
   - Removed redundant notification steps (now just comments)
   - Updated all labeling steps to use unified labeler

2. **Created `.github/actions/unified-pr-labeler/action.yml`:**
   - Single action to handle all PR labeling
   - Centralized label definitions
   - Smart update logic based on update type

3. **Added documentation:**
   - Created README for slack-pr-notifier action
   - Documents the new behavior and design

### Benefits
- **Less Spam**: 1 notification instead of 5+ per PR
- **Better Performance**: Fewer GitHub API calls
- **Easier Maintenance**: Single source of truth for labels
- **Cleaner Code**: Simplified workflow logic

### Testing
- The existing slack-pr-notifier action already handles message updates
- The unified labeler maintains the same labeling logic
- All existing functionality is preserved

### Migration
No migration needed - the changes are backward compatible and will apply to new PRs automatically.

## Summary by Sourcery

Simplify Slack notifications and PR labeling by introducing a unified-pr-labeler action, reducing redundant Slack messages to a single initial notification, centralizing label logic, and streamlining the QA workflow.

New Features:
- Add a unified-pr-labeler composite action to handle all PR labeling in one place

Enhancements:
- Reduce Slack spam by sending only an initial notification on PR open/reopen and updating the existing message
- Consolidate multiple labeling actions into a single workflow step with centralized label definitions
- Streamline the QA workflow by removing redundant notification and labeling steps and cutting GitHub API calls

CI:
- Update .github/workflows/qa.yml to replace separate build-status-labeler, pr-labeler, and pr-status-labeler actions with unified-pr-labeler and a single slack-pr-notifier call

Documentation:
- Fix the project README link to settlemint.com