### PR TITLE
fix: onboarding flow

### DIFF
--- a/kit/dapp/src/components/onboarding/onboarding-guard.tsx
+++ b/kit/dapp/src/components/onboarding/onboarding-guard.tsx
@@ -1,3 +1,4 @@
+import { authClient } from "@/lib/auth/auth.client";
 import {
   type OnboardingType,
   type PlatformOnboardingRequirements,
@@ -26,10 +27,11 @@ export function OnboardingGuard({
   const navigate = useNavigate();
 
   // Fetch user data
-  const { data: user, isLoading } = useQuery(orpc.user.me.queryOptions());
+  const { data: session, isPending } = authClient.useSession();
+  const user = session?.user;
 
   // Check if user queries are still loading
-  const userLoading = isLoading;
+  const userLoading = isPending;
 
   // Fetch system address from settings
   const { data: systemAddress } = useQuery({
@@ -55,7 +57,8 @@ export function OnboardingGuard({
   // Determine user's onboarding status
   const userHasWallet = !!user?.wallet;
   const userHasIdentity = false; // TODO: Implement identity check
-  const userRole = user?.role ?? "investor";
+  const userRole =
+    (user?.role as undefined | "issuer" | "investor" | "admin") ?? "investor";
 
   const onboardingType = user
     ? determineOnboardingType(userRole, platformRequirements)

--- a/kit/dapp/src/components/onboarding/onboarding-guard.tsx
+++ b/kit/dapp/src/components/onboarding/onboarding-guard.tsx
@@ -49,13 +49,13 @@ export function OnboardingGuard({
 
   // Determine platform onboarding requirements
   const platformRequirements: PlatformOnboardingRequirements = {
-    hasWallet: !!user?.wallet,
+    hasWallet: !!user?.initialOnboardingFinished,
     hasSystem: !!systemAddress,
     hasTokenFactories: (systemDetails?.tokenFactories.length ?? 0) > 0,
   };
 
   // Determine user's onboarding status
-  const userHasWallet = !!user?.wallet;
+  const userHasWallet = !!user?.initialOnboardingFinished;
   const userHasIdentity = false; // TODO: Implement identity check
   const userRole =
     (user?.role as undefined | "issuer" | "investor" | "admin") ?? "investor";

--- a/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
+++ b/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
@@ -21,13 +21,18 @@ export function WalletStep({ onRegisterAction }: WalletStepProps) {
   const hasWallet = !!user?.wallet;
 
   const { mutate: generateWallet, isPending } = useMutation({
-    mutationFn: () =>
-      authClient.wallet({
+    mutationFn: async () => {
+      await authClient.wallet({
         messages: {
           walletAlreadyExists: t("onboarding:wallet.already-exists"),
           walletCreationFailed: t("onboarding:wallet.creation-failed"),
         },
-      }),
+      });
+      // TODO: Remove this once we have a proper pincode setup flow
+      await authClient.pincode.enable({
+        pincode: "111111",
+      });
+    },
     onSuccess: () => {
       toast.success(t("onboarding:wallet.generated"));
       void queryClient.invalidateQueries({
@@ -56,7 +61,7 @@ export function WalletStep({ onRegisterAction }: WalletStepProps) {
         });
       }
     }
-  }, [onRegisterAction, hasWallet]);
+  }, [onRegisterAction, hasWallet, handleGenerateWallet]);
 
   // Don't auto-advance - removed the auto success callback
 

--- a/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
+++ b/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
@@ -53,7 +53,7 @@ export function WalletStep({ onRegisterAction }: WalletStepProps) {
   useEffect(() => {
     if (onRegisterAction) {
       if (!hasWallet) {
-        onRegisterAction(generateWallet);
+        onRegisterAction(handleGenerateWallet);
       } else {
         // Unregister by passing a no-op function when wallet exists
         onRegisterAction(() => {

--- a/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
+++ b/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
@@ -2,7 +2,7 @@ import { authClient } from "@/lib/auth/auth.client";
 import { queryClient } from "@/lib/query.client";
 import { AuthQueryContext } from "@daveyplate/better-auth-tanstack";
 import { useMutation } from "@tanstack/react-query";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -43,11 +43,11 @@ export function WalletStep({ onRegisterAction }: WalletStepProps) {
   });
 
   // Handle generate wallet
-  const handleGenerateWallet = () => {
+  const handleGenerateWallet = useCallback(() => {
     if (user?.id && !isPending && !hasWallet) {
       generateWallet();
     }
-  };
+  }, [user?.id, isPending, hasWallet, generateWallet]);
 
   // Register the action with parent
   useEffect(() => {

--- a/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
+++ b/kit/dapp/src/components/onboarding/steps/wallet-step.tsx
@@ -18,7 +18,7 @@ export function WalletStep({ onRegisterAction }: WalletStepProps) {
   const [justGenerated, setJustGenerated] = useState(false);
 
   const user = session?.user;
-  const hasWallet = !!user?.wallet;
+  const hasWallet = !!user?.initialOnboardingFinished;
 
   const { mutate: generateWallet, isPending } = useMutation({
     mutationFn: async () => {
@@ -44,16 +44,16 @@ export function WalletStep({ onRegisterAction }: WalletStepProps) {
 
   // Handle generate wallet
   const handleGenerateWallet = useCallback(() => {
-    if (user?.id && !isPending && !hasWallet) {
+    if (!isPending && !hasWallet) {
       generateWallet();
     }
-  }, [user?.id, isPending, hasWallet, generateWallet]);
+  }, [isPending, hasWallet, generateWallet]);
 
   // Register the action with parent
   useEffect(() => {
     if (onRegisterAction) {
       if (!hasWallet) {
-        onRegisterAction(handleGenerateWallet);
+        onRegisterAction(generateWallet);
       } else {
         // Unregister by passing a no-op function when wallet exists
         onRegisterAction(() => {

--- a/kit/dapp/src/routes/_private/onboarding/platform.tsx
+++ b/kit/dapp/src/routes/_private/onboarding/platform.tsx
@@ -6,20 +6,18 @@ import { SystemStep } from "@/components/onboarding/steps/system-step";
 import { WalletStep } from "@/components/onboarding/steps/wallet-step";
 import { StepWizard, type Step } from "@/components/step-wizard/step-wizard";
 import { ThemeToggle } from "@/components/theme/theme-toggle";
+import { authClient } from "@/lib/auth/auth.client";
 import { orpc } from "@/orpc";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/_private/onboarding/platform")({
   loader: async ({ context }) => {
     // Load user and system address in parallel
-    const [user, systemAddress] = await Promise.all([
-      context.queryClient.ensureQueryData(orpc.user.me.queryOptions()),
-      context.queryClient.ensureQueryData(
-        orpc.settings.read.queryOptions({ input: { key: "SYSTEM_ADDRESS" } })
-      ),
-    ]);
+    const systemAddress = await context.queryClient.ensureQueryData(
+      orpc.settings.read.queryOptions({ input: { key: "SYSTEM_ADDRESS" } })
+    );
 
     // If we have a system address, ensure system details are loaded
     let systemDetails = null;
@@ -31,25 +29,27 @@ export const Route = createFileRoute("/_private/onboarding/platform")({
       );
     }
 
-    return { user, systemAddress, systemDetails };
+    return { systemAddress, systemDetails };
   },
   component: PlatformOnboarding,
 });
 
 function PlatformOnboarding() {
+  const { data: session } = authClient.useSession();
   const { t } = useTranslation(["general", "onboarding"]);
   const navigate = useNavigate();
 
   // Get data from loader
-  const { user, systemAddress, systemDetails } = Route.useLoaderData();
+  const { systemAddress, systemDetails } = Route.useLoaderData();
 
   // Start with first step, will update when data loads
   const [currentStepId, setCurrentStepId] = useState("wallet");
   const [hasInitialized, setHasInitialized] = useState(false);
 
+  const user = session?.user;
   // Determine initial step based on what's completed
   const getInitialStep = () => {
-    if (!user.wallet) return "wallet";
+    if (!user?.initialOnboardingFinished) return "wallet";
     if (!systemAddress) return "system";
     if ((systemDetails?.tokenFactories.length ?? 0) === 0) return "assets";
     return "assets"; // Default to last step if all complete
@@ -71,7 +71,7 @@ function PlatformOnboarding() {
       id: "wallet",
       title: "Generate Wallet",
       description: "Create your secure blockchain wallet",
-      status: user.wallet
+      status: user?.initialOnboardingFinished
         ? "completed"
         : currentStepId === "wallet"
           ? "active"
@@ -127,7 +127,11 @@ function PlatformOnboarding() {
 
   const handleNext = () => {
     // Check if current step needs special action
-    if (currentStepId === "wallet" && !user.wallet && walletActionRef.current) {
+    if (
+      currentStepId === "wallet" &&
+      !user?.initialOnboardingFinished &&
+      walletActionRef.current
+    ) {
       walletActionRef.current();
       return;
     }
@@ -177,7 +181,7 @@ function PlatformOnboarding() {
   // Determine if next button should be disabled
   const isNextDisabled = () => {
     // For wallet step, enable button if no wallet
-    if (currentStepId === "wallet" && !user.wallet) {
+    if (currentStepId === "wallet" && !user?.initialOnboardingFinished) {
       return false; // Enable the "Generate Wallet" button
     }
 
@@ -200,7 +204,7 @@ function PlatformOnboarding() {
 
   // Determine button labels
   const getNextLabel = () => {
-    if (currentStepId === "wallet" && !user.wallet) {
+    if (currentStepId === "wallet" && !user?.initialOnboardingFinished) {
       return "Generate Wallet";
     }
     if (currentStepId === "system" && !systemAddress) {


### PR DESCRIPTION
Using a hardcoded pin for now until the UI is done

## Summary by Sourcery

Streamline the onboarding flow by migrating user session retrieval to authClient, refactoring loader logic to only fetch system settings, and updating step progression to use an initialOnboardingFinished flag. Introduce a temporary hardcoded pincode after wallet creation.

New Features:
- Enable a temporary hardcoded pincode ('111111') after wallet generation as a placeholder until the UI pincode flow is implemented.

Enhancements:
- Fetch user session via authClient.useSession instead of loader queries across onboarding components.
- Refactor loader to only retrieve systemAddress and systemDetails, removing user data fetch.
- Update onboarding step decisions and status checks to use initialOnboardingFinished instead of wallet existence.
- Adjust WalletStep dependency array and handleNext logic to align with the new initialOnboardingFinished flag.

Chores:
- Use session loading flag in OnboardingGuard and narrow user.role to a defined union type.