### PR TITLE
fix: loki sidecar image point to harbor

### DIFF
--- a/kit/charts/atk/charts/observability/values.yaml
+++ b/kit/charts/atk/charts/observability/values.yaml
@@ -218,6 +218,11 @@ loki:
   bloomGateway:
     replicas: 0
 
+  sidecar:
+    image:
+      # -- The Docker registry and image for the k8s sidecar
+      repository: docker.io/kiwigrid/k8s-sidecar
+
 
 # https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml
 alloy:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add sidecar.image.repository entry for Loki to point at docker.io/kiwigrid/k8s-sidecar in values.yaml