### PR TITLE
chore: configure renovate to run bun install after updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,7 @@
   ],
   "labels": ["dependencies"],
   "rebaseWhen": "conflicted",
+  "postUpdateOptions": ["bunInstall"],
   "packageRules": [
     {
       "groupName": "SettleMint SDK",


### PR DESCRIPTION
## Summary

This PR configures Renovate to run `bun install` after updating dependencies to ensure the lockfile (`bun.lockb`) is properly updated.

## Changes

- Added `postUpdateOptions: ["bunInstall"]` to `.github/renovate.json`

## Why this change?

When Renovate updates dependencies in `package.json`, it needs to also update the lockfile to maintain consistency. The `bunInstall` post-update option ensures that `bun install` is executed after dependency updates, which will update `bun.lockb` accordingly.

## Test Plan

The next Renovate PR should now include updates to both `package.json` and `bun.lockb` when dependencies are updated.

## Summary by Sourcery

CI:
- Configure Renovate to run `bun install` after updating dependencies to update `bun.lockb`