### PR TITLE
fix: comment night run test schedule

### DIFF
--- a/.github/workflows/e2e-playwright-tests.yml
+++ b/.github/workflows/e2e-playwright-tests.yml
@@ -1,7 +1,7 @@
 name: Playwright Tests
 on:
-  schedule:
-    - cron: "0 0 * * 1-5" # runs every night Sun-Fri at 2AM (time difference with GHA! + 1hr)
+  # schedule:
+  #   - cron: "0 0 * * 1-5" # runs every night Sun-Fri at 2AM (time difference with GHA! + 1hr)
   pull_request:
     types: [labeled]
   workflow_dispatch:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Comment out nightly schedule for Playwright tests in CI workflow