### PR TITLE
refactor: update system middleware to use orpc and EthereumAddress type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -133,7 +133,7 @@
   "typescript.suggest.completeFunctionCalls": true,
   "typescript.surveys.enabled": false,
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.tsserver.experimental.enableProjectDiagnostics": true,
+  "typescript.tsserver.experimental.enableProjectDiagnostics": false,
   "typescript.tsserver.web.typeAcquisition.enabled": false,
   "typescript.updateImportsOnFileMove.enabled": "always",
   "typescript.updateImportsOnPaste.enabled": true,


### PR DESCRIPTION
- Changed TypeScript setting `typescript.tsserver.experimental.enableProjectDiagnostics` from true to false.
- Updated `system.middleware.ts` to replace `Address` with `EthereumAddress` for the `address` field in the `TokenFactory` interface.
- Refactored the retrieval of the system address to use `orpc.settings.read.call` and updated the token factories fetching logic accordingly.

## Summary by Sourcery

Refactor system middleware to leverage ORPC for settings retrieval and adopt the EthereumAddress type throughout, removing legacy DB queries and generic address handling.

Enhancements:
- Retrieve system address via orpc.settings.read.call instead of direct database queries
- Replace generic Address type with EthereumAddress in TokenFactory definitions and middleware context
- Normalize addresses using getEthereumAddress utility when fetching token factories and setting system context

Chores:
- Disable TypeScript project diagnostics in VSCode settings