### PR TITLE
feat: improve breadcrumb system with metadata-driven approach

### DIFF
--- a/kit/dapp/src/components/breadcrumb/metadata.ts
+++ b/kit/dapp/src/components/breadcrumb/metadata.ts
@@ -1,0 +1,76 @@
+import type { AssetClass } from "@/lib/zod/validators/asset-types";
+
+/**
+ * Breadcrumb metadata that can be attached to routes
+ */
+export interface BreadcrumbMetadata {
+  /** The display title for the breadcrumb (can be an i18n key) */
+  title: string;
+  /** Whether this is an i18n key that needs translation */
+  isI18nKey?: boolean;
+  /** Optional i18n namespace (defaults to "navigation") */
+  i18nNamespace?: string;
+  /** Optional function to dynamically resolve the title */
+  getTitle?: () => string | Promise<string>;
+  /** Whether this segment should be hidden from breadcrumbs */
+  hidden?: boolean;
+  /** Optional icon identifier */
+  icon?: string;
+}
+
+/**
+ * Extended route context with breadcrumb metadata
+ */
+export interface RouteContextWithBreadcrumb {
+  breadcrumb?: BreadcrumbMetadata;
+}
+
+/**
+ * Asset class breadcrumb metadata mapping with i18n support
+ */
+export const assetClassBreadcrumbs: Record<AssetClass | "asset-management", BreadcrumbMetadata> = {
+  "asset-management": {
+    title: "assetManagement",
+    isI18nKey: true,
+  },
+  "fixed-income": {
+    title: "fixedIncome",
+    isI18nKey: true,
+  },
+  "flexible-income": {
+    title: "flexibleIncome",
+    isI18nKey: true,
+  },
+  "cash-equivalent": {
+    title: "cashEquivalent",
+    isI18nKey: true,
+  },
+} as const;
+
+/**
+ * Helper to build breadcrumb metadata for routes
+ */
+export function createBreadcrumbMetadata(
+  title: string,
+  options?: Partial<BreadcrumbMetadata>
+): BreadcrumbMetadata {
+  return {
+    title,
+    ...options,
+  };
+}
+
+/**
+ * Helper to build i18n-enabled breadcrumb metadata
+ */
+export function createI18nBreadcrumbMetadata(
+  i18nKey: string,
+  options?: Partial<BreadcrumbMetadata>
+): BreadcrumbMetadata {
+  return {
+    title: i18nKey,
+    isI18nKey: true,
+    i18nNamespace: "navigation",
+    ...options,
+  };
+}

--- a/kit/dapp/src/routes/_private/_onboarded/token/$factoryAddress/$tokenAddress.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/token/$factoryAddress/$tokenAddress.tsx
@@ -1,6 +1,14 @@
+import { RouterBreadcrumb } from "@/components/breadcrumb/router-breadcrumb";
+import {
+  assetClassBreadcrumbs,
+  createBreadcrumbMetadata,
+} from "@/components/breadcrumb/metadata";
 import { DefaultCatchBoundary } from "@/components/error/default-catch-boundary";
 import { seo } from "@/config/metadata";
-import { getAssetTypeFromFactoryTypeId } from "@/lib/zod/validators/asset-types";
+import {
+  getAssetClassFromFactoryTypeId,
+  getAssetTypeFromFactoryTypeId,
+} from "@/lib/zod/validators/asset-types";
 import { createFileRoute } from "@tanstack/react-router";
 
 /**
@@ -65,7 +73,19 @@ export const Route = createFileRoute(
       ),
     ]);
 
-    return { token, factory };
+    // Get asset class for breadcrumb
+    const assetClass = getAssetClassFromFactoryTypeId(factory.typeId);
+
+    return {
+      token,
+      factory,
+      breadcrumb: [
+        assetClassBreadcrumbs["asset-management"],
+        assetClassBreadcrumbs[assetClass],
+        createBreadcrumbMetadata(factory.name),
+        createBreadcrumbMetadata(token.name),
+      ],
+    };
   },
   /**
    * Head configuration for SEO
@@ -133,7 +153,14 @@ export const Route = createFileRoute(
  * ```
  */
 function RouteComponent() {
+  const { token } = Route.useLoaderData();
+
   return (
-    <div>Hello "/_private/_onboarded/token/$factoryAddress/$tokenAddress"!</div>
+    <div className="space-y-6 p-6">
+      <div className="space-y-2">
+        <RouterBreadcrumb />
+        <h1 className="text-3xl font-bold tracking-tight">{token.name}</h1>
+      </div>
+    </div>
   );
 }

--- a/kit/dapp/src/routes/_private/_onboarded/token/$factoryAddress/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/token/$factoryAddress/index.tsx
@@ -6,12 +6,14 @@ import { TokenFactoryRelated } from "@/components/related/token-factory-related"
 import { TokensTable } from "@/components/tables/tokens";
 import { seo } from "@/config/metadata";
 import {
+  assetClassBreadcrumbs,
+  createBreadcrumbMetadata,
+} from "@/components/breadcrumb/metadata";
+import {
   getAssetClassFromFactoryTypeId,
   getAssetTypeFromFactoryTypeId,
 } from "@/lib/zod/validators/asset-types";
 import { createFileRoute } from "@tanstack/react-router";
-import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 
 /**
  * Route configuration for the token factory details page
@@ -74,7 +76,17 @@ export const Route = createFileRoute(
       })
     );
 
-    return { factory };
+    // Get asset class for breadcrumb
+    const assetClass = getAssetClassFromFactoryTypeId(factory.typeId);
+
+    return {
+      factory,
+      breadcrumb: [
+        assetClassBreadcrumbs["asset-management"],
+        assetClassBreadcrumbs[assetClass],
+        createBreadcrumbMetadata(factory.name),
+      ],
+    };
   },
   /**
    * Head configuration for SEO
@@ -131,31 +143,14 @@ export const Route = createFileRoute(
 function RouteComponent() {
   const { factory } = Route.useLoaderData();
   const { factoryAddress } = Route.useParams();
-  const { t } = useTranslation("navigation");
 
   // Get the asset type from the factory typeId
   const assetType = getAssetTypeFromFactoryTypeId(factory.typeId);
-  const assetClass = getAssetClassFromFactoryTypeId(factory.typeId);
-
-  const intermediateSections = useMemo(
-    () => [
-      { title: t("assetManagement") },
-      {
-        title:
-          assetClass === "fixed-income"
-            ? t("fixedIncome")
-            : assetClass === "flexible-income"
-              ? t("flexibleIncome")
-              : t("cashEquivalent"),
-      },
-    ],
-    [assetClass, t]
-  );
 
   return (
     <div className="space-y-6 p-6">
       <div className="space-y-2">
-        <RouterBreadcrumb intermediateSections={intermediateSections} />
+        <RouterBreadcrumb />
         <h1 className="text-3xl font-bold tracking-tight">{factory.name}</h1>
       </div>
 


### PR DESCRIPTION
## Summary

This PR improves the breadcrumb system by introducing a metadata-driven approach that eliminates the need for manual configuration and provides better maintainability.

## Changes

### New Features
- **Breadcrumb Metadata System**: Added `metadata.ts` with types and helpers for defining breadcrumb metadata
- **Automatic Metadata Detection**: Enhanced `RouterBreadcrumb` to automatically use breadcrumb data from route loaders
- **I18n Support**: Built-in support for translating static breadcrumb segments
- **Smart Fallbacks**: Automatically extracts titles from loader data (factory/token names) when metadata isn't provided

### Improvements
- Removed the need for manual `intermediateSections` configuration on each page
- Fixed duplicate "deposits" segment appearing in breadcrumbs
- Centralized breadcrumb logic in the component folder for better organization
- Added TypeScript types for better type safety

### Breaking Changes
- `RouterBreadcrumb` no longer accepts `intermediateSections` prop (routes now define their own breadcrumb metadata in loaders)

## Technical Details

The new system works by:
1. Routes define breadcrumb metadata in their loader functions
2. RouterBreadcrumb automatically detects and uses this metadata
3. Static segments (like "Asset Management") use i18n keys
4. Dynamic segments (like factory/token names) use actual data

Example breadcrumb hierarchy:
- Factory page: `Home / Asset Management / Cash Equivalent / Deposits`
- Token page: `Home / Asset Management / Cash Equivalent / Deposits / Euro Deposits`

## Testing

- [x] Manually tested breadcrumbs on token factory pages
- [x] Manually tested breadcrumbs on token detail pages
- [x] Verified i18n translations work correctly
- [x] Confirmed no duplicate segments appear
- [x] TypeScript compilation passes (except for unrelated translation key issues)

## Migration Guide

To update existing routes to use the new breadcrumb system:

1. Remove `intermediateSections` prop from `<RouterBreadcrumb>` components
2. Add breadcrumb metadata to your route's loader:

```typescript
loader: async ({ context, params }) => {
  // ... existing loader logic
  
  return {
    // ... existing data
    breadcrumb: [
      assetClassBreadcrumbs["asset-management"],
      assetClassBreadcrumbs[assetClass],
      createBreadcrumbMetadata(dynamicName),
    ],
  };
}
```

## Related Issues

Addresses user feedback about incorrect breadcrumb display and maintainability concerns.

## Screenshots

Before: `Asset Management / Cash equivalent / Deposits / Deposits`
After: `Asset Management / Cash Equivalent / Deposits`

## Next Steps

- Update remaining routes to use the new breadcrumb metadata system
- Consider adding breadcrumb metadata to more routes for consistency