### PR TITLE
fix: besu deprecate ws flags

### DIFF
--- a/kit/charts/atk/charts/besu-network/charts/besu-node/values.yaml
+++ b/kit/charts/atk/charts/besu-network/charts/besu-node/values.yaml
@@ -111,8 +111,7 @@ node:
         - "IBFT"
         - "NET"
         - "TRACE"
-        - "EEA"
-        - "PRIV"
+
         - "QBFT"
         - "PERM"
         - "TXPOOL"


### PR DESCRIPTION
Besu 25.7.0 doesn't start with error:
```
Setting logging level to INFO
2025-07-07 13:18:18.239+00:00 | main | INFO  | Besu | Starting Besu
2025-07-07 13:18:18.398+00:00 | main | WARN  | Besu | --sync-min-peers is ignored in FULL sync-mode
Invalid value for option '--rpc-ws-api': invalid entries found [EEA, PRIV]
2025-07-07 13:18:18.406+00:00 | main | ERROR | Besu | Failed to start Besu: Invalid value for option '--rpc-ws-api': invalid entries found [EEA, PRIV]

To display full help:
besu [COMMAND] --help
stream closed EOF for atk/besu-node-rpc-1-0 (atk-besu)
```

## Summary by Sourcery

Bug Fixes:
- Remove deprecated 'EEA' and 'PRIV' entries from the --rpc-ws-api configuration in the besu-node Helm chart.