### PR TITLE
fix: improve error handling for system deployment and restore subgraph addresses

### DIFF
--- a/kit/dapp/src/orpc/middlewares/monitoring/error.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/monitoring/error.middleware.ts
@@ -246,16 +246,6 @@ export const errorMiddleware = baseRouter.middleware(async ({ next }) => {
         });
       }
 
-      // Include cause information in the error for debugging
-      if (error.cause instanceof Error) {
-        throw new ORPCError(error.code, {
-          status: error.status,
-          message: error.message,
-          cause: error.cause,
-          data: error.data,
-        });
-      }
-
       throw error;
     }
 

--- a/kit/dapp/src/orpc/middlewares/monitoring/error.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/monitoring/error.middleware.ts
@@ -226,12 +226,14 @@ export const errorMiddleware = baseRouter.middleware(async ({ next }) => {
 
     // Handle other ORPC errors
     if (error instanceof ORPCError) {
-      // Log the error for debugging
+      // Log the error for debugging with full context
       logger.error("ORPC error", {
         code: error.code,
         status: error.status,
         message: error.message || `Request failed with status ${error.code}`,
         cause: error.cause instanceof Error ? error.cause.message : error.cause,
+        stack: error.cause instanceof Error ? error.cause.stack : undefined,
+        data: error.data,
       });
 
       // Ensure the error has a meaningful message
@@ -240,6 +242,17 @@ export const errorMiddleware = baseRouter.middleware(async ({ next }) => {
           status: error.status,
           message: `Request failed with status ${error.code}`,
           cause: error.cause ?? error,
+          data: error.data,
+        });
+      }
+
+      // Include cause information in the error for debugging
+      if (error.cause instanceof Error) {
+        throw new ORPCError(error.code, {
+          status: error.status,
+          message: error.message,
+          cause: error.cause,
+          data: error.data,
         });
       }
 

--- a/kit/dapp/src/orpc/routes/system/routes/system.create.ts
+++ b/kit/dapp/src/orpc/routes/system/routes/system.create.ts
@@ -22,7 +22,12 @@ import { portalMiddleware } from "@/orpc/middlewares/services/portal.middleware"
 import { theGraphMiddleware } from "@/orpc/middlewares/services/the-graph.middleware";
 import { onboardedRouter } from "@/orpc/procedures/onboarded.router";
 import { withEventMeta } from "@orpc/server";
+import { createLogger, type LogLevel } from "@settlemint/sdk-utils/logging";
 import { SystemCreateMessagesSchema } from "./system.create.schema";
+
+const logger = createLogger({
+  level: process.env.SETTLEMINT_LOG_LEVEL as LogLevel,
+});
 
 /**
  * GraphQL mutation for creating a new system contract instance.
@@ -125,22 +130,57 @@ export const create = onboardedRouter.system.create
     const messages = SystemCreateMessagesSchema.parse(input.messages ?? {});
 
     // Execute the system creation transaction
-    const txHashResult = await context.portalClient.request(
-      CREATE_SYSTEM_MUTATION,
-      {
-        address: contract,
-        from: sender.wallet,
-        // ...(await handleChallenge(sender, verification)),
-      }
-    );
+    let txHashResult;
+    try {
+      txHashResult = await context.portalClient.request(
+        CREATE_SYSTEM_MUTATION,
+        {
+          address: contract,
+          from: sender.wallet,
+          // ...(await handleChallenge(sender, verification)),
+        }
+      );
+    } catch (error) {
+      const errorDetails = {
+        operation: "CREATE_SYSTEM_MUTATION",
+        factory: contract,
+        sender: sender.wallet,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      };
+      logger.error("System creation GraphQL mutation failed", errorDetails);
+      
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: messages.systemCreationFailed,
+        cause: new Error(
+          `GraphQL mutation failed: ${error instanceof Error ? error.message : String(error)}. Factory: ${contract}, Sender: ${sender.wallet}`
+        ),
+      });
+    }
 
     const transactionHash =
       txHashResult.ATKSystemFactoryCreateSystem?.transactionHash ?? null;
+    
+    if (transactionHash) {
+      logger.info("System creation transaction submitted", {
+        transactionHash,
+        factory: contract,
+        sender: sender.wallet,
+      });
+    }
 
     // Validate transaction hash
     if (!transactionHash) {
+      logger.error("System creation failed: No transaction hash returned", {
+        operation: "CREATE_SYSTEM_MUTATION",
+        factory: contract,
+        sender: sender.wallet,
+        result: txHashResult,
+      });
+      
       throw errors.INTERNAL_SERVER_ERROR({
         message: messages.systemCreationFailed,
+        cause: new Error("No transaction hash returned from ATKSystemFactoryCreateSystem mutation"),
       });
     }
 
@@ -173,24 +213,64 @@ export const create = onboardedRouter.system.create
     }
 
     // Query for the deployed system contract
-    const { systems } = await context.theGraphClient.request(
-      FIND_SYSTEM_FOR_TRANSACTION_QUERY,
-      {
-        deployedInTransaction: transactionHash,
-      }
-    );
-
-    if (systems.length === 0) {
+    let systems;
+    try {
+      const result = await context.theGraphClient.request(
+        FIND_SYSTEM_FOR_TRANSACTION_QUERY,
+        {
+          deployedInTransaction: transactionHash,
+        }
+      );
+      systems = result.systems;
+    } catch (error) {
+      const errorDetails = {
+        operation: "FIND_SYSTEM_FOR_TRANSACTION_QUERY",
+        transactionHash,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      };
+      logger.error("Failed to query deployed system contract", errorDetails);
+      
       throw errors.INTERNAL_SERVER_ERROR({
         message: messages.systemCreationFailed,
+        cause: new Error(
+          `TheGraph query failed: ${error instanceof Error ? error.message : String(error)}. Transaction: ${transactionHash}`
+        ),
+      });
+    }
+
+    if (systems.length === 0) {
+      logger.error("No system contracts found after deployment", {
+        operation: "FIND_SYSTEM_FOR_TRANSACTION_QUERY",
+        transactionHash,
+        systemsFound: systems.length,
+      });
+      
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: messages.systemCreationFailed,
+        cause: new Error(`System contract not found in transaction ${transactionHash} after deployment`),
       });
     }
 
     const system = systems[0];
+    
+    if (system) {
+      logger.info("System contract deployed successfully", {
+        systemAddress: system.id,
+        deploymentTransaction: transactionHash,
+      });
+    }
 
     if (!system) {
+      logger.error("System object is null after query", {
+        operation: "FIND_SYSTEM_FOR_TRANSACTION_QUERY",
+        transactionHash,
+        systems,
+      });
+      
       throw errors.INTERNAL_SERVER_ERROR({
         message: messages.systemCreationFailed,
+        cause: new Error(`System object is null for transaction ${transactionHash}`),
       });
     }
 
@@ -205,21 +285,56 @@ export const create = onboardedRouter.system.create
     );
 
     // Execute the bootstrap transaction
-    const bootstrapTxHashResult = await context.portalClient.request(
-      BOOTSTRAP_SYSTEM_MUTATION,
-      {
-        address: system.id,
-        from: sender.wallet,
-      }
-    );
+    let bootstrapTxHashResult;
+    try {
+      bootstrapTxHashResult = await context.portalClient.request(
+        BOOTSTRAP_SYSTEM_MUTATION,
+        {
+          address: system.id,
+          from: sender.wallet,
+        }
+      );
+    } catch (error) {
+      const errorDetails = {
+        operation: "BOOTSTRAP_SYSTEM_MUTATION",
+        systemAddress: system.id,
+        sender: sender.wallet,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      };
+      logger.error("System bootstrap GraphQL mutation failed", errorDetails);
+      
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: messages.bootstrapFailed,
+        cause: new Error(
+          `Bootstrap GraphQL mutation failed: ${error instanceof Error ? error.message : String(error)}. System: ${system.id}, Sender: ${sender.wallet}`
+        ),
+      });
+    }
 
     const bootstrapTransactionHash =
       bootstrapTxHashResult.IATKSystemBootstrap?.transactionHash ?? null;
+    
+    if (bootstrapTransactionHash) {
+      logger.info("System bootstrap transaction submitted", {
+        bootstrapTransactionHash,
+        systemAddress: system.id,
+        sender: sender.wallet,
+      });
+    }
 
     // Validate bootstrap transaction hash
     if (!bootstrapTransactionHash) {
+      logger.error("Bootstrap failed: No transaction hash returned", {
+        operation: "BOOTSTRAP_SYSTEM_MUTATION",
+        systemAddress: system.id,
+        sender: sender.wallet,
+        result: bootstrapTxHashResult,
+      });
+      
       throw errors.INTERNAL_SERVER_ERROR({
         message: messages.bootstrapFailed,
+        cause: new Error(`No transaction hash returned from IATKSystemBootstrap mutation for system ${system.id}`),
       });
     }
 
@@ -247,8 +362,17 @@ export const create = onboardedRouter.system.create
       // Track bootstrap success/failure
       if (event.status === "confirmed") {
         bootstrapSucceeded = true;
+        logger.info("System bootstrap completed successfully", {
+          systemAddress: system.id,
+          bootstrapTransaction: bootstrapTransactionHash,
+        });
       } else if (event.status === "failed") {
         bootstrapSucceeded = false;
+        logger.error("System bootstrap failed", {
+          systemAddress: system.id,
+          bootstrapTransaction: bootstrapTransactionHash,
+          failureMessage: event.message,
+        });
         // Don't return early - we still need to report the system ID
         break;
       }

--- a/kit/subgraph/subgraph.yaml
+++ b/kit/subgraph/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     name: SystemFactory
     network: settlemint
     source:
-      address: "0xf5059a5D33d5853360D16C683c16e67980206f36"
+      address: "0x5e771e1417100000000000000000000000020088"
       abi: SystemFactory
       startBlock: 0
     mapping:

--- a/kit/subgraph/tools/graph-deploy.ts
+++ b/kit/subgraph/tools/graph-deploy.ts
@@ -96,12 +96,14 @@ const logger = createLogger({
 // ============================================================================
 
 let originalAddresses: DeployedAddresses | null = null;
+let originalSubgraphYaml: string | null = null;
 let graphPaths: GraphPaths | null = null;
 
 /**
  * Cleanup function to restore original addresses on exit
  */
 async function cleanup(): Promise<void> {
+  // Restore subgraph.json
   if (originalAddresses && graphPaths?.subgraphConfig) {
     try {
       logger.info("Restoring original subgraph configuration...");
@@ -112,6 +114,17 @@ async function cleanup(): Promise<void> {
       logger.info("Original configuration restored");
     } catch (error) {
       logger.error("Failed to restore original configuration:", error);
+    }
+  }
+
+  // Restore subgraph.yaml
+  if (originalSubgraphYaml && graphPaths?.subgraphYaml) {
+    try {
+      logger.info("Restoring original subgraph.yaml...");
+      await Bun.write(graphPaths.subgraphYaml, originalSubgraphYaml);
+      logger.info("Original subgraph.yaml restored");
+    } catch (error) {
+      logger.error("Failed to restore original subgraph.yaml:", error);
     }
   }
 }
@@ -427,9 +440,14 @@ async function updateSubgraphYaml(addresses: DeployedAddresses): Promise<void> {
       throw new Error("Missing subgraph yaml");
     }
 
-    const subgraphYamlConfig = (await parse(
-      await subgraphYaml.text()
-    )) as SubgraphYamlConfig;
+    // Backup original subgraph.yaml content if not already backed up
+    const yamlContent = await subgraphYaml.text();
+    if (!originalSubgraphYaml) {
+      originalSubgraphYaml = yamlContent;
+      logger.debug("Backed up original subgraph.yaml");
+    }
+
+    const subgraphYamlConfig = (await parse(yamlContent)) as SubgraphYamlConfig;
 
     // Update contract addresses
     const updatedSubgraphYamlConfig: typeof subgraphYamlConfig = {


### PR DESCRIPTION
## Summary
- Enhanced error handling and logging for the "Deploy System" functionality
- Fixed subgraph.yaml restoration issue that was causing SystemFactory address to persist after deployments
- Improved debugging capabilities with detailed error context

## Changes

### Enhanced Error Handling in System Deployment
- Added `logger.error` calls before throwing exceptions in `system.create.ts` with detailed context including:
  - Transaction hashes
  - Contract addresses
  - Operation names
  - Error stack traces
- Wrapped GraphQL requests in try-catch blocks to capture and log request failures
- Added info logging for successful operations to aid in debugging

### Improved Error Display in UI
- Extended error toast notification duration to 10 seconds to allow users time to read detailed errors
- Added console logging of full error details including causes and stack traces
- Added prompts in toast notifications to check browser console for debugging details
- Enhanced `use-streaming-mutation.ts` to extract and display error causes

### Fixed Subgraph Cleanup
- Modified `graph-deploy.ts` to store and restore the original `subgraph.yaml` content
- Fixed cleanup function to restore both `subgraph.json` and `subgraph.yaml` files
- Reset SystemFactory address in `subgraph.yaml` to genesis address `0x5e771e1417100000000000000000000000020088`

### Enhanced Error Middleware
- Added comprehensive error logging with stack traces and error data
- Ensured error causes are properly propagated through the middleware
- **Fixed redundant error re-throwing**: Removed unnecessary ORPCError recreation when error has a cause

## Test plan
- [ ] Deploy System action shows detailed error messages when it fails
- [ ] Error details appear in server logs with full context
- [ ] Browser console shows complete error information
- [ ] Toast notifications display for 10 seconds with error details
- [ ] Running deployment scripts properly restores subgraph.yaml to original state
- [ ] SystemFactory address remains as `0x5e771e1417100000000000000000000000020088` after builds
- [ ] Original ORPC errors are preserved without unnecessary object allocation