### PR TITLE
fix: remove all reactions when PR is merged in Slack notifications

### DIFF
--- a/.github/actions/slack-pr-notifier/slack-notifier.js
+++ b/.github/actions/slack-pr-notifier/slack-notifier.js
@@ -488,14 +488,14 @@ async function manageReactionsEfficiently(slackTs, labels, slackApi, SLACK_CHANN
     'qa:failed': 'x',
     'status:ready-for-review': 'eyes',
     'status:approved': 'thumbsup',
-    'status:mergeable': 'rocket',
-    'status:merged': 'tada'
+    'status:mergeable': 'rocket'
+    // Note: status:merged is intentionally not mapped - merged PRs should have no reactions
   };
 
   // Define mutually exclusive groups (only one can be active at a time)
   const exclusiveGroups = {
     'qa': ['hourglass_flowing_sand', 'runner', 'white_check_mark', 'x'],
-    'status': ['eyes', 'thumbsup', 'rocket', 'tada']
+    'status': ['eyes', 'thumbsup', 'rocket']
   };
 
   // All possible status reactions we manage
@@ -602,6 +602,13 @@ async function manageReactionsEfficiently(slackTs, labels, slackApi, SLACK_CHANN
  */
 function calculateDesiredReactions(labels, statusReactions, exclusiveGroups) {
   console.log('\n=== CALCULATING DESIRED REACTIONS ===');
+  
+  // Check if PR is merged - if so, we want NO reactions
+  const isMerged = labels.some(l => l.name === 'status:merged');
+  if (isMerged) {
+    console.log('PR is merged - no reactions should be displayed');
+    return [];
+  }
   
   // Map labels to reactions
   const mappedReactions = [];


### PR DESCRIPTION
## Summary
This PR fixes an issue where Slack notifications for merged PRs would still display status reaction emojis (like checkmarks and fire emojis), creating visual clutter on completed PRs.

## Changes
- Modified `calculateDesiredReactions` function to return an empty array when a PR has the `status:merged` label
- Removed the `status:merged` -> `tada` reaction mapping from `statusReactions` object
- Updated the exclusive groups to exclude the `tada` reaction
- Added explanatory comment about why merged PRs have no reaction mapping

## Technical Details
The Slack notifier now checks if a PR is merged at the beginning of the reaction calculation process. When merged, it returns an empty array of desired reactions, which causes the efficient reaction manager to remove all existing managed reactions from the message.

The message text itself still displays the :tada: emoji for merged PRs (in the message content), but the reaction emojis below the message are cleared to maintain a clean appearance.

## Testing
- [x] Code changes follow the existing patterns
- [x] No breaking changes introduced
- [x] Logic is clear with added comments

## Screenshots
Before: Merged PRs showed reaction emojis (✅ 🔥) below the message
After: Merged PRs will have no reaction emojis, only the :tada: in the message text

## Related Issues
Addresses the issue shown in the user's screenshot where merged PRs still displayed status reactions.