### PR TITLE
chore(deps): update to prettier 3.6

### DIFF
--- a/.github/actions/slack-pr-notifier/action.yml
+++ b/.github/actions/slack-pr-notifier/action.yml
@@ -113,7 +113,7 @@ runs:
           // STRICT LABEL-TO-REACTION MAPPING
           // Only show reactions that have exact corresponding labels
           const currentStatuses = [];
-          
+
           // Map each label to its reaction
           for (const label of labels) {
             if (statusReactions[label.name]) {
@@ -121,21 +121,21 @@ runs:
               console.log(`Label "${label.name}" maps to reaction "${statusReactions[label.name]}"`);
             }
           }
-          
+
           // Apply exclusive group rules
           const finalStatuses = [];
           const usedGroups = new Set();
-          
+
           // Priority order for exclusive groups
           const groupPriority = {
             'qa': ['qa:failed', 'qa:success', 'qa:running', 'qa:pending'],
             'status': ['status:merged', 'status:mergeable', 'status:approved', 'status:ready-for-review']
           };
-          
+
           // For each group, pick only the highest priority reaction
           for (const [groupName, groupReactions] of Object.entries(exclusiveGroups)) {
             const priorityOrder = groupPriority[groupName] || [];
-            
+
             // Find the highest priority label from this group
             let selectedReaction = null;
             for (const priorityLabel of priorityOrder) {
@@ -144,19 +144,19 @@ runs:
                 break;
               }
             }
-            
+
             if (selectedReaction && currentStatuses.includes(selectedReaction)) {
               finalStatuses.push(selectedReaction);
               usedGroups.add(groupName);
             }
           }
-          
+
           // If QA is running or pending, don't show status reactions
           const hasQaInProgress = labels.some(l => l.name === 'qa:running' || l.name === 'qa:pending');
-          const filteredStatuses = hasQaInProgress 
+          const filteredStatuses = hasQaInProgress
             ? finalStatuses.filter(r => exclusiveGroups.qa.includes(r))
             : finalStatuses;
-          
+
           console.log('All label names:', labels.map(l => l.name));
           console.log('Final reactions (strict sync with labels):', filteredStatuses);
 
@@ -168,7 +168,7 @@ runs:
           });
 
           console.log(`Found ${comments.length} comments on PR`);
-          
+
           // Check for a creation lock first
           const lockComment = comments.find(c => c.body && c.body.includes('<!-- slack-creating-lock -->'));
           if (lockComment) {
@@ -178,14 +178,14 @@ runs:
               console.log(`Found recent creation lock (${lockAge}ms old), waiting for other process to complete...`);
               // Wait and retry to find the created message
               await new Promise(resolve => setTimeout(resolve, 5000));
-              
+
               // Re-fetch comments
               const { data: newComments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr_number
               });
-              
+
               const slackComment = newComments.find(c => c.body && c.body.includes('<!-- slack-ts:'));
               if (slackComment) {
                 const match = slackComment.body.match(/<!-- slack-ts:([0-9.]+) -->/);
@@ -208,7 +208,7 @@ runs:
               }
             }
           }
-          
+
           // Look for existing Slack message
           const slackComment = comments.find(c => c.body && c.body.includes('<!-- slack-ts:'));
           let slackTs = null;
@@ -236,17 +236,30 @@ runs:
 
             const data = await response.json();
             if (!data.ok) {
+              console.error(`Slack API error details:`, JSON.stringify(data, null, 2));
               throw new Error(`Slack API error: ${data.error}`);
             }
             return data;
           }
 
+          // Helper function to escape text for Slack
+          function escapeSlackText(text) {
+            // Slack requires escaping &, <, and > in plain text
+            return text
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
+          }
+
           // Check if PR is merged or abandoned
           const isMerged = labels.some(l => l.name === 'status:merged');
           const isAbandoned = '${{ inputs.is_abandoned }}' === 'true';
-          
+
+          // Escape the PR title for use in Slack messages
+          const escapedTitle = escapeSlackText(pr_title);
+
           let messageBlocks;
-          
+
           if (isMerged) {
             // Simplified message for merged PRs
             messageBlocks = [
@@ -254,7 +267,7 @@ runs:
                 type: 'section',
                 text: {
                   type: 'mrkdwn',
-                  text: `:tada: ${pr_title}`
+                  text: `:tada: ${escapedTitle}`
                 },
                 accessory: {
                   type: 'button',
@@ -275,7 +288,7 @@ runs:
                 type: 'section',
                 text: {
                   type: 'mrkdwn',
-                  text: `:file_folder: ${pr_title}`
+                  text: `:file_folder: ${escapedTitle}`
                 },
                 accessory: {
                   type: 'button',
@@ -295,14 +308,16 @@ runs:
             const qaRunning = labels.some(l => l.name === 'qa:running');
             const cacheKey = qaRunning ? `qa-${Date.now()}` : Date.now();
             const ogImageUrl = `https://opengraph.githubassets.com/${cacheKey}/${context.repo.owner}/${context.repo.repo}/pull/${pr_number}`;
-            
+
             console.log(`Using OG image URL with cache key: ${cacheKey}`);
-            
+
             messageBlocks = [
               {
-                type: 'image',
-                image_url: ogImageUrl,
-                alt_text: `PR #${pr_number}: ${pr_title}`
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: `*<${pr_url}|#${pr_number}: ${escapedTitle}>*\n_by ${pr_author}_`
+                }
               },
               {
                 type: 'actions',
@@ -351,7 +366,7 @@ runs:
                       text: 'Review',
                       emoji: false
                     },
-                    url: `${pr_url}#pullrequestreview-new_comment_form`
+                    url: `${pr_url}/files?w=1#review-changes-modal`
                   }
                 ]
               }
@@ -375,11 +390,11 @@ runs:
                 repo: context.repo.repo,
                 issue_number: pr_number
               });
-              
-              const existingSlackComment = checkComments.find(c => 
+
+              const existingSlackComment = checkComments.find(c =>
                 c.body && c.body.includes('<!-- slack-ts:') && c.id !== lockComment.id
               );
-              
+
               if (existingSlackComment) {
                 console.log('Another process created a Slack message while we were locking, using that instead');
                 // Delete our lock
@@ -388,7 +403,7 @@ runs:
                   repo: context.repo.repo,
                   comment_id: lockComment.id
                 });
-                
+
                 const match = existingSlackComment.body.match(/<!-- slack-ts:([0-9.]+) -->/);
                 if (match) {
                   slackTs = match[1];
@@ -397,14 +412,14 @@ runs:
                 // Send new message
                 const result = await slackAPI('chat.postMessage', {
                   channel: process.env.SLACK_CHANNEL_ID,
-                  text: `#${pr_number}: ${pr_title}`,
+                  text: `#${pr_number}: ${escapedTitle}`,
                   blocks: messageBlocks
                 });
 
                 // Store timestamp
                 if (result.ts) {
                 console.log(`Storing Slack timestamp ${result.ts} as PR comment`);
-                
+
                 // Get Slack workspace info for the permalink
                 let permalink = '';
                 try {
@@ -415,7 +430,7 @@ runs:
                 } catch (e) {
                   console.log('Could not generate Slack permalink:', e.message);
                 }
-                
+
                 const commentBody = [
                   `<!-- slack-ts:${result.ts} -->`,
                   `This pull request is being tracked in Slack.`,
@@ -431,14 +446,14 @@ runs:
                   ``,
                   `</details>`
                 ].join('\n');
-                
+
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr_number,
                   body: commentBody
                 });
-                
+
                 // Delete the lock comment
                 try {
                   await github.rest.issues.deleteComment({
@@ -450,7 +465,7 @@ runs:
                 } catch (e) {
                   console.log('Could not delete lock comment:', e.message);
                 }
-                
+
                 slackTs = result.ts;
                 console.log('Successfully stored Slack timestamp');
               }
@@ -461,7 +476,7 @@ runs:
               await slackAPI('chat.update', {
                 channel: process.env.SLACK_CHANNEL_ID,
                 ts: slackTs,
-                text: `#${pr_number}: ${pr_title}`,
+                text: `#${pr_number}: ${escapedTitle}`,
                 blocks: messageBlocks
               });
             }
@@ -497,12 +512,12 @@ runs:
 
               // STRICT SYNC: Only show reactions that have corresponding labels
               // This ensures 100% sync between labels and reactions
-              
+
               let reactionsToRemove, reactionsToAdd;
-              
+
               if (isMerged) {
                 // For merged PRs, remove ALL managed reactions
-                reactionsToRemove = existingReactions.filter(reaction => 
+                reactionsToRemove = existingReactions.filter(reaction =>
                   allStatusReactions.includes(reaction)
                 );
                 reactionsToAdd = [];
@@ -514,18 +529,18 @@ runs:
                   if (!allStatusReactions.includes(reaction)) {
                     return false; // Don't remove reactions we don't manage
                   }
-                  
+
                   // Check if this reaction has a corresponding current label
                   return !filteredStatuses.includes(reaction);
                 });
-                
+
                 // Step 2: Determine what reactions need to be added
                 // Only add reactions that correspond to current labels and aren't already present
-                reactionsToAdd = filteredStatuses.filter(reaction => 
+                reactionsToAdd = filteredStatuses.filter(reaction =>
                   !existingReactions.includes(reaction)
                 );
               }
-              
+
               console.log('Current label-based reactions:', filteredStatuses);
               console.log('Existing reactions:', existingReactions);
               console.log('Reactions to remove (not in labels):', reactionsToRemove);

--- a/.github/actions/slack-pr-notifier/action.yml
+++ b/.github/actions/slack-pr-notifier/action.yml
@@ -313,11 +313,9 @@ runs:
 
             messageBlocks = [
               {
-                type: 'section',
-                text: {
-                  type: 'mrkdwn',
-                  text: `*<${pr_url}|#${pr_number}: ${escapedTitle}>*\n_by ${pr_author}_`
-                }
+                type: 'image',
+                image_url: ogImageUrl,
+                alt_text: `PR #${pr_number}: ${escapedTitle}`
               },
               {
                 type: 'actions',
@@ -410,11 +408,38 @@ runs:
                 }
               } else {
                 // Send new message
-                const result = await slackAPI('chat.postMessage', {
-                  channel: process.env.SLACK_CHANNEL_ID,
-                  text: `#${pr_number}: ${escapedTitle}`,
-                  blocks: messageBlocks
-                });
+                let result;
+                try {
+                  // First try with the image block
+                  result = await slackAPI('chat.postMessage', {
+                    channel: process.env.SLACK_CHANNEL_ID,
+                    text: `#${pr_number}: ${escapedTitle}`,
+                    blocks: messageBlocks
+                  });
+                } catch (e) {
+                  if (e.message.includes('invalid_blocks')) {
+                    console.log('Image block failed, trying with fallback text format...');
+                    // Fallback: Create text-only blocks without the image
+                    const fallbackBlocks = messageBlocks.filter(block => block.type !== 'image');
+
+                    // Add a section block with PR info if we removed the image
+                    fallbackBlocks.unshift({
+                      type: 'section',
+                      text: {
+                        type: 'mrkdwn',
+                        text: `*<${pr_url}|#${pr_number}: ${escapedTitle}>*\n_by ${pr_author}_`
+                      }
+                    });
+
+                    result = await slackAPI('chat.postMessage', {
+                      channel: process.env.SLACK_CHANNEL_ID,
+                      text: `#${pr_number}: ${escapedTitle}`,
+                      blocks: fallbackBlocks
+                    });
+                  } else {
+                    throw e;
+                  }
+                }
 
                 // Store timestamp
                 if (result.ts) {
@@ -473,12 +498,41 @@ runs:
             } else {
               // Always update the message to ensure latest title and content
               console.log('Updating Slack message with latest content');
-              await slackAPI('chat.update', {
-                channel: process.env.SLACK_CHANNEL_ID,
-                ts: slackTs,
-                text: `#${pr_number}: ${escapedTitle}`,
-                blocks: messageBlocks
-              });
+              try {
+                // First try with the image block
+                await slackAPI('chat.update', {
+                  channel: process.env.SLACK_CHANNEL_ID,
+                  ts: slackTs,
+                  text: `#${pr_number}: ${escapedTitle}`,
+                  blocks: messageBlocks
+                });
+              } catch (e) {
+                if (e.message.includes('invalid_blocks')) {
+                  console.log('Image block failed on update, trying with fallback text format...');
+                  // Fallback: Create text-only blocks without the image
+                  const fallbackBlocks = messageBlocks.filter(block => block.type !== 'image');
+
+                  // Add a section block with PR info if we removed the image
+                  if (!isMerged && !isAbandoned) {
+                    fallbackBlocks.unshift({
+                      type: 'section',
+                      text: {
+                        type: 'mrkdwn',
+                        text: `*<${pr_url}|#${pr_number}: ${escapedTitle}>*\n_by ${pr_author}_`
+                      }
+                    });
+                  }
+
+                  await slackAPI('chat.update', {
+                    channel: process.env.SLACK_CHANNEL_ID,
+                    ts: slackTs,
+                    text: `#${pr_number}: ${escapedTitle}`,
+                    blocks: fallbackBlocks
+                  });
+                } else {
+                  throw e;
+                }
+              }
             }
 
             if (slackTs) {

--- a/.prettierrc
+++ b/.prettierrc
@@ -11,5 +11,6 @@
         "parser": "markdown"
       }
     }
-  ]
+  ],
+  "plugins": ["@prettier/plugin-oxc"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,9 @@
     "": {
       "name": "@settlemint/asset-tokenization-kit",
       "devDependencies": {
+        "@prettier/plugin-oxc": "0.0.2",
         "@settlemint/sdk-cli": "2.4.0",
-        "prettier": "3.5.3",
+        "prettier": "3.6.0",
         "turbo": "2.5.4",
         "typescript": "5.8.3",
       },
@@ -168,7 +169,7 @@
     "adm-zip": "0.5.16",
     "elliptic": "6.6.1",
     "graphql": "16.11.0",
-    "prettier": "3.5.3",
+    "prettier": "3.6.0",
     "react-is": "19.1.0",
     "undici": "7.10.0",
     "ws": "8.18.2",
@@ -308,6 +309,12 @@
     "@ecies/ciphers": ["@ecies/ciphers@0.2.3", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-tapn6XhOueMwht3E2UzY0ZZjYokdaw9XtL9kEyjhQ/Fb9vL9xTFbOaI+fV0AWvTpYu4BNloC6getKW6NtSg4mA=="],
 
     "@electric-sql/client": ["@electric-sql/client@1.0.0-beta.1", "", { "optionalDependencies": { "@rollup/rollup-darwin-arm64": "^4.18.1" } }, "sha512-Ei9jN3pDoGzc+a/bGqnB5ajb52IvSv7/n2btuyzUlcOHIR2kM9fqtYTJXPwZYKLkGZlHWlpHgWyRtrinkP2nHg=="],
+
+    "@emnapi/core": ["@emnapi/core@1.4.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.2", "tslib": "^2.4.0" } }, "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.4.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.0.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -587,6 +594,8 @@
 
     "@multiformats/multiaddr-to-uri": ["@multiformats/multiaddr-to-uri@11.0.0", "", { "dependencies": { "@multiformats/multiaddr": "^12.3.0" } }, "sha512-9RNmlIGwZbBLsHekT50dbt4o4u8Iciw9kGjv+WHiGxQdsJ6xKKjU1+C0Vbas6RilMbaVOAOnEyfNcXbUmTkLxQ=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.11", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.9.0" } }, "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA=="],
+
     "@netlify/binary-info": ["@netlify/binary-info@1.0.0", "", {}, "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw=="],
 
     "@netlify/blobs": ["@netlify/blobs@9.1.2", "", { "dependencies": { "@netlify/dev-utils": "2.2.0", "@netlify/runtime-utils": "1.3.1" } }, "sha512-7dMjExSH4zj4ShvLem49mE3mf0K171Tx2pV4WDWhJbRUWW3SJIR2qntz0LvUGS97N5HO1SmnzrgWUhEXCsApiw=="],
@@ -763,6 +772,38 @@
 
     "@orpc/zod": ["@orpc/zod@1.5.2", "", { "dependencies": { "@orpc/openapi": "1.5.2", "@orpc/shared": "1.5.2", "escape-string-regexp": "^5.0.0", "wildcard-match": "^5.1.3" }, "peerDependencies": { "@orpc/contract": "1.5.2", "@orpc/server": "1.5.2", "zod": ">=3.24.2" } }, "sha512-4yrpMChqcWb1xqBRetGzUeo2mOOW3mTWIS32dxmIoCF9rm+aYzMhGz8gjIpt3LAUnu2wv6DISJ5ZqQax0ZbYEg=="],
 
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.73.2", "", { "os": "android", "cpu": "arm64" }, "sha512-YkO/7t7yshWtHCWxd5oADgXBU8Dput6UFtPULSUXgwEbim8dZvMDc7T8vCcEmtOEHOJBcJRHuK1fuKXJnwU5Aw=="],
+
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.73.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-z5E/dcecYUvh3o6pHz8qGGnqY6ICTk0GL1vvDI40cKOig70QTGOM837z/+m2tyjjkny06QlxJKQql97LV+dJIg=="],
+
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.73.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-uzmLaxRyiNW/YFRI/NIkVxktP4fqvdwPvwICVDHceXj9MiRYQKvQLD/amZY3FjYcUxuZyWd88MnNfGaO4fPufw=="],
+
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.73.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-8i5qqv38UKo+2uloxC2SAsTrNdsoJitiUEXCm2Bu/4N/ZmIe+uM4DBTJgT9pR3eWTCszqCeipQ4LkB6CONtp7w=="],
+
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.73.2", "", { "os": "linux", "cpu": "arm" }, "sha512-Vrd+B+BMu9JsdG/+BNXCK5OVuSQbowxym0wz60jSeNIFFEQcZmo35B+OKDEhVrNlWH6GijodbBopq5cKv6n9og=="],
+
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.73.2", "", { "os": "linux", "cpu": "arm" }, "sha512-eMQKxZTqO0udYOqHCM33cZg8wlg8pgD8CTJL4udwGkRJGKuTy6rIAgnQ4xJxHBbjcrVOBMW8MZKJopyKKIUdgg=="],
+
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.73.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-OPFujKAe8Gl59WHp7FVFgOkAe6mC9v1Xd7c8cwH+aJr/Bur5wDeNm3bjmZ4Z9bmUZGPe4tLBYtVcSFuTK2C04g=="],
+
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.73.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-5iR58UQEy7t71T8jxU1Ss9DLZQ6me/0TIumOAAO+8w48Zj3DfUfqC5FyXNELUGEATsRUsrR/+4YKpy2fppdxHQ=="],
+
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.73.2", "", { "os": "linux", "cpu": "none" }, "sha512-k4jBa99BM2NHoQnSVZwF+MwDzH1TXU97MWtpq7RMg7IhLtnZYxlsHWxctAbmij5C41gn7eCGtCv/8shCoYbslg=="],
+
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.73.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-gx7wQMmAP5YbWlv4qPnzgnyJ+kQkZ8OlP0mRZ9rOvMDMu0BOP42Q0iOGxqEbStW47aSCw4JVNgNk9oPKdEABmg=="],
+
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.73.2", "", { "os": "linux", "cpu": "x64" }, "sha512-hmREwjiRQOnOsMzq325I1901pnStfVZh3O8vAqPetMzPlOM+RA3BofipoBERblYFYwWDmixb4yUOv/FaxFjhlQ=="],
+
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.73.2", "", { "os": "linux", "cpu": "x64" }, "sha512-jMbryKAJiXXA0OKLZpYRp7fcUyLzK1sBgJCHinVWM0JvGrM7D4V75HpGtOJUqZNUr6Y9rs14FgdKD4O0adZ9iA=="],
+
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.73.2", "", { "dependencies": { "@napi-rs/wasm-runtime": "^0.2.11" }, "cpu": "none" }, "sha512-6sb52wCUT/gfh9UWyWbJ1dS5GKu4ATTcdgdKl+osUTHv7Xgv+ZPkw1VPXvNLCVgR22XKXWzPnNvyuFPMwAh3Wg=="],
+
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.73.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-d0ldjCMMCDpp9q2wKyQieajR4rENjfZsr+8xoWImU+tRBLVVBACW9N3c+xtXm/XO1bn05fPk5/USBCLJs1V8eg=="],
+
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.73.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7vOE4af8hSvgo0OOls8Qv3nqPhREbi3t/6GF3PiMK3m1CWWoLWtffJ9epKAtxmBJAfx23x9y5LzYu9xnVv+0Rw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.73.2", "", {}, "sha512-kU2FjfCb9VTNg/KbOTKVi2sYrKTkNQYq1Fi1v1jCKjbUGA9wqkNDqijNBLeDwagFtDuK2EIWvTzNDYU4k/918g=="],
+
     "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
 
     "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.1", "", { "os": "android", "cpu": "arm64" }, "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA=="],
@@ -820,6 +861,8 @@
     "@poppinss/dumper": ["@poppinss/dumper@0.6.3", "", { "dependencies": { "@poppinss/colors": "^4.1.4", "@sindresorhus/is": "^7.0.1", "supports-color": "^10.0.0" } }, "sha512-iombbn8ckOixMtuV1p3f8jN6vqhXefNjJttoPaJDMeIk/yIGhkkL3OrHkEjE9SRsgoAx1vBUU2GtgggjvA5hCA=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.1", "", {}, "sha512-aQypoot0HPSJa6gDPEPTntc1GT6QINrSbgRlRhadGW2WaYqUK3tK4Bw9SBMZXhmxd3GeAlZjVcODHgiu+THY7A=="],
+
+    "@prettier/plugin-oxc": ["@prettier/plugin-oxc@0.0.2", "", { "dependencies": { "oxc-parser": "0.73.2" } }, "sha512-Ibg1Kvg5mMn1PUUFrEovs9LFUMRZSKPMPGcHQYKIDhVnHe+MSc0bYJxGai/7Ck8t6qyp515AO11Jmp+ynV6F4w=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -961,7 +1004,7 @@
 
     "@rescript/std": ["@rescript/std@9.0.0", "", {}, "sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.11", "", {}, "sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.19", "", {}, "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA=="],
 
     "@rollup/plugin-alias": ["@rollup/plugin-alias@5.1.1", "", { "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ=="],
 
@@ -1203,6 +1246,8 @@
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
+
     "@types/babel__code-frame": ["@types/babel__code-frame@7.0.6", "", {}, "sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -1297,7 +1342,7 @@
 
     "@vercel/nft": ["@vercel/nft@0.29.4", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^10.4.5", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.5.2", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.11", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-QNVT3/Lxx99nMQWJWF7K4N6apUEuT0KlZA3mx/mVaoGj3smm/8rc8ezz15J1pcbcjDK0V15rpHetVfya08r76Q=="],
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.6.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.19", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.17", "", { "dependencies": { "@babel/parser": "^7.27.5", "@vue/shared": "3.5.17", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA=="],
 
@@ -2789,6 +2834,8 @@
 
     "ox": ["ox@0.8.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A=="],
 
+    "oxc-parser": ["oxc-parser@0.73.2", "", { "dependencies": { "@oxc-project/types": "^0.73.2" }, "optionalDependencies": { "@oxc-parser/binding-android-arm64": "0.73.2", "@oxc-parser/binding-darwin-arm64": "0.73.2", "@oxc-parser/binding-darwin-x64": "0.73.2", "@oxc-parser/binding-freebsd-x64": "0.73.2", "@oxc-parser/binding-linux-arm-gnueabihf": "0.73.2", "@oxc-parser/binding-linux-arm-musleabihf": "0.73.2", "@oxc-parser/binding-linux-arm64-gnu": "0.73.2", "@oxc-parser/binding-linux-arm64-musl": "0.73.2", "@oxc-parser/binding-linux-riscv64-gnu": "0.73.2", "@oxc-parser/binding-linux-s390x-gnu": "0.73.2", "@oxc-parser/binding-linux-x64-gnu": "0.73.2", "@oxc-parser/binding-linux-x64-musl": "0.73.2", "@oxc-parser/binding-wasm32-wasi": "0.73.2", "@oxc-parser/binding-win32-arm64-msvc": "0.73.2", "@oxc-parser/binding-win32-x64-msvc": "0.73.2" } }, "sha512-Gu4S3s2GChWsT5FgmjfdRZirR5c+ixxvm/ZH11XlV+2009kHHoYkyK1Ab9DkEoI6mL630NEyBjI28I0DscJrWQ=="],
+
     "p-cancelable": ["p-cancelable@3.0.0", "", {}, "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="],
 
     "p-defer": ["p-defer@3.0.0", "", {}, "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="],
@@ -2921,7 +2968,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
+    "prettier": ["prettier@3.6.0", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
@@ -3081,7 +3128,7 @@
 
     "rimraf": ["rimraf@2.7.1", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="],
 
-    "ripemd160": ["ripemd160@2.0.2", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1" } }, "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA=="],
+    "ripemd160": ["ripemd160@2.0.1", "", { "dependencies": { "hash-base": "^2.0.0", "inherits": "^2.0.1" } }, "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w=="],
 
     "rlp": ["rlp@2.2.7", "", { "dependencies": { "bn.js": "^5.2.0" }, "bin": { "rlp": "bin/rlp" } }, "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ=="],
 
@@ -4091,8 +4138,6 @@
 
     "pbkdf2/create-hash": ["create-hash@1.1.3", "", { "dependencies": { "cipher-base": "^1.0.1", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "sha.js": "^2.4.0" } }, "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA=="],
 
-    "pbkdf2/ripemd160": ["ripemd160@2.0.1", "", { "dependencies": { "hash-base": "^2.0.0", "inherits": "^2.0.1" } }, "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w=="],
-
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -4126,6 +4171,8 @@
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "ripemd160/hash-base": ["hash-base@2.0.2", "", { "dependencies": { "inherits": "^2.0.1" } }, "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw=="],
 
     "rollup-plugin-visualizer/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
@@ -4492,10 +4539,6 @@
     "ora/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
-
-    "pbkdf2/create-hash/ripemd160": ["ripemd160@2.0.2", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1" } }, "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA=="],
-
-    "pbkdf2/ripemd160/hash-base": ["hash-base@2.0.2", "", { "dependencies": { "inherits": "^2.0.1" } }, "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw=="],
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/kit/contracts/package.json
+++ b/kit/contracts/package.json
@@ -13,7 +13,7 @@
     "artifacts:abi": "bun run tools/artifacts-abi.ts",
     "lint": "solhint --config .solhint.json ./contracts/**/*.sol",
     "format:forge": "settlemint scs foundry format",
-    "format:prettier": "prettier -l --write .",
+    "format:prettier": "prettier --experimental-cli --write .",
     "clean:deployments": "rm -Rf ignition/deployments/atk-local",
     "publish": "bun run clean:deployments && settlemint scs hardhat script local --script scripts/hardhat/main.ts",
     "abi-output": "bash tools/abi-output.sh",

--- a/kit/dapp-v1/package-backup.json
+++ b/kit/dapp-v1/package-backup.json
@@ -13,7 +13,7 @@
     "xwatch": "tsc --noEmit --watch",
     "xcodegen:settlemint": "settlemint codegen",
     "xcodegen:gql-tada": "gql-tada turbo",
-    "xformat": "prettier -l --write .",
+    "xformat": "prettier --experimental-cli --write .",
     "xlint": "next lint",
     "xbuild": "next build --turbopack",
     "xdev": "next dev --turbopack",
@@ -134,9 +134,7 @@
   "peerDependencies": {
     "contracts": "workspace:*"
   },
-  "trustedDependencies": [
-    "sharp"
-  ],
+  "trustedDependencies": ["sharp"],
   "overrides": {
     "react-is": "19.1.0",
     "@sinclair/typebox": "0.34.33"

--- a/kit/dapp-v1/package.json
+++ b/kit/dapp-v1/package.json
@@ -8,7 +8,7 @@
     "xwatch": "tsc --noEmit --watch",
     "xcodegen:settlemint": "settlemint codegen",
     "xcodegen:gql-tada": "gql-tada turbo",
-    "xformat": "prettier -l --write .",
+    "xformat": "prettier --experimental-cli --write .",
     "xlint": "next lint",
     "xbuild": "next build --turbopack",
     "xdev": "next dev --turbopack",

--- a/kit/dapp/package.json
+++ b/kit/dapp/package.json
@@ -14,7 +14,7 @@
     "shadcn": "bunx --bun shadcn@canary",
     "codegen:settlemint": "settlemint codegen",
     "codegen:gql-tada": "gql-tada turbo",
-    "format": "prettier -l --write .",
+    "format": "prettier --experimental-cli --write .",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "publish": "DOCKER_BUILD_TAG=$(jq -r .version ../../package.json); if [ -z \"$CI\" ]; then DOCKER_BUILD_TAG=\"$DOCKER_BUILD_TAG-dev.$(date +%s)\"; fi; docker buildx build . --platform=linux/amd64,linux/arm64 --provenance true --sbom true -t ghcr.io/settlemint/asset-tokenization-kit:$DOCKER_BUILD_TAG --push",

--- a/kit/dapp/src/hooks/use-streaming-mutation.ts
+++ b/kit/dapp/src/hooks/use-streaming-mutation.ts
@@ -17,7 +17,7 @@ import { formatValidationError } from "@/lib/utils/format-validation-error";
 /**
  * Extract the result type from an async iterator of events
  * Handles AsyncIteratorObject (used by ORPC), AsyncGenerator and AsyncIterable types
- * 
+ *
  * TypeScript improvements in this PR:
  * - Added support for AsyncIteratorObject type which ORPC uses
  * - Uses conditional types with infer to extract nested result types
@@ -34,7 +34,7 @@ type ExtractResultType<T> =
 
 /**
  * Streaming mutation options that transform callbacks to work with extracted result
- * 
+ *
  * TypeScript enhancements:
  * - The onSuccess callback receives the extracted result type, not the raw iterator
  * - This provides better developer experience with proper type hints

--- a/kit/dapp/src/orpc/context/context.ts
+++ b/kit/dapp/src/orpc/context/context.ts
@@ -66,7 +66,7 @@ export interface Context {
 
   /**
    * The Graph client instance for querying blockchain data.
-   * 
+   *
    * This is a validated wrapper around the base The Graph client that enforces
    * runtime type safety through Zod schema validation. The ValidatedTheGraphClient
    * type ensures that:
@@ -74,9 +74,9 @@ export interface Context {
    * - Type inference works seamlessly from schema to result type
    * - Runtime errors are caught early with descriptive validation messages
    * - The client maintains full compatibility with the underlying GraphQL operations
-   * 
+   *
    * Injected by theGraphMiddleware when a procedure requires blockchain data access.
-   * 
+   *
    * @optional - Only available in procedures that use theGraphMiddleware
    * @see {@link @/orpc/middlewares/services/the-graph.middleware} - The Graph middleware implementation
    * @see {@link ValidatedTheGraphClient} - Type definition with validation methods
@@ -85,21 +85,21 @@ export interface Context {
 
   /**
    * Portal client instance for interacting with the SettleMint Portal API.
-   * 
+   *
    * This validated client wrapper enhances the base Portal client with automatic
    * validation and type safety features. The ValidatedPortalClient type provides:
    * - Automatic transaction hash extraction and validation for mutations
    * - Required Zod schema validation for all query operations
    * - Type-safe error handling with descriptive validation messages
    * - Seamless integration with the Portal GraphQL schema
-   * 
+   *
    * The validation layer ensures that:
    * - Mutation results containing transaction hashes are properly typed
    * - Query results match expected schemas at runtime
    * - Invalid API responses are caught before they can cause downstream errors
-   * 
+   *
    * Injected by portalMiddleware when a procedure needs Portal API access.
-   * 
+   *
    * @optional - Only available in procedures that use portalMiddleware
    * @see {@link @/orpc/middlewares/services/portal.middleware} - Portal middleware implementation
    * @see {@link ValidatedPortalClient} - Type definition with validation methods

--- a/kit/dapp/src/orpc/middlewares/services/portal.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/services/portal.middleware.ts
@@ -16,7 +16,7 @@ const logger = createLogger({
 
 /**
  * Represents an event emitted during transaction processing.
- * 
+ *
  * @interface TransactionEvent
  * @property {("pending" | "confirmed" | "failed")} status - Current status of the transaction
  *   - `pending`: Transaction is submitted but not yet confirmed
@@ -33,30 +33,30 @@ interface TransactionEvent {
 
 /**
  * Creates a validated Portal client with built-in error handling and validation.
- * 
+ *
  * This function returns a client that wraps Portal GraphQL operations with:
  * - Automatic transaction hash extraction and validation for mutations
  * - Real-time transaction tracking with event streaming
  * - Zod schema validation for queries
  * - Consistent error handling and logging
  * - Integration with TheGraph for indexing status monitoring
- * 
+ *
  * @param {Object} errors - ORPC error constructors for consistent error handling
  * @param {ValidatedTheGraphClient} [theGraphClient] - Optional TheGraph client for indexing monitoring.
  *   If provided, mutations will track both blockchain confirmation and indexing status.
  *   If omitted, mutations will only track blockchain confirmation.
- * 
+ *
  * @returns {Object} A validated Portal client with `mutate` and `query` methods
- * 
+ *
  * @example
  * ```typescript
  * const client = createValidatedPortalClient(errors, theGraphClient);
- * 
+ *
  * // For mutations with transaction tracking
  * for await (const event of client.mutate(CREATE_TOKEN_MUTATION, variables, "Failed to create token")) {
  *   console.log(event.status, event.message);
  * }
- * 
+ *
  * // For queries with validation
  * const data = await client.query(GET_TOKEN_QUERY, variables, TokenSchema, "Token not found");
  * ```
@@ -68,15 +68,15 @@ function createValidatedPortalClient(
   const client = {
     /**
      * Executes a GraphQL mutation and tracks the resulting transaction through its lifecycle.
-     * 
+     *
      * This method uses an AsyncGenerator pattern to stream real-time transaction status updates.
      * It automatically extracts the transaction hash from the mutation response and monitors
      * the transaction through three phases:
-     * 
+     *
      * 1. **Submission Phase**: Mutation is sent to Portal and transaction hash is extracted
      * 2. **Mining Phase**: Transaction is monitored until mined and confirmed on-chain
      * 3. **Indexing Phase**: (Optional) Transaction is monitored until indexed by TheGraph
-     * 
+     *
      * @param {TadaDocumentNode} document - The GraphQL mutation document
      * @param {TVariables} variables - Variables for the GraphQL mutation
      * @param {string} userMessage - User-friendly error message to show if operation fails
@@ -88,13 +88,13 @@ function createValidatedPortalClient(
      * @param {string} [trackingMessages.waitingForIndexing] - Message while waiting for indexing
      * @param {string} [trackingMessages.transactionIndexed] - Message when indexing completes
      * @param {string} [trackingMessages.indexingTimeout] - Message when indexing times out
-     * 
+     *
      * @yields {TransactionEvent} Real-time transaction status updates
      * @returns {string} The transaction hash once tracking is complete
-     * 
+     *
      * @throws {PORTAL_ERROR} When Portal GraphQL operation fails
      * @throws {INTERNAL_SERVER_ERROR} When transaction fails, times out, or has invalid format
-     * 
+     *
      * @example
      * ```typescript
      * // Basic usage with default messages
@@ -106,7 +106,7 @@ function createValidatedPortalClient(
      *   // pending: Transaction confirmed. Waiting for indexing... (0x123...)
      *   // confirmed: Transaction successfully indexed. (0x123...)
      * }
-     * 
+     *
      * // Custom tracking messages
      * for await (const event of client.mutate(
      *   TRANSFER_MUTATION,
@@ -119,7 +119,7 @@ function createValidatedPortalClient(
      * )) {
      *   updateUI(event);
      * }
-     * 
+     *
      * // Error handling
      * try {
      *   for await (const event of client.mutate(RISKY_MUTATION, vars, "Operation failed")) {
@@ -475,22 +475,22 @@ function createValidatedPortalClient(
 
     /**
      * Executes a GraphQL query with automatic response validation.
-     * 
+     *
      * This method performs a GraphQL query operation and validates the response
      * against a provided Zod schema. This ensures type safety at runtime and
      * helps catch API response format changes early.
-     * 
+     *
      * @param {TadaDocumentNode} document - The GraphQL query document
      * @param {TVariables} variables - Variables for the GraphQL query
      * @param {z.ZodType} schema - Zod schema to validate the response against
      * @param {string} userMessage - User-friendly error message to show if operation fails
-     * 
+     *
      * @returns {Promise<TValidated>} The validated query response data
-     * 
+     *
      * @throws {PORTAL_ERROR} When the Portal service encounters an error
      * @throws {NOT_FOUND} When the requested resource is not found
      * @throws {INTERNAL_SERVER_ERROR} When the query fails or response validation fails
-     * 
+     *
      * @example
      * ```typescript
      * // Define the expected response schema
@@ -503,7 +503,7 @@ function createValidatedPortalClient(
      *     decimals: z.number()
      *   })
      * });
-     * 
+     *
      * // Execute query with validation
      * const tokenData = await client.query(
      *   GET_TOKEN_QUERY,
@@ -511,10 +511,10 @@ function createValidatedPortalClient(
      *   TokenSchema,
      *   "Failed to fetch token details"
      * );
-     * 
+     *
      * // TypeScript knows tokenData matches TokenSchema
      * console.log(tokenData.getToken.name); // Type-safe access
-     * 
+     *
      * // Complex nested schema example
      * const TransferHistorySchema = z.object({
      *   getTransfers: z.array(z.object({
@@ -529,7 +529,7 @@ function createValidatedPortalClient(
      *     })
      *   }))
      * });
-     * 
+     *
      * const transfers = await client.query(
      *   GET_TRANSFER_HISTORY_QUERY,
      *   { address: userAddress, limit: 10 },
@@ -621,25 +621,25 @@ function createValidatedPortalClient(
 
 /**
  * Recursively searches for a transactionHash field in a GraphQL response.
- * 
+ *
  * This helper function performs a depth-first search through an object structure
  * to locate a `transactionHash` field. This is necessary because different GraphQL
  * mutations may return the transaction hash at different nesting levels in the response.
- * 
+ *
  * @param {unknown} obj - The object to search through (typically a GraphQL response)
  * @param {string} [path=""] - The current path in the object tree (used for recursion and error reporting)
- * 
+ *
  * @returns {{ value: unknown; path: string } | null} An object containing the found value and its path,
  *   or null if no transactionHash field is found
- * 
+ *
  * @example
  * ```typescript
  * // Example mutation response structures this function handles:
- * 
+ *
  * // Direct response
  * const response1 = { transactionHash: "0x123..." };
  * findTransactionHash(response1); // { value: "0x123...", path: "transactionHash" }
- * 
+ *
  * // Nested in mutation result
  * const response2 = {
  *   createToken: {
@@ -648,7 +648,7 @@ function createValidatedPortalClient(
  *   }
  * };
  * findTransactionHash(response2); // { value: "0x456...", path: "createToken.transactionHash" }
- * 
+ *
  * // Deeply nested
  * const response3 = {
  *   data: {
@@ -660,7 +660,7 @@ function createValidatedPortalClient(
  *   }
  * };
  * findTransactionHash(response3); // { value: "0x789...", path: "data.result.transaction.transactionHash" }
- * 
+ *
  * // Not found
  * const response4 = { success: true, id: "123" };
  * findTransactionHash(response4); // null

--- a/kit/dapp/src/orpc/middlewares/services/the-graph.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/services/the-graph.middleware.ts
@@ -11,21 +11,21 @@ const logger = createLogger({
 
 /**
  * Creates a validated TheGraph client with built-in error handling and validation.
- * 
+ *
  * This function returns a client that wraps TheGraph GraphQL queries with:
  * - Automatic Zod schema validation for all responses
  * - Operation name extraction from GraphQL documents
  * - Comprehensive error logging and categorization
  * - User-friendly error messages
- * 
+ *
  * @param {Object} errors - ORPC error constructors for consistent error handling
- * 
+ *
  * @returns {Object} A validated TheGraph client with a `query` method
- * 
+ *
  * @example
  * ```typescript
  * const client = createValidatedTheGraphClient(errors);
- * 
+ *
  * // Query with validation
  * const data = await client.query(
  *   GET_TRANSFERS_QUERY,
@@ -41,30 +41,30 @@ function createValidatedTheGraphClient(
   return {
     /**
      * Executes a GraphQL query against TheGraph with automatic response validation.
-     * 
+     *
      * This method performs a GraphQL query operation against TheGraph's indexed blockchain data
      * and validates the response against a provided Zod schema. Unlike raw GraphQL queries,
      * this method ensures:
-     * 
+     *
      * 1. **Type Safety**: Response data is validated at runtime against the provided schema
      * 2. **Error Categorization**: Errors are automatically categorized (NOT_FOUND vs INTERNAL_SERVER_ERROR)
      * 3. **Operation Tracking**: Operation names are extracted for better logging and debugging
      * 4. **Consistent Error Messages**: User-friendly messages are shown while technical details are logged
-     * 
+     *
      * @param {TadaDocumentNode} document - The GraphQL query document with TypeScript types
      * @param {TVariables} variables - Variables for the GraphQL query
      * @param {z.ZodType} schema - Zod schema to validate the response against. This schema
      *   must match the expected response structure from TheGraph
      * @param {string} userMessage - User-friendly error message to show if the operation fails.
      *   This message is shown to end users, while technical details are logged separately
-     * 
+     *
      * @returns {Promise<TValidated>} The validated query response data matching the provided schema
-     * 
+     *
      * @throws {NOT_FOUND} When TheGraph returns a 404 error or "not found" message,
      *   typically indicating the subgraph doesn't exist or the entity wasn't found
      * @throws {INTERNAL_SERVER_ERROR} When the query fails for other reasons or when
      *   the response doesn't match the expected schema structure
-     * 
+     *
      * @example
      * ```typescript
      * // Define the expected response schema
@@ -78,11 +78,11 @@ function createValidatedTheGraphClient(
      *     transactionHash: z.string()
      *   }))
      * });
-     * 
+     *
      * // Execute query with validation
      * const transfers = await client.query(
      *   GET_TOKEN_TRANSFERS_QUERY,
-     *   { 
+     *   {
      *     tokenAddress: "0x123...",
      *     first: 100,
      *     orderBy: "timestamp",
@@ -91,12 +91,12 @@ function createValidatedTheGraphClient(
      *   TokenTransfersSchema,
      *   "Failed to fetch token transfer history"
      * );
-     * 
+     *
      * // TypeScript knows transfers matches TokenTransfersSchema
      * transfers.transfers.forEach(transfer => {
      *   console.log(`${transfer.from} → ${transfer.to}: ${transfer.value}`);
      * });
-     * 
+     *
      * // Complex aggregation query example
      * const StatsSchema = z.object({
      *   token: z.object({
@@ -110,7 +110,7 @@ function createValidatedTheGraphClient(
      *     priceUSD: z.string()
      *   }))
      * });
-     * 
+     *
      * const stats = await client.query(
      *   GET_TOKEN_ANALYTICS_QUERY,
      *   { tokenId: tokenAddress, days: 30 },
@@ -257,17 +257,17 @@ export const theGraphMiddleware = baseRouter.middleware((options) => {
 
 /**
  * Type representing a validated TheGraph client instance.
- * 
+ *
  * This type is inferred from the return type of `createValidatedTheGraphClient`
  * and provides TypeScript type information for the client's methods.
- * 
+ *
  * @example
  * ```typescript
  * // In a procedure that uses theGraphMiddleware
  * interface Context {
  *   theGraphClient: ValidatedTheGraphClient;
  * }
- * 
+ *
  * async function fetchTokenData(
  *   context: Context,
  *   tokenAddress: string

--- a/kit/dapp/src/orpc/routes/system/routes/system.create.ts
+++ b/kit/dapp/src/orpc/routes/system/routes/system.create.ts
@@ -111,7 +111,7 @@ const FIND_SYSTEM_FOR_TRANSACTION_QUERY = theGraphGraphql(`
  *   contract: "0x123..."
  * })) {
  *   console.log(`Status: ${event.status}, Message: ${event.message}`);
- *   
+ *
  *   if (event.status === "confirmed" && event.result) {
  *     console.log(`System created at: ${event.result}`);
  *   }

--- a/kit/dapp/src/orpc/routes/system/routes/system.read.ts
+++ b/kit/dapp/src/orpc/routes/system/routes/system.read.ts
@@ -123,13 +123,11 @@ export const read = onboardedRouter.system.read
       tokenFactoryRegistry: result.system.tokenFactoryRegistry
         ?.id as EthereumAddress,
       tokenFactories:
-        result.system.tokenFactoryRegistry?.tokenFactories.map(
-          (factory) => ({
-            id: factory.id as EthereumAddress,
-            name: factory.name,
-            typeId: factory.typeId,
-          })
-        ) ?? [],
+        result.system.tokenFactoryRegistry?.tokenFactories.map((factory) => ({
+          id: factory.id as EthereumAddress,
+          name: factory.name,
+          typeId: factory.typeId,
+        })) ?? [],
     };
 
     return output;

--- a/kit/dapp/src/orpc/routes/tokens/routes/factory.create.schema.ts
+++ b/kit/dapp/src/orpc/routes/tokens/routes/factory.create.schema.ts
@@ -107,7 +107,7 @@ const SingleFactorySchema = z.object({
 /**
  * Combined messages schema for factory creation
  * Extends common transaction tracking messages with factory-specific messages
- * 
+ *
  * TypeScript improvements:
  * - Each message field has proper type inference from Zod schema
  * - Optional fields with default values ensure type safety without requiring all messages
@@ -214,7 +214,7 @@ const FactoryResultSchema = z.object({
 
 /**
  * Output schema for streaming events
- * 
+ *
  * TypeScript features:
  * - Discriminated union via status enum for type-safe event handling
  * - Optional fields allow progressive enhancement of event data
@@ -244,7 +244,7 @@ export type SingleFactory = z.infer<typeof SingleFactorySchema>;
 
 /**
  * Helper function to get default implementations for a token type
- * 
+ *
  * TypeScript benefits:
  * - Const assertion on DEFAULT_IMPLEMENTATIONS ensures literal types
  * - TokenType union ensures only valid token types are accepted

--- a/kit/subgraph/package.json
+++ b/kit/subgraph/package.json
@@ -6,7 +6,7 @@
     "codegen": "settlemint scs subgraph codegen",
     "codegen:interfaceid": "bun run tools/interfaceid.ts",
     "codegen:gql-tada": "gql-tada generate-schema http://localhost:${THE_GRAPH_PORT_LOCAL_QUERY:-8000}/subgraphs/name/smart-protocol && gql-tada turbo && gql-tada generate-output",
-    "format": "prettier -l --write .",
+    "format": "prettier --experimental-cli --write .",
     "compile": "mkdir -p .generated && bunx graph build --ipfs=https://ipfs.console.settlemint.com | tee /dev/tty | grep -o 'Qm[a-zA-Z0-9]*' | tail -1 | tee .generated/subgraph-hash.txt | xargs -I {} echo 'SUBGRAPH=kit:{}' > .generated/subgraph-env",
     "publish": "bun run tools/graph-deploy.ts --local",
     "publish:remote": "bun run tools/graph-deploy.ts --remote",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,9 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@prettier/plugin-oxc": "0.0.2",
     "@settlemint/sdk-cli": "2.4.0",
-    "prettier": "3.5.3",
+    "prettier": "3.6.0",
     "turbo": "2.5.4",
     "typescript": "5.8.3"
   },
@@ -96,7 +97,7 @@
     "ws": "8.18.2",
     "adm-zip": "0.5.16",
     "undici": "7.10.0",
-    "prettier": "3.5.3",
+    "prettier": "3.6.0",
     "zod": "3.25.67",
     "@tanstack/query-broadcast-client-experimental": "5.81.2",
     "@tanstack/query-sync-storage-persister": "5.81.2",


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Prettier to v3.6 across the monorepo and update formatting scripts to use the new CLI flags, then reformat code to comply with the updated style guidelines.

Enhancements:
- Apply Prettier 3.6 formatting across the codebase (trim trailing spaces in JSDoc and reformat files)

Build:
- Bump Prettier to 3.6.0 in multiple package.json files and add @prettier/plugin-oxc

Chores:
- Update format scripts in contracts, dapp, dapp-v1, and subgraph to invoke Prettier with --experimental-cli flag