### PR TITLE
refactor: cleaner use of the context

### DIFF
--- a/kit/dapp/src/routes/_private/_onboarded.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded.tsx
@@ -8,15 +8,16 @@ import {
 } from "@/components/ui/sidebar";
 import { UserDropdown } from "@/components/user-dropdown/user-dropdown";
 import { authClient } from "@/lib/auth/auth.client";
-import { orpc } from "@/orpc";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/_onboarded")({
   component: LayoutComponent,
-  beforeLoad: async ({ context }) => {
+  beforeLoad: async ({ context: { queryClient, orpc } }) => {
     // Ensure factory list is loaded for the sidebar navigation
-    await context.queryClient.ensureQueryData(
-      orpc.token.factoryList.queryOptions({ input: { hasTokens: true } })
+    await queryClient.ensureQueryData(
+      orpc.token.factoryList.queryOptions({
+        input: { hasTokens: true },
+      })
     );
   },
 });

--- a/kit/dapp/src/routes/_private/_onboarded/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/index.tsx
@@ -16,7 +16,6 @@
 
 import { CreateDepositForm } from "@/components/asset-designer/deposit/form";
 import { Dashboard as IssuerDashboard } from "@/components/issuer-dashboard/dashboard";
-import { orpc } from "@/orpc";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/_onboarded/")({
@@ -38,12 +37,12 @@ export const Route = createFileRoute("/_private/_onboarded/")({
     // User data should be loaded in parent _private route, but we need to ensure it exists
     // to handle cache misses, invalidation, or direct navigation
     const user = await context.queryClient.ensureQueryData(
-      orpc.user.me.queryOptions()
+      context.orpc.user.me.queryOptions()
     );
 
     // Ensure systems data is loaded
     const systems = await context.queryClient.ensureQueryData(
-      orpc.system.list.queryOptions({ input: {} })
+      context.orpc.system.list.queryOptions({ input: {} })
     );
 
     return { user, systems };

--- a/kit/dapp/src/routes/_private/_onboarded/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/index.tsx
@@ -33,17 +33,13 @@ export const Route = createFileRoute("/_private/_onboarded/")({
    * @param root0
    * @param root0.context
    */
-  loader: async ({ context }) => {
-    // User data should be loaded in parent _private route, but we need to ensure it exists
+  loader: async ({ context: { queryClient, orpc } }) => {
+    // User and systems data should be loaded in parent _private route, but we need to ensure it exists
     // to handle cache misses, invalidation, or direct navigation
-    const user = await context.queryClient.ensureQueryData(
-      context.orpc.user.me.queryOptions()
-    );
-
-    // Ensure systems data is loaded
-    const systems = await context.queryClient.ensureQueryData(
-      context.orpc.system.list.queryOptions({ input: {} })
-    );
+    const [user, systems] = await Promise.all([
+      queryClient.ensureQueryData(orpc.user.me.queryOptions()),
+      queryClient.ensureQueryData(orpc.system.list.queryOptions({ input: {} })),
+    ]);
 
     return { user, systems };
   },

--- a/kit/dapp/src/routes/_private/_onboarded/token/$factoryAddress/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/token/$factoryAddress/index.tsx
@@ -9,7 +9,6 @@ import {
   getAssetClassFromFactoryTypeId,
   getAssetTypeFromFactoryTypeId,
 } from "@/lib/zod/validators/asset-types";
-import { orpc } from "@/orpc";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -55,19 +54,22 @@ export const Route = createFileRoute(
    * @returns Object containing the factory details
    * @throws If the factory is not found or the user lacks permissions
    */
-  loader: async ({ context, params }) => {
+  loader: async ({
+    context: { queryClient, orpc },
+    params: { factoryAddress },
+  }) => {
     // Ensure factory data is loaded
-    const factory = await context.queryClient.ensureQueryData(
+    const factory = await queryClient.ensureQueryData(
       orpc.token.factoryRead.queryOptions({
-        input: { id: params.factoryAddress },
+        input: { id: factoryAddress },
       })
     );
 
     // Prefetch tokens list for better UX
-    void context.queryClient.prefetchQuery(
+    void queryClient.prefetchQuery(
       orpc.token.list.queryOptions({
         input: {
-          tokenFactory: params.factoryAddress,
+          tokenFactory: factoryAddress,
         },
       })
     );

--- a/kit/dapp/src/routes/_private/_onboarded/token/stats.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/token/stats.tsx
@@ -1,17 +1,16 @@
 import { RouterBreadcrumb } from "@/components/breadcrumb/router-breadcrumb";
-import { orpc } from "@/orpc";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/_onboarded/token/stats")({
-  loader: async ({ context }) => {
+  loader: async ({ context: { queryClient, orpc } }) => {
     // Ensure all token factories are loaded for statistics overview
-    const factories = await context.queryClient.ensureQueryData(
+    const factories = await queryClient.ensureQueryData(
       orpc.token.factoryList.queryOptions({ input: {} })
     );
 
     // Get tokens from the first factory for demonstration
     if (factories.length > 0 && factories[0]) {
-      void context.queryClient.prefetchQuery(
+      void queryClient.prefetchQuery(
         orpc.token.list.queryOptions({
           input: {
             tokenFactory: factories[0].id,

--- a/kit/dapp/src/routes/_private/onboarding/index.tsx
+++ b/kit/dapp/src/routes/_private/onboarding/index.tsx
@@ -2,18 +2,17 @@ import {
   determineOnboardingType,
   type PlatformOnboardingRequirements,
 } from "@/lib/types/onboarding";
-import { orpc } from "@/orpc";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/onboarding/")({
-  beforeLoad: async ({ context }) => {
-    const queryClient = context.queryClient;
-
+  beforeLoad: async ({ context: { queryClient, orpc } }) => {
     // Fetch user and system address data in parallel
     const [user, systemAddress] = await Promise.all([
       queryClient.ensureQueryData(orpc.user.me.queryOptions()),
       queryClient.ensureQueryData(
-        orpc.settings.read.queryOptions({ input: { key: "SYSTEM_ADDRESS" } })
+        orpc.settings.read.queryOptions({
+          input: { key: "SYSTEM_ADDRESS" },
+        })
       ),
     ]);
 

--- a/kit/dapp/src/routes/_private/onboarding/investor.tsx
+++ b/kit/dapp/src/routes/_private/onboarding/investor.tsx
@@ -12,18 +12,15 @@ import {
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth/auth.client";
 import type { OnboardingType } from "@/lib/types/onboarding";
-import { orpc } from "@/orpc";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { AlertCircle, UserCheck } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/_private/onboarding/investor")({
-  loader: async ({ context }) => {
+  loader: async ({ context: { queryClient, orpc } }) => {
     // User data is critical for determining step status
-    const user = await context.queryClient.ensureQueryData(
-      orpc.user.me.queryOptions()
-    );
+    const user = await queryClient.ensureQueryData(orpc.user.me.queryOptions());
     return { user };
   },
   component: InvestorOnboarding,

--- a/kit/dapp/src/routes/_private/onboarding/issuer.tsx
+++ b/kit/dapp/src/routes/_private/onboarding/issuer.tsx
@@ -4,17 +4,14 @@ import { WalletStep } from "@/components/onboarding/steps/wallet-step";
 import { StepWizard, type Step } from "@/components/step-wizard/step-wizard";
 import { authClient } from "@/lib/auth/auth.client";
 import type { OnboardingType } from "@/lib/types/onboarding";
-import { orpc } from "@/orpc";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/_private/onboarding/issuer")({
-  loader: async ({ context }) => {
+  loader: async ({ context: { queryClient, orpc } }) => {
     // User data is critical for determining step status
-    const user = await context.queryClient.ensureQueryData(
-      orpc.user.me.queryOptions()
-    );
+    const user = await queryClient.ensureQueryData(orpc.user.me.queryOptions());
     return { user };
   },
   component: IssuerOnboarding,

--- a/kit/dapp/src/routes/_private/onboarding/platform.tsx
+++ b/kit/dapp/src/routes/_private/onboarding/platform.tsx
@@ -10,25 +10,26 @@ import { ThemeToggle } from "@/components/theme/theme-toggle";
 import { useSettings } from "@/hooks/use-settings";
 import { authClient } from "@/lib/auth/auth.client";
 import type { OnboardingType } from "@/lib/types/onboarding";
-import { orpc } from "@/orpc";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/_private/onboarding/platform")({
-  loader: async ({ context }) => {
+  loader: async ({ context: { queryClient, orpc } }) => {
     // Load user and system address in parallel
     const [user, systemAddress] = await Promise.all([
-      context.queryClient.ensureQueryData(orpc.user.me.queryOptions()),
-      context.queryClient.ensureQueryData(
-        orpc.settings.read.queryOptions({ input: { key: "SYSTEM_ADDRESS" } })
+      queryClient.ensureQueryData(orpc.user.me.queryOptions()),
+      queryClient.ensureQueryData(
+        orpc.settings.read.queryOptions({
+          input: { key: "SYSTEM_ADDRESS" },
+        })
       ),
     ]);
 
     // If we have a system address, ensure system details are loaded
     let systemDetails = null;
     if (systemAddress) {
-      systemDetails = await context.queryClient.ensureQueryData(
+      systemDetails = await queryClient.ensureQueryData(
         orpc.system.read.queryOptions({
           input: { id: systemAddress },
         })


### PR DESCRIPTION
## Summary by Sourcery

Refactor route data fetching to consistently use context destructuring for queryClient and orpc, remove module-level orpc imports, and enhance the token detail route with prefetching, SEO metadata, and error handling.

New Features:
- Add loader to the token detail route to prefetch token and factory data via the queryClient
- Add SEO head configuration for the token detail route using factory and token metadata
- Introduce DefaultCatchBoundary as the errorComponent for the token detail route

Enhancements:
- Refactor all route loaders and beforeLoad hooks to destructure queryClient and orpc from context and remove direct orpc imports
- Standardize use of queryClient.ensureQueryData and prefetchQuery across multiple onboarding and dashboard routes