### PR TITLE
fix(exchange-rates): remove provider field from API responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,11 +136,15 @@ kit/
 
 - **Strict mode always** - all strict compiler options enabled
 - **Forbidden**: `any`, `@ts-ignore`, enums, namespaces, `var`
-- **Preferred**: `type` over `interface`, `readonly` by default, no default exports
-- **Naming**: kebab-case files, camelCase variables, PascalCase types, UPPER_SNAKE_CASE constants
+- **Preferred**: `type` over `interface`, `readonly` by default, no default
+  exports
+- **Naming**: kebab-case files, camelCase variables, PascalCase types,
+  UPPER_SNAKE_CASE constants
 - **Return types required** on top-level functions (except JSX components)
-- **Modern patterns**: Discriminated unions, const assertions over enums, Result types, branded types
-- **Code quality**: No unused imports/variables/parameters, === over ==, exhaustive switches
+- **Modern patterns**: Discriminated unions, const assertions over enums, Result
+  types, branded types
+- **Code quality**: No unused imports/variables/parameters, === over ==,
+  exhaustive switches
 - **Schema-first**: Define Zod schemas, derive TypeScript types, use type guards
 - **Error handling**: Use Result types, proper error handling with `new Error`
 
@@ -161,12 +165,14 @@ kit/
 
 ### Code Quality
 
-- **Logging**: Use
-  `createLogger({ level: (process.env.SETTLEMINT_LOG_LEVEL as LogLevel) || "info" })`
-  instead of console.log
+- **Logging**: Use `createLogger({ level: env.SETTLEMINT_LOG_LEVEL })` instead
+  of console.log
 - **No unused**: imports, variables, parameters, members
-- **Modern practices**: for...of, template literals, async/await, object spread, numeric separators
-- **Accessibility**: Valid ARIA usage, keyboard support (onClick→onKey*), meaningful labels/alt text, required attributes (lang, title, type), no accessKey or aria-hidden on focusable elements
+- **Modern practices**: for...of, template literals, async/await, object spread,
+  numeric separators
+- **Accessibility**: Valid ARIA usage, keyboard support (onClick→onKey\*),
+  meaningful labels/alt text, required attributes (lang, title, type), no
+  accessKey or aria-hidden on focusable elements
 - **Forbidden**: console.log, debugger, delete, eval, hardcoded secrets
 
 ### Logging Best Practices
@@ -176,7 +182,7 @@ kit/
 import { createLogger, type LogLevel } from "@settlemint/sdk-utils/logging";
 
 const logger = createLogger({
-  level: (process.env.SETTLEMINT_LOG_LEVEL as LogLevel) || "info"
+  level: env.SETTLEMINT_LOG_LEVEL,
 });
 
 // Use appropriate log levels
@@ -196,7 +202,7 @@ console.error("Use logger.error instead");
 
 ```typescript
 // Use DefaultCatchBoundary for route-level error handling
-export const Route = createFileRoute('/path')({ 
+export const Route = createFileRoute("/path")({
   errorComponent: DefaultCatchBoundary,
   component: MyComponent,
 });
@@ -204,7 +210,7 @@ export const Route = createFileRoute('/path')({
 // For data table components, use DataTableErrorBoundary
 <DataTableErrorBoundary>
   <DataTable {...props} />
-</DataTableErrorBoundary>
+</DataTableErrorBoundary>;
 ```
 
 #### Toast Notifications
@@ -221,9 +227,9 @@ try {
   const errorMessage = formatValidationError(error);
   toast.error(errorMessage, {
     duration: 10000, // Longer duration for errors
-    description: "Check browser console for details"
+    description: "Check browser console for details",
   });
-  
+
   // Also log to console for debugging
   logger.error("Operation failed", { error, context: additionalContext });
 }
@@ -238,7 +244,7 @@ const { mutate, isTracking } = useStreamingMutation({
   onSuccess: (result) => {
     // Handle success with properly typed result
     router.navigate({ to: "/tokens/$address", params: { address: result } });
-  }
+  },
 });
 ```
 
@@ -265,9 +271,9 @@ const { mutate, isTracking } = useStreamingMutation({
 ```typescript
 // ✅ Use URL state for shareable, persistent UI state
 const tableState = useDataTableState({
-  enableUrlPersistence: true,  // Enables URL-based state
+  enableUrlPersistence: true, // Enables URL-based state
   defaultPageSize: 20,
-  debounceMs: 300,  // Prevent excessive URL updates
+  debounceMs: 300, // Prevent excessive URL updates
 });
 
 // URL state is ideal for:
@@ -296,25 +302,33 @@ const expensiveResult = useMemo(() => {
 }, [data]); // Only recompute when data changes
 
 // ✅ Memoize callbacks passed to child components
-const handleClick = useCallback((id: string) => {
-  doSomething(id);
-}, [doSomething]); // Stable reference prevents unnecessary re-renders
+const handleClick = useCallback(
+  (id: string) => {
+    doSomething(id);
+  },
+  [doSomething]
+); // Stable reference prevents unnecessary re-renders
 
 // ✅ Memoize components that receive complex props
-const MemoizedComponent = React.memo(ExpensiveComponent, (prevProps, nextProps) => {
-  // Custom comparison for performance
-  return prevProps.id === nextProps.id && 
-         prevProps.version === nextProps.version;
-});
+const MemoizedComponent = React.memo(
+  ExpensiveComponent,
+  (prevProps, nextProps) => {
+    // Custom comparison for performance
+    return (
+      prevProps.id === nextProps.id && prevProps.version === nextProps.version
+    );
+  }
+);
 
 // ✅ Use virtualization for large lists
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 // ✅ Debounce expensive operations
 const debouncedSearch = useMemo(
-  () => debounce((query: string) => {
-    performSearch(query);
-  }, 300),
+  () =>
+    debounce((query: string) => {
+      performSearch(query);
+    }, 300),
   [performSearch]
 );
 
@@ -352,9 +366,11 @@ Before any PR:
 
 ### Structure
 
-Translations are organized into focused, domain-specific namespaces for better maintainability:
+Translations are organized into focused, domain-specific namespaces for better
+maintainability:
 
 #### Core UI Namespaces
+
 - **`common`** - App-wide basics (app name, description, continue, generating)
 - **`navigation`** - Menu items and breadcrumbs
 - **`errors`** - All error messages with title/description pairs
@@ -363,30 +379,36 @@ Translations are organized into focused, domain-specific namespaces for better m
 - **`accessibility`** - Screen reader text and ARIA labels
 
 #### Component-Specific Namespaces
+
 - **`data-table`** - Generic data table UI (sorting, filtering, pagination)
 - **`deposits-table`** - Specific deposit table functionality
 - **`dashboard`** - Dashboard widgets and statistics
 - **`wallet`** - Web3 wallet connection and management
 
 #### Feature Namespaces
-- **`asset-types`** - Asset definitions (bonds, deposits, equity, funds, stablecoins)
+
+- **`asset-types`** - Asset definitions (bonds, deposits, equity, funds,
+  stablecoins)
 - **`token-factory`** - Token creation and factory management
 - **`blockchain`** - Transaction and blockchain terminology
 - **`auth`** - Authentication and authorization
 - **`onboarding`** - User onboarding flow
 
 #### Technical Namespaces
+
 - **`formats`** - Date, time, number, and blockchain formatting patterns
 - **`seo`** - Meta tags and SEO content
 
 ### Usage Guidelines
 
 1. **Use multiple namespaces** in components when needed:
+
    ```typescript
    const { t } = useTranslation(["data-table", "errors", "toast"]);
    ```
 
-2. **Keep translations minimal** - avoid duplicating the same string across namespaces
+2. **Keep translations minimal** - avoid duplicating the same string across
+   namespaces
 
 3. **Component-specific translations** belong in dedicated files, not in general
 
@@ -436,9 +458,13 @@ Translations are organized into focused, domain-specific namespaces for better m
 - Run `bun artifacts` and `bun codegen` before running any
   testing/linting/formatting tasks
 - `routeTree.gen.ts` is auto generated, ignore it
-- Before starting any work, run `bunx settlemint connect --instance local` and `bun run codegen`
-- Always use error boundaries (DefaultCatchBoundary for routes, DataTableErrorBoundary for tables)
+- Before starting any work, run `bunx settlemint connect --instance local` and
+  `bun run codegen`
+- Always use error boundaries (DefaultCatchBoundary for routes,
+  DataTableErrorBoundary for tables)
 - Use toast notifications with formatValidationError for user feedback
-- Prefer URL state for persistent UI configuration, local state for ephemeral interactions
+- Prefer URL state for persistent UI configuration, local state for ephemeral
+  interactions
 - Only optimize performance after measuring with React DevTools Profiler
-- Translations are organized into focused namespaces - use multiple namespaces in components as needed
+- Translations are organized into focused namespaces - use multiple namespaces
+  in components as needed

--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,10 @@
   "workspaces": {
     "": {
       "name": "@settlemint/asset-tokenization-kit",
+      "dependencies": {
+        "currency-codes": "2.2.0",
+        "drizzle-zod": "0.8.2",
+      },
       "devDependencies": {
         "@prettier/plugin-oxc": "0.0.4",
         "@settlemint/sdk-cli": "2.4.1",
@@ -1803,6 +1807,8 @@
 
     "csv-stringify": ["csv-stringify@6.5.2", "", {}, "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA=="],
 
+    "currency-codes": ["currency-codes@2.2.0", "", { "dependencies": { "first-match": "~0.0.1", "nub": "~0.0.0" } }, "sha512-vpbQc5sEYHGdTVAYUhHnKv0DWiYLRvzl/KKyqeHzBh7HD/j3UlWoScpZ9tN/jG6w2feddWoObsBbaNVu5yDapg=="],
+
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
     "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
@@ -1958,6 +1964,8 @@
     "drizzle-kit": ["drizzle-kit@0.31.4", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA=="],
 
     "drizzle-orm": ["drizzle-orm@0.44.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-zGAqBzWWkVSFjZpwPOrmCrgO++1kZ5H/rZ4qTGeGOe18iXGVJWf3WPfHOVwFIbmi8kHjfJstC6rJomzGx8g/dQ=="],
+
+    "drizzle-zod": ["drizzle-zod@0.8.2", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "zod": "^3.25.1" } }, "sha512-9Do/16OjFFNrQDZgvMtxtDDwKWbFOxUAIwNPKX98SfxrP8H18vhN1BvNXbhelLcdgCE7GEaXDJqBjMExSkhpkA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -2176,6 +2184,8 @@
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
 
     "find-yarn-workspace-root2": ["find-yarn-workspace-root2@1.2.16", "", { "dependencies": { "micromatch": "^4.0.2", "pkg-dir": "^4.2.0" } }, "sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA=="],
+
+    "first-match": ["first-match@0.0.1", "", {}, "sha512-VvKbnaxrC0polTFDC+teKPTdl2mn6B/KUW+WB3C9RzKDeNwbzfLdnUz3FxC+tnjvus6bI0jWrWicQyVIPdS37A=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
 
@@ -2908,6 +2918,8 @@
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "nub": ["nub@0.0.0", "", {}, "sha512-dK0Ss9C34R/vV0FfYJXuqDAqHlaW9fvWVufq9MmGF2umCuDbd5GRfRD9fpi/LiM0l4ZXf8IBB+RYmZExqCrf0w=="],
 
     "number-to-bn": ["number-to-bn@1.7.0", "", { "dependencies": { "bn.js": "4.11.6", "strip-hex-prefix": "1.0.0" } }, "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig=="],
 

--- a/kit/charts/atk/charts/support/README.md
+++ b/kit/charts/atk/charts/support/README.md
@@ -18,7 +18,7 @@ A Helm chart for the supporting components
 | https://stakater.github.io/stakater-charts | reloader | 2.1.4 |
 | oci://registry-1.docker.io/bitnamicharts | minio | 17.0.9 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql-ha | 16.0.16 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 21.2.6 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 21.2.7 |
 
 ## Values
 

--- a/kit/dapp/drizzle/0000_perpetual_joseph.sql
+++ b/kit/dapp/drizzle/0000_perpetual_joseph.sql
@@ -1,0 +1,147 @@
+CREATE TABLE "account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp with time zone,
+	"refresh_token_expires_at" timestamp with time zone,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "apikey" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"start" text,
+	"prefix" text,
+	"key" text NOT NULL,
+	"user_id" text NOT NULL,
+	"refill_interval" integer,
+	"refill_amount" integer,
+	"last_refill_at" timestamp with time zone,
+	"enabled" boolean DEFAULT true,
+	"rate_limit_enabled" boolean DEFAULT true,
+	"rate_limit_time_window" integer DEFAULT 60000,
+	"rate_limit_max" integer DEFAULT 60,
+	"request_count" integer,
+	"remaining" integer,
+	"last_request" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"permissions" text,
+	"metadata" text
+);
+--> statement-breakpoint
+CREATE TABLE "passkey" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"public_key" text NOT NULL,
+	"user_id" text NOT NULL,
+	"credential_i_d" text NOT NULL,
+	"counter" integer NOT NULL,
+	"device_type" text NOT NULL,
+	"backed_up" boolean NOT NULL,
+	"transports" text,
+	"created_at" timestamp with time zone,
+	"aaguid" text
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	"impersonated_by" text,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean NOT NULL,
+	"image" text,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"role" text,
+	"banned" boolean,
+	"ban_reason" text,
+	"ban_expires" timestamp with time zone,
+	"wallet" text,
+	"last_login_at" timestamp with time zone,
+	"pincode_enabled" boolean DEFAULT false NOT NULL,
+	"pincode_verification_id" text,
+	"two_factor_enabled" boolean DEFAULT false NOT NULL,
+	"two_factor_verification_id" text,
+	"secret_code_verification_id" text,
+	CONSTRAINT "user_email_unique" UNIQUE("email"),
+	CONSTRAINT "user_wallet_unique" UNIQUE("wallet"),
+	CONSTRAINT "user_pincode_verification_id_unique" UNIQUE("pincode_verification_id"),
+	CONSTRAINT "user_two_factor_verification_id_unique" UNIQUE("two_factor_verification_id"),
+	CONSTRAINT "user_secret_code_verification_id_unique" UNIQUE("secret_code_verification_id")
+);
+--> statement-breakpoint
+CREATE TABLE "verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "currencies" (
+	"code" varchar(3) PRIMARY KEY NOT NULL,
+	"name" varchar(64) NOT NULL,
+	"decimals" numeric(2, 0) DEFAULT '2'
+);
+--> statement-breakpoint
+CREATE TABLE "fx_rates" (
+	"base_code" varchar(3) NOT NULL,
+	"quote_code" varchar(3) NOT NULL,
+	"provider" varchar(32) NOT NULL,
+	"effective_at" timestamp with time zone NOT NULL,
+	"rate" numeric(38, 18) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "fx_rates_base_code_quote_code_provider_effective_at_pk" PRIMARY KEY("base_code","quote_code","provider","effective_at")
+);
+--> statement-breakpoint
+CREATE TABLE "fx_rates_latest" (
+	"base_code" varchar(3) NOT NULL,
+	"quote_code" varchar(3) NOT NULL,
+	"provider" varchar(32) NOT NULL,
+	"rate" numeric(38, 18) NOT NULL,
+	"effective_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "fx_rates_latest_base_code_quote_code_provider_pk" PRIMARY KEY("base_code","quote_code","provider")
+);
+--> statement-breakpoint
+CREATE TABLE "settings" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" text NOT NULL,
+	"last_updated" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "apikey" ADD CONSTRAINT "apikey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "fx_rates" ADD CONSTRAINT "fx_rates_base_code_currencies_code_fk" FOREIGN KEY ("base_code") REFERENCES "public"."currencies"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "fx_rates" ADD CONSTRAINT "fx_rates_quote_code_currencies_code_fk" FOREIGN KEY ("quote_code") REFERENCES "public"."currencies"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "fx_rates_latest" ADD CONSTRAINT "fx_rates_latest_base_code_currencies_code_fk" FOREIGN KEY ("base_code") REFERENCES "public"."currencies"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "fx_rates_latest" ADD CONSTRAINT "fx_rates_latest_quote_code_currencies_code_fk" FOREIGN KEY ("quote_code") REFERENCES "public"."currencies"("code") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_fx_rates_quote_base_ts" ON "fx_rates" USING btree ("quote_code","base_code","effective_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_fx_rates_base_quote_ts" ON "fx_rates" USING btree ("base_code","quote_code","effective_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_fx_rates_provider_ts" ON "fx_rates" USING btree ("provider","effective_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_fx_latest_quote_base" ON "fx_rates_latest" USING btree ("quote_code","base_code");--> statement-breakpoint
+CREATE INDEX "idx_fx_latest_provider" ON "fx_rates_latest" USING btree ("provider");

--- a/kit/dapp/drizzle/meta/0000_snapshot.json
+++ b/kit/dapp/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,968 @@
+{
+  "id": "17720c7f-2005-4339-b6c1-37926ed612a8",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_i_d": {
+          "name": "credential_i_d",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet": {
+          "name": "wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pincode_enabled": {
+          "name": "pincode_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pincode_verification_id": {
+          "name": "pincode_verification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_verification_id": {
+          "name": "two_factor_verification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_code_verification_id": {
+          "name": "secret_code_verification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_wallet_unique": {
+          "name": "user_wallet_unique",
+          "nullsNotDistinct": false,
+          "columns": ["wallet"]
+        },
+        "user_pincode_verification_id_unique": {
+          "name": "user_pincode_verification_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["pincode_verification_id"]
+        },
+        "user_two_factor_verification_id_unique": {
+          "name": "user_two_factor_verification_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["two_factor_verification_id"]
+        },
+        "user_secret_code_verification_id_unique": {
+          "name": "user_secret_code_verification_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["secret_code_verification_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.currencies": {
+      "name": "currencies",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(3)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "numeric(2, 0)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'2'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "base_code": {
+          "name": "base_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_code": {
+          "name": "quote_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fx_rates_quote_base_ts": {
+          "name": "idx_fx_rates_quote_base_ts",
+          "columns": [
+            {
+              "expression": "quote_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fx_rates_base_quote_ts": {
+          "name": "idx_fx_rates_base_quote_ts",
+          "columns": [
+            {
+              "expression": "base_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quote_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fx_rates_provider_ts": {
+          "name": "idx_fx_rates_provider_ts",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fx_rates_base_code_currencies_code_fk": {
+          "name": "fx_rates_base_code_currencies_code_fk",
+          "tableFrom": "fx_rates",
+          "tableTo": "currencies",
+          "columnsFrom": ["base_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fx_rates_quote_code_currencies_code_fk": {
+          "name": "fx_rates_quote_code_currencies_code_fk",
+          "tableFrom": "fx_rates",
+          "tableTo": "currencies",
+          "columnsFrom": ["quote_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fx_rates_base_code_quote_code_provider_effective_at_pk": {
+          "name": "fx_rates_base_code_quote_code_provider_effective_at_pk",
+          "columns": ["base_code", "quote_code", "provider", "effective_at"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates_latest": {
+      "name": "fx_rates_latest",
+      "schema": "",
+      "columns": {
+        "base_code": {
+          "name": "base_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_code": {
+          "name": "quote_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fx_latest_quote_base": {
+          "name": "idx_fx_latest_quote_base",
+          "columns": [
+            {
+              "expression": "quote_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fx_latest_provider": {
+          "name": "idx_fx_latest_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fx_rates_latest_base_code_currencies_code_fk": {
+          "name": "fx_rates_latest_base_code_currencies_code_fk",
+          "tableFrom": "fx_rates_latest",
+          "tableTo": "currencies",
+          "columnsFrom": ["base_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fx_rates_latest_quote_code_currencies_code_fk": {
+          "name": "fx_rates_latest_quote_code_currencies_code_fk",
+          "tableFrom": "fx_rates_latest",
+          "tableTo": "currencies",
+          "columnsFrom": ["quote_code"],
+          "columnsTo": ["code"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "fx_rates_latest_base_code_quote_code_provider_pk": {
+          "name": "fx_rates_latest_base_code_quote_code_provider_pk",
+          "columns": ["base_code", "quote_code", "provider"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/kit/dapp/drizzle/meta/_journal.json
+++ b/kit/dapp/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1751893018659,
+      "tag": "0000_perpetual_joseph",
+      "breakpoints": true
+    }
+  ]
+}

--- a/kit/dapp/src/lib/db/schema.ts
+++ b/kit/dapp/src/lib/db/schema.ts
@@ -20,3 +20,4 @@
 
 export * from "./schemas/auth";
 export * from "./schemas/settings";
+export * from "./schemas/exchange-rates";

--- a/kit/dapp/src/lib/db/schemas/exchange-rates.ts
+++ b/kit/dapp/src/lib/db/schemas/exchange-rates.ts
@@ -173,7 +173,14 @@ export const insertFxRateSchema = createInsertSchema(fxRates, {
   baseCode: fiatCurrency(),
   quoteCode: fiatCurrency(),
   provider: exchangeRateProvider,
-  rate: z.string().refine((val) => /^\d+(\.\d+)?$/u.test(val), {
+  rate: z.string().refine((val) => {
+    // Simple validation for positive decimal numbers
+    const parts = val.split('.');
+    if (parts.length > 2) return false;
+    if (parts[0] && !/^\d+$/.exec(parts[0])) return false;
+    if (parts[1] && !/^\d+$/.exec(parts[1])) return false;
+    return true;
+  }, {
     message: "Invalid rate format",
   }),
   effectiveAt: z.date(),
@@ -185,7 +192,14 @@ export const insertFxRateLatestSchema = createInsertSchema(fxRatesLatest, {
   baseCode: fiatCurrency(),
   quoteCode: fiatCurrency(),
   provider: exchangeRateProvider,
-  rate: z.string().refine((val) => /^\d+(\.\d+)?$/u.test(val), {
+  rate: z.string().refine((val) => {
+    // Simple validation for positive decimal numbers
+    const parts = val.split('.');
+    if (parts.length > 2) return false;
+    if (parts[0] && !/^\d+$/.exec(parts[0])) return false;
+    if (parts[1] && !/^\d+$/.exec(parts[1])) return false;
+    return true;
+  }, {
     message: "Invalid rate format",
   }),
   effectiveAt: z.date(),

--- a/kit/dapp/src/lib/db/schemas/exchange-rates.ts
+++ b/kit/dapp/src/lib/db/schemas/exchange-rates.ts
@@ -173,16 +173,19 @@ export const insertFxRateSchema = createInsertSchema(fxRates, {
   baseCode: fiatCurrency(),
   quoteCode: fiatCurrency(),
   provider: exchangeRateProvider,
-  rate: z.string().refine((val) => {
-    // Simple validation for positive decimal numbers
-    const parts = val.split('.');
-    if (parts.length > 2) return false;
-    if (parts[0] && !/^\d+$/.exec(parts[0])) return false;
-    if (parts[1] && !/^\d+$/.exec(parts[1])) return false;
-    return true;
-  }, {
-    message: "Invalid rate format",
-  }),
+  rate: z.string().refine(
+    (val) => {
+      // Simple validation for positive decimal numbers
+      const parts = val.split(".");
+      if (parts.length > 2) return false;
+      if (parts[0] && !/^\d+$/.exec(parts[0])) return false;
+      if (parts[1] && !/^\d+$/.exec(parts[1])) return false;
+      return true;
+    },
+    {
+      message: "Invalid rate format",
+    }
+  ),
   effectiveAt: z.date(),
 });
 export const selectFxRateSchema = createSelectSchema(fxRates);
@@ -192,16 +195,19 @@ export const insertFxRateLatestSchema = createInsertSchema(fxRatesLatest, {
   baseCode: fiatCurrency(),
   quoteCode: fiatCurrency(),
   provider: exchangeRateProvider,
-  rate: z.string().refine((val) => {
-    // Simple validation for positive decimal numbers
-    const parts = val.split('.');
-    if (parts.length > 2) return false;
-    if (parts[0] && !/^\d+$/.exec(parts[0])) return false;
-    if (parts[1] && !/^\d+$/.exec(parts[1])) return false;
-    return true;
-  }, {
-    message: "Invalid rate format",
-  }),
+  rate: z.string().refine(
+    (val) => {
+      // Simple validation for positive decimal numbers
+      const parts = val.split(".");
+      if (parts.length > 2) return false;
+      if (parts[0] && !/^\d+$/.exec(parts[0])) return false;
+      if (parts[1] && !/^\d+$/.exec(parts[1])) return false;
+      return true;
+    },
+    {
+      message: "Invalid rate format",
+    }
+  ),
   effectiveAt: z.date(),
 });
 export const selectFxRateLatestSchema = createSelectSchema(fxRatesLatest);

--- a/kit/dapp/src/lib/db/schemas/exchange-rates.ts
+++ b/kit/dapp/src/lib/db/schemas/exchange-rates.ts
@@ -1,0 +1,201 @@
+/**
+ * Exchange Rates Database Schema
+ *
+ * This module defines the database schema for foreign exchange rate storage and management.
+ * It implements a production-grade FX microservice schema optimized for:
+ * - Fast retrieval of latest rates (p99 < 2ms)
+ * - Efficient historical data scanning for charting and analysis
+ * - Support for multiple rate providers
+ * - High-precision rates for both traditional and crypto currencies
+ *
+ * The schema uses a dual-table design:
+ * - `fx_rates`: Immutable time-series data for historical records
+ * - `fx_rates_latest`: Hot cache table for current rates
+ *
+ * @module ExchangeRatesSchema
+ */
+
+import {
+  pgTable,
+  varchar,
+  numeric,
+  timestamp,
+  primaryKey,
+  index,
+} from "drizzle-orm/pg-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { fiatCurrency } from "@/lib/zod/validators/fiat-currency";
+import { z } from "zod/v4";
+
+/**
+ * Reference table for currency metadata.
+ * Stores ISO-4217 currency codes and their properties.
+ */
+export const currencies = pgTable("currencies", {
+  /** ISO-4217 currency code (e.g., 'USD', 'EUR') */
+  code: varchar("code", { length: 3 }).primaryKey(),
+  /** Full currency name */
+  name: varchar("name", { length: 64 }).notNull(),
+  /** Number of decimal places used by the currency (0-8) */
+  decimals: numeric("decimals", { precision: 2, scale: 0 }).default("2"),
+});
+
+/**
+ * Time-series table for exchange rate history.
+ * Stores all historical exchange rates with provider information.
+ * Designed for partitioning by month for efficient archival.
+ *
+ * Primary key: (baseCode, quoteCode, provider, effectiveAt)
+ * This ensures uniqueness and supports efficient point lookups.
+ */
+export const fxRates = pgTable(
+  "fx_rates",
+  {
+    /** Base currency code (what you're converting from) */
+    baseCode: varchar("base_code", { length: 3 })
+      .references(() => currencies.code, { onDelete: "restrict" })
+      .notNull(),
+    /** Quote currency code (what you're converting to) */
+    quoteCode: varchar("quote_code", { length: 3 })
+      .references(() => currencies.code, { onDelete: "restrict" })
+      .notNull(),
+    /** Rate provider identifier (e.g., 'ECB', 'er-api') */
+    provider: varchar("provider", { length: 32 }).notNull(),
+    /** Timestamp when this rate became effective */
+    effectiveAt: timestamp("effective_at", { withTimezone: true }).notNull(),
+    /** Exchange rate with high precision (38 digits, 18 decimal places) */
+    rate: numeric("rate", { precision: 38, scale: 18 }).notNull(),
+    /** Timestamp when this record was created */
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    /** Composite primary key for uniqueness */
+    primaryKey({
+      columns: [
+        table.baseCode,
+        table.quoteCode,
+        table.provider,
+        table.effectiveAt,
+      ],
+    }),
+    /** Index for reverse pair lookups (e.g., finding EUR/USD when you have USD/EUR) */
+    index("idx_fx_rates_quote_base_ts").on(
+      table.quoteCode,
+      table.baseCode,
+      table.effectiveAt.desc()
+    ),
+    /** Index for forward pair lookups */
+    index("idx_fx_rates_base_quote_ts").on(
+      table.baseCode,
+      table.quoteCode,
+      table.effectiveAt.desc()
+    ),
+    /** Index for provider-specific queries */
+    index("idx_fx_rates_provider_ts").on(
+      table.provider,
+      table.effectiveAt.desc()
+    ),
+  ]
+);
+
+/**
+ * Latest rates cache table for O(1) retrieval.
+ * Maintains exactly one row per currency pair and provider.
+ * This small table (<1000 rows) stays in memory for sub-millisecond access.
+ *
+ * Updated via UPSERT whenever new rates arrive.
+ */
+export const fxRatesLatest = pgTable(
+  "fx_rates_latest",
+  {
+    /** Base currency code */
+    baseCode: varchar("base_code", { length: 3 })
+      .references(() => currencies.code, { onDelete: "restrict" })
+      .notNull(),
+    /** Quote currency code */
+    quoteCode: varchar("quote_code", { length: 3 })
+      .references(() => currencies.code, { onDelete: "restrict" })
+      .notNull(),
+    /** Rate provider identifier */
+    provider: varchar("provider", { length: 32 }).notNull(),
+    /** Current exchange rate */
+    rate: numeric("rate", { precision: 38, scale: 18 }).notNull(),
+    /** When this rate became effective */
+    effectiveAt: timestamp("effective_at", { withTimezone: true }).notNull(),
+    /** When this record was last updated */
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    /** Primary key ensures one rate per pair/provider */
+    primaryKey({
+      columns: [table.baseCode, table.quoteCode, table.provider],
+    }),
+    /** Index for reverse pair lookups */
+    index("idx_fx_latest_quote_base").on(table.quoteCode, table.baseCode),
+    /** Index for finding all rates from a provider */
+    index("idx_fx_latest_provider").on(table.provider),
+  ]
+);
+
+/**
+ * Type exports for TypeScript usage
+ */
+export type Currency = typeof currencies.$inferSelect;
+export type NewCurrency = typeof currencies.$inferInsert;
+export type FxRate = typeof fxRates.$inferSelect;
+export type NewFxRate = typeof fxRates.$inferInsert;
+export type FxRateLatest = typeof fxRatesLatest.$inferSelect;
+export type NewFxRateLatest = typeof fxRatesLatest.$inferInsert;
+
+/**
+ * Zod schemas for validation
+ */
+
+// Currency schemas
+export const insertCurrencySchema = createInsertSchema(currencies, {
+  code: fiatCurrency(),
+  decimals: z
+    .string()
+    .regex(/^\d{1,2}$/)
+    .optional(),
+});
+export const selectCurrencySchema = createSelectSchema(currencies);
+
+// Exchange rate providers
+const exchangeRateProvider = z.enum(["er-api", "ECB", "manual"]);
+
+// FX rates schemas
+export const insertFxRateSchema = createInsertSchema(fxRates, {
+  baseCode: fiatCurrency(),
+  quoteCode: fiatCurrency(),
+  provider: exchangeRateProvider,
+  rate: z.string().refine((val) => /^\d+(\.\d+)?$/u.test(val), {
+    message: "Invalid rate format",
+  }),
+  effectiveAt: z.date(),
+});
+export const selectFxRateSchema = createSelectSchema(fxRates);
+
+// FX rates latest schemas
+export const insertFxRateLatestSchema = createInsertSchema(fxRatesLatest, {
+  baseCode: fiatCurrency(),
+  quoteCode: fiatCurrency(),
+  provider: exchangeRateProvider,
+  rate: z.string().refine((val) => /^\d+(\.\d+)?$/u.test(val), {
+    message: "Invalid rate format",
+  }),
+  effectiveAt: z.date(),
+});
+export const selectFxRateLatestSchema = createSelectSchema(fxRatesLatest);
+
+// Parsed types from schemas
+export type InsertCurrency = z.infer<typeof insertCurrencySchema>;
+export type SelectCurrency = z.infer<typeof selectCurrencySchema>;
+export type InsertFxRate = z.infer<typeof insertFxRateSchema>;
+export type SelectFxRate = z.infer<typeof selectFxRateSchema>;
+export type InsertFxRateLatest = z.infer<typeof insertFxRateLatestSchema>;
+export type SelectFxRateLatest = z.infer<typeof selectFxRateLatestSchema>;

--- a/kit/dapp/src/lib/zod/validators/fiat-currency.test.ts
+++ b/kit/dapp/src/lib/zod/validators/fiat-currency.test.ts
@@ -12,9 +12,10 @@ describe("fiatCurrency", () => {
       expect(validator.parse("JPY")).toBe("JPY");
     });
 
-    it("should transform to uppercase", () => {
-      expect(validator.parse("usd")).toBe("USD");
-      expect(validator.parse("eur")).toBe("EUR");
+    it("should only accept uppercase codes", () => {
+      expect(validator.parse("CHF")).toBe("CHF");
+      expect(validator.parse("AUD")).toBe("AUD");
+      expect(validator.parse("SGD")).toBe("SGD");
     });
   });
 
@@ -26,10 +27,11 @@ describe("fiatCurrency", () => {
       expect(() => validator.parse("")).toThrow();
     });
 
-    it("should accept and transform mixed case codes", () => {
-      expect(validator.parse("usd")).toBe("USD");
-      expect(validator.parse("eur")).toBe("EUR");
-      expect(validator.parse("Usd")).toBe("USD");
+    it("should reject lowercase and mixed case codes", () => {
+      expect(() => validator.parse("usd")).toThrow();
+      expect(() => validator.parse("eur")).toThrow();
+      expect(() => validator.parse("Usd")).toThrow();
+      expect(() => validator.parse("UsD")).toThrow();
     });
 
     it("should reject non-3-letter codes", () => {
@@ -48,7 +50,7 @@ describe("fiatCurrency", () => {
 
   describe("safeParse", () => {
     it("should return success for valid currency", () => {
-      const result = validator.safeParse("chf");
+      const result = validator.safeParse("CHF");
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data).toBe("CHF");
@@ -69,7 +71,7 @@ describe("fiatCurrency", () => {
     });
 
     it("should handle safeParse", () => {
-      const result = validator.safeParse("aud");
+      const result = validator.safeParse("AUD");
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data).toBe("AUD");

--- a/kit/dapp/src/lib/zod/validators/fiat-currency.ts
+++ b/kit/dapp/src/lib/zod/validators/fiat-currency.ts
@@ -24,7 +24,7 @@ function getValidFiatCurrencies(): string[] {
 
     // Exclude currencies without decimal information
     // Exclude currencies without decimal information
-    if (!currency || typeof currency.digits !== 'number') return false;
+    if (!currency || typeof currency.digits !== "number") return false;
 
     return true;
   });
@@ -66,7 +66,7 @@ export function getCurrencyMetadata(
 
   return {
     name: currency.currency,
-    decimals: typeof currency.digits === 'number' ? currency.digits : 2,
+    decimals: typeof currency.digits === "number" ? currency.digits : 2,
   };
 }
 

--- a/kit/dapp/src/lib/zod/validators/fiat-currency.ts
+++ b/kit/dapp/src/lib/zod/validators/fiat-currency.ts
@@ -6,22 +6,38 @@
  * in digital asset platforms and stablecoin systems.
  * @module FiatCurrencyValidation
  */
+import * as cc from "currency-codes";
 import { z } from "zod/v4";
 
 /**
- * Supported fiat currency codes (ISO 4217).
- * @remarks
- * Major global currencies supported by the platform:
- * - `USD`: United States Dollar
- * - `EUR`: Euro
- * - `GBP`: British Pound Sterling
- * - `JPY`: Japanese Yen
- * - `CHF`: Swiss Franc
- * - `CAD`: Canadian Dollar
- * - `AUD`: Australian Dollar
- * - `AED`: United Arab Emirates Dirham
- * - `SGD`: Singapore Dollar
- * - `SAR`: Saudi Arabian Riyal
+ * Get all valid ISO 4217 currency codes.
+ * Filters out cryptocurrencies and test currencies.
+ */
+function getValidFiatCurrencies(): string[] {
+  return cc.codes().filter((code) => {
+    const currency = cc.code(code);
+    if (!currency) return false;
+
+    // Exclude test currencies (XTS), precious metals (XAU, XAG, etc.),
+    // and special drawing rights (XDR)
+    if (code.startsWith("X")) return false;
+
+    // Exclude currencies without decimal information
+    if (!("digits" in currency) || currency.digits == null) return false;
+
+    return true;
+  });
+}
+
+/**
+ * All valid fiat currency codes from ISO 4217.
+ * Dynamically generated from currency-codes package.
+ */
+export const allFiatCurrencies = getValidFiatCurrencies();
+
+/**
+ * Supported fiat currency codes for the platform.
+ * A curated subset of major global currencies.
  */
 export const fiatCurrencies = [
   "USD",
@@ -37,36 +53,60 @@ export const fiatCurrencies = [
 ] as const;
 
 /**
+ * Get currency metadata from ISO 4217 data.
+ * @param code - Currency code
+ * @returns Currency metadata or undefined
+ */
+export function getCurrencyMetadata(
+  code: string
+): { name: string; decimals: number } | undefined {
+  const currency = cc.code(code);
+  if (!currency) return undefined;
+
+  return {
+    name: currency.currency,
+    decimals: currency.digits ?? 2,
+  };
+}
+
+/**
+ * Currency metadata for supported fiat currencies.
+ * Dynamically generated from currency-codes package.
+ */
+export const fiatCurrencyMetadata = Object.fromEntries(
+  fiatCurrencies.map((code) => {
+    const metadata = getCurrencyMetadata(code);
+    return [code, metadata ?? { name: code, decimals: 2 }];
+  })
+) as Record<FiatCurrency, { name: string; decimals: number }>;
+
+/**
  * Creates a Zod schema that validates fiat currency codes.
- * Automatically converts input to uppercase before validation.
+ * Only accepts uppercase ISO 4217 currency codes.
  * @returns A Zod schema for fiat currency validation
  * @example
  * ```typescript
  * const schema = fiatCurrency();
  *
- * // Valid currencies (case-insensitive)
+ * // Valid currencies (must be uppercase)
  * schema.parse("USD");  // "USD"
- * schema.parse("usd");  // "USD" (converted to uppercase)
- * schema.parse("eur");  // "EUR"
+ * schema.parse("EUR");  // "EUR"
  * schema.parse("GBP");  // "GBP"
  *
  * // Invalid currencies
+ * schema.parse("usd");  // Throws - must be uppercase
  * schema.parse("BTC");  // Throws - cryptocurrency
  * schema.parse("CNY");  // Throws - not in supported list
  * ```
  */
 export const fiatCurrency = () =>
-  z
-    .string()
-    .transform((val) => val.toUpperCase()) // Normalize to uppercase
-    .pipe(z.enum(fiatCurrencies)) // Validate against allowed currencies
-    .describe("Fiat currency code");
+  z.enum(fiatCurrencies).describe("Fiat currency code (ISO 4217)");
 
 /**
  * Type representing a validated fiat currency code.
- * Ensures type safety.
+ * Uses the literal union type from the const array for better type safety.
  */
-export type FiatCurrency = z.infer<ReturnType<typeof fiatCurrency>>;
+export type FiatCurrency = (typeof fiatCurrencies)[number];
 
 /**
  * Type guard to check if a value is a valid fiat currency.
@@ -74,7 +114,7 @@ export type FiatCurrency = z.infer<ReturnType<typeof fiatCurrency>>;
  * @returns `true` if the value is a valid fiat currency, `false` otherwise
  * @example
  * ```typescript
- * const userInput: unknown = "eur";
+ * const userInput: unknown = "EUR";
  * if (isFiatCurrency(userInput)) {
  *   // TypeScript knows userInput is FiatCurrency
  *   console.log(`Valid currency: ${userInput}`); // "EUR"
@@ -94,13 +134,14 @@ export function isFiatCurrency(value: unknown): value is FiatCurrency {
 /**
  * Safely parse and return a fiat currency or throw an error.
  * @param value - The value to parse as a fiat currency
- * @returns The validated fiat currency code (uppercase)
+ * @returns The validated fiat currency code
  * @throws {Error} If the value is not a valid fiat currency
  * @example
  * ```typescript
  * try {
- *   const currency = getFiatCurrency("usd"); // Returns "USD"
+ *   const currency = getFiatCurrency("USD"); // Returns "USD"
  *   const invalid = getFiatCurrency("BTC"); // Throws Error
+ *   const lowercase = getFiatCurrency("usd"); // Throws Error - must be uppercase
  * } catch (error) {
  *   console.error("Invalid fiat currency provided");
  * }

--- a/kit/dapp/src/lib/zod/validators/fiat-currency.ts
+++ b/kit/dapp/src/lib/zod/validators/fiat-currency.ts
@@ -23,7 +23,8 @@ function getValidFiatCurrencies(): string[] {
     if (code.startsWith("X")) return false;
 
     // Exclude currencies without decimal information
-    if (!("digits" in currency) || currency.digits == null) return false;
+    // Exclude currencies without decimal information
+    if (!currency || typeof currency.digits !== 'number') return false;
 
     return true;
   });
@@ -65,7 +66,7 @@ export function getCurrencyMetadata(
 
   return {
     name: currency.currency,
-    decimals: currency.digits ?? 2,
+    decimals: typeof currency.digits === 'number' ? currency.digits : 2,
   };
 }
 

--- a/kit/dapp/src/orpc/routes/contract.ts
+++ b/kit/dapp/src/orpc/routes/contract.ts
@@ -1,4 +1,5 @@
 import { accountContract } from "@/orpc/routes/account/account.contract";
+import { exchangeRatesContract } from "@/orpc/routes/exchange-rates/exchange-rates.contract";
 import { metricsContract } from "@/orpc/routes/metrics/metrics.contract";
 import { settingsContract } from "@/orpc/routes/settings/settings.contract";
 import { systemContract } from "@/orpc/routes/system/system.contract";
@@ -34,6 +35,18 @@ export const contract = {
    * @see {@link ./account/account.router} - Corresponding router implementation
    */
   account: accountContract,
+
+  /**
+   * Exchange rates API contract.
+   *
+   * Contains type definitions for foreign exchange rate management procedures.
+   * Provides real-time currency conversion rates with automatic synchronization
+   * from external providers, manual rate overrides, and historical data access
+   * for analytics and charting.
+   * @see {@link ./exchange-rates/exchange-rates.contract} - Exchange rates contract implementation
+   * @see {@link ./exchange-rates/exchange-rates.router} - Corresponding router implementation
+   */
+  exchangeRates: exchangeRatesContract,
 
   /**
    * Metrics-related API contract.

--- a/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.contract.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.contract.ts
@@ -1,0 +1,161 @@
+/**
+ * Exchange Rates API Contract
+ *
+ * This module defines the API contracts for exchange rate management,
+ * including CRUD operations and synchronization with external providers.
+ * @module ExchangeRatesContract
+ */
+import { baseContract } from "@/orpc/procedures/base.contract";
+import { z } from "zod/v4";
+import {
+  ExchangeRatesListSchema,
+  ExchangeRatesListOutputSchema,
+} from "./routes/exchange-rates.list.schema";
+import { ExchangeRatesReadSchema } from "./routes/exchange-rates.read.schema";
+import { ExchangeRatesUpdateSchema } from "./routes/exchange-rates.update.schema";
+import { ExchangeRatesDeleteSchema } from "./routes/exchange-rates.delete.schema";
+import { ExchangeRatesSyncSchema } from "./routes/exchange-rates.sync.schema";
+import { ExchangeRatesHistorySchema } from "./routes/exchange-rates.history.schema";
+
+/**
+ * Contract for reading the current exchange rate between two currencies.
+ * Automatically triggers sync if no rates exist.
+ */
+const read = baseContract
+  .route({
+    method: "GET",
+    path: "/exchange-rates/:baseCurrency/:quoteCurrency",
+    description: "Get the current exchange rate between two currencies",
+    successDescription: "Exchange rate retrieved successfully",
+    tags: ["exchange-rates"],
+  })
+  .input(ExchangeRatesReadSchema)
+  .output(
+    z
+      .object({
+        baseCurrency: z.string(),
+        quoteCurrency: z.string(),
+        rate: z.number(),
+        effectiveAt: z.date(),
+      })
+      .nullable()
+  );
+
+/**
+ * Contract for listing all available exchange rates.
+ * Supports filtering by base currency and pagination.
+ */
+const list = baseContract
+  .route({
+    method: "GET",
+    path: "/exchange-rates",
+    description: "List all available exchange rates with pagination",
+    successDescription: "Exchange rates list retrieved successfully",
+    tags: ["exchange-rates"],
+  })
+  .input(ExchangeRatesListSchema)
+  .output(ExchangeRatesListOutputSchema);
+
+/**
+ * Contract for manually updating an exchange rate.
+ * Useful for overrides or when external APIs are unavailable.
+ */
+const update = baseContract
+  .route({
+    method: "PUT",
+    path: "/exchange-rates/:baseCurrency/:quoteCurrency",
+    description: "Manually update an exchange rate",
+    successDescription: "Exchange rate updated successfully",
+    tags: ["exchange-rates"],
+  })
+  .input(ExchangeRatesUpdateSchema)
+  .output(
+    z.object({
+      success: z.boolean(),
+      rate: z.object({
+        baseCurrency: z.string(),
+        quoteCurrency: z.string(),
+        rate: z.number(),
+        effectiveAt: z.date(),
+      }),
+    })
+  );
+
+/**
+ * Contract for deleting a manual exchange rate.
+ * Only manual rates can be deleted, not synced rates.
+ */
+const del = baseContract
+  .route({
+    method: "DELETE",
+    path: "/exchange-rates/:baseCurrency/:quoteCurrency",
+    description: "Delete a manual exchange rate",
+    successDescription: "Exchange rate deleted successfully",
+    tags: ["exchange-rates"],
+  })
+  .input(ExchangeRatesDeleteSchema)
+  .output(z.object({ success: z.boolean() }));
+
+/**
+ * Contract for synchronizing exchange rates with external providers.
+ * Fetches latest rates from configured APIs and updates the database.
+ */
+const sync = baseContract
+  .route({
+    method: "POST",
+    path: "/exchange-rates/sync",
+    description: "Synchronize exchange rates with external providers",
+    successDescription: "Exchange rates synchronized successfully",
+    tags: ["exchange-rates"],
+  })
+  .input(ExchangeRatesSyncSchema)
+  .output(
+    z.object({
+      success: z.boolean(),
+      ratesUpdated: z.number(),
+      provider: z.string(),
+      syncedAt: z.date(),
+    })
+  );
+
+/**
+ * Contract for retrieving historical exchange rates.
+ * Useful for charting and historical analysis.
+ */
+const history = baseContract
+  .route({
+    method: "GET",
+    path: "/exchange-rates/:baseCurrency/:quoteCurrency/history",
+    description: "Get historical exchange rates for a currency pair",
+    successDescription: "Historical rates retrieved successfully",
+    tags: ["exchange-rates"],
+  })
+  .input(ExchangeRatesHistorySchema)
+  .output(
+    z.array(
+      z.object({
+        baseCurrency: z.string(),
+        quoteCurrency: z.string(),
+        rate: z.number(),
+        effectiveAt: z.date(),
+      })
+    )
+  );
+
+/**
+ * Exchange rates API contract collection.
+ *
+ * Provides comprehensive exchange rate management including:
+ * - Real-time rate queries with automatic sync
+ * - Manual rate updates for overrides
+ * - Historical data access
+ * - External provider synchronization
+ */
+export const exchangeRatesContract = {
+  read,
+  list,
+  update,
+  delete: del,
+  sync,
+  history,
+};

--- a/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.contract.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.contract.ts
@@ -115,6 +115,7 @@ const sync = baseContract
       ratesUpdated: z.number(),
       provider: z.string(),
       syncedAt: z.date(),
+      message: z.string().optional(),
     })
   );
 

--- a/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.contract.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.contract.ts
@@ -113,7 +113,6 @@ const sync = baseContract
     z.object({
       success: z.boolean(),
       ratesUpdated: z.number(),
-      provider: z.string(),
       syncedAt: z.date(),
       message: z.string().optional(),
     })

--- a/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.router.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.router.ts
@@ -1,0 +1,42 @@
+/**
+ * Exchange Rates Router Module
+ *
+ * Aggregates all exchange rate-related route handlers into a single
+ * exportable object for the main ORPC router.
+ * @module ExchangeRatesRouter
+ */
+import { del } from "./routes/exchange-rates.delete";
+import { history } from "./routes/exchange-rates.history";
+import { list } from "./routes/exchange-rates.list";
+import { read } from "./routes/exchange-rates.read";
+import { sync } from "./routes/exchange-rates.sync";
+import { update } from "./routes/exchange-rates.update";
+
+/**
+ * Exchange rates router module.
+ *
+ * Provides comprehensive exchange rate management including:
+ * - Real-time rate queries with automatic sync
+ * - Manual rate updates for overrides
+ * - Historical data access for analytics
+ * - External provider synchronization
+ * - CRUD operations for rate management
+ *
+ * Current routes:
+ * - read: GET /exchange-rates/:baseCurrency/:quoteCurrency - Get current rate
+ * - list: GET /exchange-rates - List all rates with pagination
+ * - update: PUT /exchange-rates/:baseCurrency/:quoteCurrency - Manual update
+ * - delete: DELETE /exchange-rates/:baseCurrency/:quoteCurrency - Delete manual rate
+ * - sync: POST /exchange-rates/sync - Sync with external providers
+ * - history: GET /exchange-rates/:baseCurrency/:quoteCurrency/history - Get historical rates
+ */
+const routes = {
+  read,
+  list,
+  update,
+  delete: del,
+  sync,
+  history,
+};
+
+export default routes;

--- a/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.test.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.test.ts
@@ -190,7 +190,7 @@ describe("Exchange Rates Schemas", () => {
         "AED",
         "SGD",
         "SAR",
-      ];
+      ] as const;
 
       for (const currency of supportedCurrencies) {
         const input = {

--- a/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.test.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/exchange-rates.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Exchange Rates Tests
+ *
+ * Unit tests for exchange rates schemas and validation.
+ * @module ExchangeRatesTests
+ */
+import { safeParse } from "@/lib/zod";
+import { describe, expect, it, mock } from "bun:test";
+import { ExchangeRatesReadSchema } from "./routes/exchange-rates.read.schema";
+import { ExchangeRatesUpdateSchema } from "./routes/exchange-rates.update.schema";
+import { ExchangeRatesDeleteSchema } from "./routes/exchange-rates.delete.schema";
+import { ExchangeRatesHistorySchema } from "./routes/exchange-rates.history.schema";
+import { ExchangeRatesListSchema } from "./routes/exchange-rates.list.schema";
+import { ExchangeRatesSyncSchema } from "./routes/exchange-rates.sync.schema";
+import { exchangeRateApiResponseSchema } from "./schemas";
+
+// Mock the logger to avoid console output during tests
+mock.module("@settlemint/sdk-utils/logging", () => ({
+  createLogger: () => ({
+    error: mock(() => undefined),
+    warn: mock(() => undefined),
+    info: mock(() => undefined),
+    debug: mock(() => undefined),
+  }),
+}));
+
+describe("Exchange Rates Schemas", () => {
+  describe("Read Schema", () => {
+    it("should validate read schema correctly", () => {
+      const validInput = {
+        baseCurrency: "USD" as const,
+        quoteCurrency: "EUR" as const,
+      };
+      const result = safeParse(ExchangeRatesReadSchema, validInput);
+      expect(result).toEqual(validInput);
+    });
+
+    it("should reject invalid currency codes", () => {
+      const invalidInput = {
+        baseCurrency: "INVALID",
+        quoteCurrency: "EUR",
+      };
+      expect(() => safeParse(ExchangeRatesReadSchema, invalidInput)).toThrow();
+    });
+
+    it("should validate update schema with manual rate", () => {
+      const validInput = {
+        baseCurrency: "USD" as const,
+        quoteCurrency: "EUR" as const,
+        rate: 0.85,
+      };
+      const result = safeParse(ExchangeRatesUpdateSchema, validInput);
+      expect(result.baseCurrency).toBe("USD");
+      expect(result.quoteCurrency).toBe("EUR");
+      expect(result.rate).toBe(0.85);
+    });
+
+    it("should validate update schema", () => {
+      const validInput = {
+        baseCurrency: "USD" as const,
+        quoteCurrency: "EUR" as const,
+        rate: 0.86,
+      };
+      const result = safeParse(ExchangeRatesUpdateSchema, validInput);
+      expect(result.rate).toBe(0.86);
+    });
+
+    it("should validate delete schema", () => {
+      const validInput = {
+        baseCurrency: "USD" as const,
+        quoteCurrency: "EUR" as const,
+      };
+      const result = safeParse(ExchangeRatesDeleteSchema, validInput);
+      expect(result).toEqual(validInput);
+    });
+
+    it("should validate API response schema", () => {
+      const validResponse = {
+        result: "success",
+        provider: "er-api.com",
+        documentation: "https://www.exchangerate-api.com",
+        terms_of_use: "https://www.exchangerate-api.com/terms",
+        time_last_update_unix: 1735776000,
+        time_last_update_utc: "Thu, 02 Jan 2025 00:00:00 +0000",
+        time_next_update_unix: 1735862400,
+        time_next_update_utc: "Fri, 03 Jan 2025 00:00:00 +0000",
+        time_eol_unix: 0,
+        base_code: "USD",
+        rates: {
+          USD: 1,
+          EUR: 0.85,
+          GBP: 0.73,
+          JPY: 110.5,
+        },
+      };
+      const result = safeParse(exchangeRateApiResponseSchema, validResponse);
+      expect(result.result).toBe("success");
+      expect(result.rates.EUR).toBe(0.85);
+    });
+  });
+
+  describe("History Schema", () => {
+    it("should validate history query parameters", () => {
+      const validInput = {
+        baseCurrency: "USD",
+        quoteCurrency: "EUR",
+        startDate: new Date("2025-01-01"),
+        endDate: new Date("2025-01-31"),
+        limit: 100,
+      };
+      const result = safeParse(ExchangeRatesHistorySchema, validInput);
+      expect(result.baseCurrency).toBe("USD");
+      expect(result.quoteCurrency).toBe("EUR");
+      expect(result.limit).toBe(100);
+    });
+
+    it("should apply default limit", () => {
+      const validInput = {
+        baseCurrency: "USD",
+        quoteCurrency: "EUR",
+      };
+      const result = safeParse(ExchangeRatesHistorySchema, validInput);
+      expect(result.limit).toBe(100);
+    });
+  });
+
+  describe("List Schema", () => {
+    it("should validate list parameters with filters", () => {
+      const validInput = {
+        offset: 0,
+        limit: 20,
+        baseCurrency: "USD",
+        quoteCurrency: "EUR",
+      };
+      const result = safeParse(ExchangeRatesListSchema, validInput);
+      expect(result.offset).toBe(0);
+      expect(result.limit).toBe(20);
+      expect(result.baseCurrency).toBe("USD");
+      expect(result.orderDirection).toBe("asc"); // default
+      expect(result.orderBy).toBe("id"); // default
+    });
+
+    it("should work without optional filters", () => {
+      const validInput = {
+        offset: 20,
+        limit: 50,
+      };
+      const result = safeParse(ExchangeRatesListSchema, validInput);
+      expect(result.offset).toBe(20);
+      expect(result.limit).toBe(50);
+      expect(result.baseCurrency).toBeUndefined();
+    });
+
+    it("should apply defaults when no params provided", () => {
+      const validInput = {};
+      const result = safeParse(ExchangeRatesListSchema, validInput);
+      expect(result.offset).toBe(0);
+      expect(result.limit).toBeUndefined();
+      expect(result.orderDirection).toBe("asc");
+      expect(result.orderBy).toBe("id");
+    });
+  });
+
+  describe("Sync Schema", () => {
+    it("should validate sync parameters", () => {
+      const validInput = {
+        force: true,
+      };
+      const result = safeParse(ExchangeRatesSyncSchema, validInput);
+      expect(result.force).toBe(true);
+    });
+
+    it("should apply defaults", () => {
+      const validInput = {};
+      const result = safeParse(ExchangeRatesSyncSchema, validInput);
+      expect(result.force).toBe(false);
+    });
+  });
+
+  describe("Currency Validation", () => {
+    it("should validate all supported fiat currencies", () => {
+      const supportedCurrencies = [
+        "USD",
+        "EUR",
+        "GBP",
+        "JPY",
+        "CHF",
+        "CAD",
+        "AUD",
+        "AED",
+        "SGD",
+        "SAR",
+      ];
+
+      for (const currency of supportedCurrencies) {
+        const input = {
+          baseCurrency: currency,
+          quoteCurrency: "USD",
+        };
+        const result = safeParse(ExchangeRatesReadSchema, input);
+        expect(result.baseCurrency).toBe(currency);
+      }
+    });
+
+    it("should reject unsupported currencies", () => {
+      const unsupportedCurrencies = ["XYZ", "ABC", "123", "BTC", "ETH"];
+
+      for (const currency of unsupportedCurrencies) {
+        const input = {
+          baseCurrency: currency,
+          quoteCurrency: "USD",
+        };
+        expect(() => safeParse(ExchangeRatesReadSchema, input)).toThrow();
+      }
+    });
+  });
+
+  describe("Rate Precision", () => {
+    it("should handle high-precision decimal rates", () => {
+      const input = {
+        baseCurrency: "USD",
+        quoteCurrency: "EUR",
+        rate: 0.12345678901234,
+      };
+      const result = safeParse(ExchangeRatesUpdateSchema, input);
+      expect(result.rate).toBe(0.12345678901234);
+    });
+
+    it("should handle very large rates", () => {
+      const input = {
+        baseCurrency: "USD",
+        quoteCurrency: "JPY",
+        rate: 150.123456789,
+      };
+      const result = safeParse(ExchangeRatesUpdateSchema, input);
+      expect(result.rate).toBe(150.123456789);
+    });
+
+    it("should reject negative rates", () => {
+      const input = {
+        baseCurrency: "USD",
+        quoteCurrency: "EUR",
+        rate: -0.85,
+      };
+      expect(() => safeParse(ExchangeRatesUpdateSchema, input)).toThrow();
+    });
+
+    it("should reject zero rates", () => {
+      const input = {
+        baseCurrency: "USD",
+        quoteCurrency: "EUR",
+        rate: 0,
+      };
+      expect(() => safeParse(ExchangeRatesUpdateSchema, input)).toThrow();
+    });
+  });
+});

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.delete.schema.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.delete.schema.ts
@@ -1,0 +1,26 @@
+/**
+ * Exchange Rates Delete Schema
+ *
+ * Validation schemas for deleting manual exchange rates.
+ * @module ExchangeRatesDeleteSchema
+ */
+import { fiatCurrency } from "@/lib/zod/validators/fiat-currency";
+import { z } from "zod/v4";
+
+/**
+ * Schema for deleting a manual exchange rate.
+ * Only manual rates can be deleted.
+ */
+export const ExchangeRatesDeleteSchema = z.object({
+  /** Base currency code */
+  baseCurrency: fiatCurrency(),
+  /** Quote currency code */
+  quoteCurrency: fiatCurrency(),
+});
+
+/**
+ * Type for exchange rate delete input
+ */
+export type ExchangeRatesDeleteInput = z.infer<
+  typeof ExchangeRatesDeleteSchema
+>;

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.delete.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.delete.ts
@@ -1,0 +1,66 @@
+/**
+ * Exchange Rates Delete Route
+ *
+ * Allows deletion of manual exchange rates.
+ * @module ExchangeRatesDelete
+ */
+import { fxRatesLatest } from "@/lib/db/schema";
+import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
+import { authRouter } from "@/orpc/procedures/auth.router";
+import { and, eq } from "drizzle-orm";
+
+/**
+ * Exchange rate delete route handler.
+ *
+ * Deletes a manual exchange rate from the latest rates table.
+ * Only rates with provider="manual" can be deleted to prevent
+ * accidental removal of synced rates from external providers.
+ *
+ * Note: This only removes the rate from the latest table.
+ * Historical entries in the time-series table are preserved
+ * for audit and compliance purposes.
+ *
+ * Authentication: Required
+ * Permissions: Requires admin role
+ * Method: DELETE /exchange-rates/:baseCurrency/:quoteCurrency
+ * @param input - Delete parameters
+ * @param context - Request context with database connection
+ * @returns Success status
+ */
+export const del = authRouter.exchangeRates.delete
+  .use(databaseMiddleware)
+  .handler(async ({ input, context }) => {
+    const { baseCurrency, quoteCurrency } = input;
+
+    // Check if the rate exists and is manual
+    const [existingRate] = await context.db
+      .select()
+      .from(fxRatesLatest)
+      .where(
+        and(
+          eq(fxRatesLatest.baseCode, baseCurrency),
+          eq(fxRatesLatest.quoteCode, quoteCurrency),
+          eq(fxRatesLatest.provider, "manual")
+        )
+      )
+      .limit(1);
+
+    if (!existingRate) {
+      throw new Error(
+        `No manual exchange rate found for ${baseCurrency}/${quoteCurrency}`
+      );
+    }
+
+    // Delete the manual rate
+    await context.db
+      .delete(fxRatesLatest)
+      .where(
+        and(
+          eq(fxRatesLatest.baseCode, baseCurrency),
+          eq(fxRatesLatest.quoteCode, quoteCurrency),
+          eq(fxRatesLatest.provider, "manual")
+        )
+      );
+
+    return { success: true };
+  });

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.history.schema.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.history.schema.ts
@@ -1,0 +1,45 @@
+/**
+ * Exchange Rates History Schema
+ *
+ * Validation schemas for retrieving historical exchange rates.
+ * @module ExchangeRatesHistorySchema
+ */
+import {
+  fiatCurrency,
+  type FiatCurrency,
+} from "@/lib/zod/validators/fiat-currency";
+import { z } from "zod/v4";
+
+/**
+ * Schema for querying historical exchange rates.
+ * Supports date range filtering.
+ */
+export const ExchangeRatesHistorySchema = z.object({
+  /** Base currency code */
+  baseCurrency: fiatCurrency(),
+  /** Quote currency code */
+  quoteCurrency: fiatCurrency(),
+  /** Start date for historical data */
+  startDate: z.date().optional(),
+  /** End date for historical data */
+  endDate: z.date().optional(),
+  /** Maximum number of records to return */
+  limit: z.number().int().positive().max(1000).default(100),
+});
+
+/**
+ * Type for exchange rate history input
+ */
+export type ExchangeRatesHistoryInput = z.infer<
+  typeof ExchangeRatesHistorySchema
+>;
+
+/**
+ * Type for historical exchange rate item
+ */
+export interface ExchangeRateHistoryItem {
+  baseCurrency: FiatCurrency;
+  quoteCurrency: FiatCurrency;
+  rate: number;
+  effectiveAt: Date;
+}

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.history.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.history.ts
@@ -1,0 +1,75 @@
+/**
+ * Exchange Rates History Route
+ *
+ * Retrieves historical exchange rates for a currency pair.
+ * @module ExchangeRatesHistory
+ */
+import { fxRates } from "@/lib/db/schema";
+import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
+import { publicRouter } from "@/orpc/procedures/public.router";
+import { and, between, desc, eq } from "drizzle-orm";
+
+/**
+ * Exchange rate history route handler.
+ *
+ * Retrieves historical exchange rates for a specific currency pair.
+ * Useful for:
+ * - Creating charts and visualizations
+ * - Analyzing rate trends
+ * - Backtesting and reconciliation
+ *
+ * Results are ordered by effective date (newest first) and limited
+ * to prevent excessive data transfer.
+ *
+ * Authentication: Not required (public endpoint)
+ * Method: GET /exchange-rates/:baseCurrency/:quoteCurrency/history
+ * @param input - History query parameters
+ * @param context - Request context with database connection
+ * @returns Array of historical rates
+ */
+export const history = publicRouter.exchangeRates.history
+  .use(databaseMiddleware)
+  .handler(async ({ input, context }) => {
+    const {
+      baseCurrency,
+      quoteCurrency,
+      startDate,
+      endDate,
+      limit = 100,
+    } = input;
+
+    // Build filter conditions
+    const conditions = [
+      eq(fxRates.baseCode, baseCurrency),
+      eq(fxRates.quoteCode, quoteCurrency),
+    ];
+
+    if (startDate && endDate) {
+      conditions.push(between(fxRates.effectiveAt, startDate, endDate));
+    } else if (startDate) {
+      conditions.push(eq(fxRates.effectiveAt, startDate));
+    } else if (endDate) {
+      conditions.push(eq(fxRates.effectiveAt, endDate));
+    }
+
+    // Query historical rates
+    const rates = await context.db
+      .select({
+        baseCurrency: fxRates.baseCode,
+        quoteCurrency: fxRates.quoteCode,
+        rate: fxRates.rate,
+        effectiveAt: fxRates.effectiveAt,
+      })
+      .from(fxRates)
+      .where(and(...conditions))
+      .orderBy(desc(fxRates.effectiveAt))
+      .limit(limit);
+
+    // Convert rates to numbers
+    return rates.map((rate) => ({
+      baseCurrency: rate.baseCurrency,
+      quoteCurrency: rate.quoteCurrency,
+      rate: Number.parseFloat(rate.rate),
+      effectiveAt: rate.effectiveAt,
+    }));
+  });

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.list.schema.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.list.schema.ts
@@ -1,0 +1,55 @@
+/**
+ * Exchange Rates List Schema
+ *
+ * Validation schemas for listing exchange rates with pagination.
+ * @module ExchangeRatesListSchema
+ */
+import {
+  fiatCurrency,
+  type FiatCurrency,
+} from "@/lib/zod/validators/fiat-currency";
+import { ListSchema } from "@/orpc/routes/common/schemas/list.schema";
+import { z } from "zod/v4";
+
+/**
+ * Schema for listing exchange rates with optional filters.
+ */
+export const ExchangeRatesListSchema = ListSchema.extend({
+  /** Optional base currency filter */
+  baseCurrency: fiatCurrency().optional(),
+  /** Optional quote currency filter */
+  quoteCurrency: fiatCurrency().optional(),
+});
+
+/**
+ * Output schema for exchange rates list response.
+ */
+export const ExchangeRatesListOutputSchema = z.object({
+  /** Array of exchange rate records */
+  items: z.array(
+    z.object({
+      baseCurrency: fiatCurrency(),
+      quoteCurrency: fiatCurrency(),
+      rate: z.number(),
+      effectiveAt: z.date(),
+      updatedAt: z.date(),
+    })
+  ),
+  /** Total number of records */
+  totalCount: z.number(),
+  /** Current offset */
+  offset: z.number(),
+  /** Current limit */
+  limit: z.number().optional(),
+});
+
+/**
+ * Type for the exchange rate list item
+ */
+export interface ExchangeRateListItem {
+  baseCurrency: FiatCurrency;
+  quoteCurrency: FiatCurrency;
+  rate: number;
+  effectiveAt: Date;
+  updatedAt: Date;
+}

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.list.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.list.ts
@@ -1,0 +1,102 @@
+/**
+ * Exchange Rates List Route
+ *
+ * Lists all available exchange rates with pagination and filtering.
+ * @module ExchangeRatesList
+ */
+import { fxRatesLatest } from "@/lib/db/schema";
+import { type FiatCurrency } from "@/lib/zod/validators/fiat-currency";
+import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
+import { publicRouter } from "@/orpc/procedures/public.router";
+import { and, count, eq, sql } from "drizzle-orm";
+
+/**
+ * Exchange rates list route handler.
+ *
+ * Retrieves a paginated list of current exchange rates.
+ * Supports filtering by base currency, quote currency, and provider.
+ *
+ * Authentication: Not required (public endpoint)
+ * Method: GET /exchange-rates
+ * @param input - List parameters including pagination and filters
+ * @param context - Request context with database connection
+ * @returns Paginated list of exchange rates
+ */
+export const list = publicRouter.exchangeRates.list
+  .use(databaseMiddleware)
+  .handler(async ({ input, context }) => {
+    const {
+      offset = 0,
+      limit,
+      baseCurrency,
+      quoteCurrency,
+      orderBy = "id",
+      orderDirection = "asc",
+    } = input;
+
+    // Build filter conditions
+    const conditions = [];
+    if (baseCurrency) {
+      conditions.push(eq(fxRatesLatest.baseCode, baseCurrency));
+    }
+    if (quoteCurrency) {
+      conditions.push(eq(fxRatesLatest.quoteCode, quoteCurrency));
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Get total count
+    const [countResult] = await context.db
+      .select({ total: count() })
+      .from(fxRatesLatest)
+      .where(whereClause);
+
+    const total = countResult?.total ?? 0;
+
+    // Map orderBy field to actual column
+    const orderColumn =
+      {
+        id: fxRatesLatest.baseCode, // Default to baseCode for id
+        baseCode: fxRatesLatest.baseCode,
+        quoteCode: fxRatesLatest.quoteCode,
+        rate: fxRatesLatest.rate,
+        effectiveAt: fxRatesLatest.effectiveAt,
+        updatedAt: fxRatesLatest.updatedAt,
+      }[orderBy] ?? fxRatesLatest.baseCode;
+
+    // Get paginated results
+    const orderSql =
+      orderDirection === "desc"
+        ? sql`${orderColumn} DESC`
+        : sql`${orderColumn} ASC`;
+
+    const rates = await context.db
+      .select({
+        baseCurrency: fxRatesLatest.baseCode,
+        quoteCurrency: fxRatesLatest.quoteCode,
+        rate: fxRatesLatest.rate,
+        effectiveAt: fxRatesLatest.effectiveAt,
+        updatedAt: fxRatesLatest.updatedAt,
+      })
+      .from(fxRatesLatest)
+      .where(whereClause)
+      .orderBy(orderSql)
+      .limit(limit ?? 1000)
+      .offset(offset);
+
+    // Transform rates to numbers and ensure type safety
+    const items = rates.map((rate) => ({
+      baseCurrency: rate.baseCurrency as FiatCurrency,
+      quoteCurrency: rate.quoteCurrency as FiatCurrency,
+      rate: Number.parseFloat(rate.rate),
+      effectiveAt: rate.effectiveAt,
+      updatedAt: rate.updatedAt,
+    }));
+
+    return {
+      items,
+      totalCount: total,
+      offset,
+      limit,
+    };
+  });

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.read.schema.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.read.schema.ts
@@ -1,0 +1,48 @@
+/**
+ * Exchange Rates Read Schema
+ *
+ * Validation schemas for reading exchange rates between currency pairs.
+ * @module ExchangeRatesReadSchema
+ */
+import { fiatCurrency } from "@/lib/zod/validators/fiat-currency";
+import { z } from "zod/v4";
+
+/**
+ * Schema for reading an exchange rate.
+ * Validates the currency pair parameters.
+ */
+export const ExchangeRatesReadSchema = z.object({
+  /** Base currency code (converting from) */
+  baseCurrency: fiatCurrency(),
+  /** Quote currency code (converting to) */
+  quoteCurrency: fiatCurrency(),
+});
+
+/**
+ * Schema for exchange rate read response.
+ * Returns the current rate between two currencies.
+ */
+export const ExchangeRatesReadOutputSchema = z
+  .object({
+    /** Base currency code */
+    baseCurrency: fiatCurrency(),
+    /** Quote currency code */
+    quoteCurrency: fiatCurrency(),
+    /** Exchange rate value */
+    rate: z.number().positive(),
+    /** When this rate became effective */
+    effectiveAt: z.date(),
+  })
+  .nullable();
+
+/**
+ * Type for exchange rate read input
+ */
+export type ExchangeRatesReadInput = z.infer<typeof ExchangeRatesReadSchema>;
+
+/**
+ * Type for exchange rate read output
+ */
+export type ExchangeRatesReadOutput = z.infer<
+  typeof ExchangeRatesReadOutputSchema
+>;

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.read.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.read.ts
@@ -1,0 +1,131 @@
+/**
+ * Exchange Rates Read Route
+ *
+ * Retrieves the current exchange rate between two currencies.
+ * Automatically triggers synchronization if no rates exist.
+ * @module ExchangeRatesRead
+ */
+import { fxRatesLatest } from "@/lib/db/schema";
+import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
+import { publicRouter } from "@/orpc/procedures/public.router";
+import { and, eq, or } from "drizzle-orm";
+import { call } from "@orpc/server";
+import { sync } from "./exchange-rates.sync";
+
+/**
+ * Exchange rate read route handler.
+ *
+ * Retrieves the current exchange rate between two currencies.
+ * If no rates exist in the database, automatically triggers a sync
+ * with external providers before returning the rate.
+ *
+ * The handler checks for both direct rates (e.g., USD/EUR) and
+ * inverse rates (e.g., EUR/USD) to maximize data availability.
+ *
+ * Authentication: Not required (public endpoint)
+ * Method: GET /exchange-rates/:baseCurrency/:quoteCurrency
+ * @param input - Currency pair to query
+ * @param context - Request context with database connection
+ * @returns Current exchange rate or null if not available
+ */
+export const read = publicRouter.exchangeRates.read
+  .use(databaseMiddleware)
+  .handler(async ({ input, context }) => {
+    const { baseCurrency, quoteCurrency } = input;
+
+    // Handle same currency case
+    if (baseCurrency === quoteCurrency) {
+      return {
+        baseCurrency,
+        quoteCurrency,
+        rate: 1,
+        effectiveAt: new Date(),
+      };
+    }
+
+    // Build query conditions
+    const conditions = [];
+
+    // Direct rate condition
+    conditions.push(
+      and(
+        eq(fxRatesLatest.baseCode, baseCurrency),
+        eq(fxRatesLatest.quoteCode, quoteCurrency)
+      )
+    );
+
+    // Query for the rate
+    const [rate] = await context.db
+      .select()
+      .from(fxRatesLatest)
+      .where(or(...conditions))
+      .limit(1);
+
+    // If rate exists, return it
+    if (rate) {
+      const rateValue = Number.parseFloat(rate.rate);
+
+      return {
+        baseCurrency: rate.baseCode,
+        quoteCurrency: rate.quoteCode,
+        rate: rateValue,
+        effectiveAt: rate.effectiveAt,
+      };
+    }
+
+    // No rates found - check if we have any rates at all
+    const rateCount = await context.db.select().from(fxRatesLatest).limit(1);
+
+    if (rateCount.length === 0) {
+      try {
+        // Trigger sync with default provider
+        await call(sync, { force: true }, { context });
+
+        // Try to get the rate again after sync
+        const [syncedRate] = await context.db
+          .select()
+          .from(fxRatesLatest)
+          .where(or(...conditions))
+          .limit(1);
+
+        if (syncedRate) {
+          const rateValue = Number.parseFloat(syncedRate.rate);
+
+          return {
+            baseCurrency: syncedRate.baseCode,
+            quoteCurrency: syncedRate.quoteCode,
+            rate: rateValue,
+            effectiveAt: syncedRate.effectiveAt,
+          };
+        }
+      } catch {
+        // Sync failed, continue to return null
+      }
+    }
+
+    // Check for inverse rate
+    const [inverseRate] = await context.db
+      .select()
+      .from(fxRatesLatest)
+      .where(
+        and(
+          eq(fxRatesLatest.baseCode, quoteCurrency),
+          eq(fxRatesLatest.quoteCode, baseCurrency)
+        )
+      )
+      .limit(1);
+
+    if (inverseRate) {
+      const inverseValue = Number.parseFloat(inverseRate.rate);
+      const rateValue = 1 / inverseValue;
+
+      return {
+        baseCurrency,
+        quoteCurrency,
+        rate: rateValue,
+        effectiveAt: inverseRate.effectiveAt,
+      };
+    }
+
+    return null;
+  });

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.read.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.read.ts
@@ -8,7 +8,7 @@
 import { fxRatesLatest } from "@/lib/db/schema";
 import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
 import { publicRouter } from "@/orpc/procedures/public.router";
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, or, desc } from "drizzle-orm";
 import { call } from "@orpc/server";
 import { sync } from "./exchange-rates.sync";
 
@@ -59,6 +59,7 @@ export const read = publicRouter.exchangeRates.read
       .select()
       .from(fxRatesLatest)
       .where(or(...conditions))
+      .orderBy(desc(fxRatesLatest.effectiveAt))
       .limit(1);
 
     // If rate exists, return it
@@ -86,6 +87,7 @@ export const read = publicRouter.exchangeRates.read
           .select()
           .from(fxRatesLatest)
           .where(or(...conditions))
+          .orderBy(desc(fxRatesLatest.effectiveAt))
           .limit(1);
 
         if (syncedRate) {

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.sync.schema.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.sync.schema.ts
@@ -1,0 +1,31 @@
+/**
+ * Exchange Rates Sync Schema
+ *
+ * Validation schemas for synchronizing exchange rates with external providers.
+ * @module ExchangeRatesSyncSchema
+ */
+import { fiatCurrency } from "@/lib/zod/validators/fiat-currency";
+import { z } from "zod/v4";
+import { exchangeRateProvider } from "../schemas";
+
+/**
+ * Schema for syncing exchange rates.
+ * This is an admin operation for updating the exchange rate database.
+ */
+export const ExchangeRatesSyncSchema = z.object({
+  /** Force sync even if recent data exists */
+  force: z.boolean().default(false),
+});
+
+/**
+ * Internal schema with provider for the sync function.
+ * Not exposed to API users.
+ */
+export const ExchangeRatesSyncInternalSchema = z.object({
+  /** Provider to sync from (defaults to 'er-api') */
+  provider: exchangeRateProvider().default("er-api"),
+  /** Base currency to use for sync (defaults to USD) */
+  baseCurrency: fiatCurrency().default("USD"),
+  /** Force sync even if recent data exists */
+  force: z.boolean().default(false),
+});

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.sync.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.sync.ts
@@ -110,7 +110,7 @@ export const sync = authRouter.exchangeRates.sync
     const provider = "er-api"; // Default provider
     const syncedAt = new Date();
     const { db } = context;
-    
+
     // Check if we have recent data (within last hour) unless force is true
     if (!force) {
       const recentRate = await db
@@ -118,18 +118,17 @@ export const sync = authRouter.exchangeRates.sync
         .from(fxRatesLatest)
         .where(sql`${fxRatesLatest.effectiveAt} > NOW() - INTERVAL '1 hour'`)
         .limit(1);
-      
-      if (recentRate.length > 0) {
+
+      if (recentRate.length > 0 && recentRate[0]) {
         return {
           success: true,
           ratesUpdated: 0,
-          provider,
           syncedAt: recentRate[0].effectiveAt,
           message: "Recent rates already exist. Use force=true to update.",
         };
       }
     }
-    
+
     // First, ensure all currencies exist in the database
     const currencyInserts = fiatCurrencies.map((code) =>
       safeParse(insertCurrencySchema, {
@@ -195,7 +194,6 @@ export const sync = authRouter.exchangeRates.sync
     return {
       success: true,
       ratesUpdated,
-      provider,
       syncedAt,
     };
   });

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.sync.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.sync.ts
@@ -1,0 +1,181 @@
+/**
+ * Exchange Rates Sync Route
+ *
+ * Synchronizes exchange rates with external providers.
+ * @module ExchangeRatesSync
+ */
+import {
+  currencies,
+  fxRates,
+  fxRatesLatest,
+  insertCurrencySchema,
+  insertFxRateSchema,
+  insertFxRateLatestSchema,
+} from "@/lib/db/schema";
+import { safeParse } from "@/lib/zod";
+import {
+  fiatCurrencies,
+  fiatCurrencyMetadata,
+} from "@/lib/zod/validators/fiat-currency";
+import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
+import { authRouter } from "@/orpc/procedures/auth.router";
+import { sql } from "drizzle-orm";
+import { exchangeRateApiResponseSchema } from "../schemas";
+
+/**
+ * Fetches exchange rates from the ExchangeRate-API.
+ */
+async function fetchExchangeRatesFromApi(
+  baseCurrency: string
+): Promise<Record<string, number>> {
+  const response = await fetch(
+    `https://open.er-api.com/v6/latest/${baseCurrency}`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch exchange rates: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = await response.json();
+
+  // Validate the response with Zod schema
+  const parsed = safeParse(exchangeRateApiResponseSchema, data);
+
+  return parsed.rates;
+}
+
+/**
+ * Calculates cross rates for all currency pairs.
+ */
+async function calculateCrossRates(): Promise<
+  Map<string, { rate: number; effectiveAt: Date }>
+> {
+  const ratesMap = new Map<string, { rate: number; effectiveAt: Date }>();
+  const effectiveAt = new Date();
+
+  // Fetch USD rates as base currency
+  const usdRates = await fetchExchangeRatesFromApi("USD");
+
+  // Calculate cross rates for all currency pairs
+  for (const baseCurrency of fiatCurrencies) {
+    for (const quoteCurrency of fiatCurrencies) {
+      if (baseCurrency === quoteCurrency) {
+        continue;
+      }
+
+      // Convert through USD
+      const baseRate = usdRates[baseCurrency];
+      const quoteRate = usdRates[quoteCurrency];
+
+      if (!baseRate || !quoteRate) {
+        continue;
+      }
+
+      const baseToUSD = baseCurrency === "USD" ? 1 : 1 / baseRate;
+      const usdToQuote = quoteCurrency === "USD" ? 1 : quoteRate;
+      const crossRate = baseToUSD * usdToQuote;
+
+      ratesMap.set(`${baseCurrency}-${quoteCurrency}`, {
+        rate: crossRate,
+        effectiveAt,
+      });
+    }
+  }
+
+  return ratesMap;
+}
+
+/**
+ * Exchange rate sync route handler.
+ *
+ * Synchronizes exchange rates with external providers.
+ * Requires authentication and appropriate permissions.
+ *
+ * Authentication: Required
+ * Permissions: Requires admin or issuer role
+ * Method: POST /exchange-rates/sync
+ */
+export const sync = authRouter.exchangeRates.sync
+  .use(databaseMiddleware)
+  .handler(async ({ context }) => {
+    // force parameter is reserved for future use
+    const provider = "er-api"; // Default provider
+    const syncedAt = new Date();
+    const { db } = context;
+    // First, ensure all currencies exist in the database
+    const currencyInserts = fiatCurrencies.map((code) =>
+      safeParse(insertCurrencySchema, {
+        code,
+        name: fiatCurrencyMetadata[code].name,
+        decimals: fiatCurrencyMetadata[code].decimals.toString(),
+      })
+    );
+
+    await db.insert(currencies).values(currencyInserts).onConflictDoNothing();
+
+    // Calculate all cross rates
+    const ratesMap = await calculateCrossRates();
+    let ratesUpdated = 0;
+
+    // Begin transaction for atomic updates
+    await db.transaction(async (tx) => {
+      // Insert rates into both tables
+      for (const [pair, data] of ratesMap) {
+        const [baseCurrency, quoteCurrency] = pair.split("-");
+        const rateString = data.rate.toFixed(18);
+
+        // Insert into time-series table
+        const fxRateData = safeParse(insertFxRateSchema, {
+          baseCode: baseCurrency,
+          quoteCode: quoteCurrency,
+          provider,
+          rate: rateString,
+          effectiveAt: data.effectiveAt,
+        });
+
+        await tx.insert(fxRates).values(fxRateData);
+
+        // Upsert into latest rates table
+        const fxRateLatestData = safeParse(insertFxRateLatestSchema, {
+          baseCode: baseCurrency,
+          quoteCode: quoteCurrency,
+          provider,
+          rate: rateString,
+          effectiveAt: data.effectiveAt,
+        });
+
+        await tx
+          .insert(fxRatesLatest)
+          .values(fxRateLatestData)
+          .onConflictDoUpdate({
+            target: [
+              fxRatesLatest.baseCode,
+              fxRatesLatest.quoteCode,
+              fxRatesLatest.provider,
+            ],
+            set: {
+              rate: rateString,
+              effectiveAt: data.effectiveAt,
+              updatedAt: sql`NOW()`,
+            },
+          });
+
+        ratesUpdated++;
+      }
+    });
+
+    return {
+      success: true,
+      ratesUpdated,
+      provider,
+      syncedAt,
+    };
+  });

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.update.schema.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.update.schema.ts
@@ -1,0 +1,52 @@
+/**
+ * Exchange Rates Update Schema
+ *
+ * Validation schemas for manually updating exchange rates.
+ * @module ExchangeRatesUpdateSchema
+ */
+import { fiatCurrency } from "@/lib/zod/validators/fiat-currency";
+import { z } from "zod/v4";
+
+/**
+ * Schema for updating an exchange rate.
+ * Used for manual rate overrides.
+ */
+export const ExchangeRatesUpdateSchema = z.object({
+  /** Base currency code */
+  baseCurrency: fiatCurrency(),
+  /** Quote currency code */
+  quoteCurrency: fiatCurrency(),
+  /** New exchange rate value */
+  rate: z.number().positive("Rate must be positive"),
+  /** Optional effective date (defaults to now) */
+  effectiveAt: z.date().optional(),
+});
+
+/**
+ * Schema for exchange rate update response.
+ */
+export const ExchangeRatesUpdateOutputSchema = z.object({
+  /** Operation success status */
+  success: z.boolean(),
+  /** Updated rate details */
+  rate: z.object({
+    baseCurrency: fiatCurrency(),
+    quoteCurrency: fiatCurrency(),
+    rate: z.number().positive(),
+    effectiveAt: z.date(),
+  }),
+});
+
+/**
+ * Type for exchange rate update input
+ */
+export type ExchangeRatesUpdateInput = z.infer<
+  typeof ExchangeRatesUpdateSchema
+>;
+
+/**
+ * Type for exchange rate update output
+ */
+export type ExchangeRatesUpdateOutput = z.infer<
+  typeof ExchangeRatesUpdateOutputSchema
+>;

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.update.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.update.ts
@@ -102,7 +102,6 @@ export const update = authRouter.exchangeRates.update
         baseCurrency,
         quoteCurrency,
         rate,
-        provider: "manual",
         effectiveAt,
       },
     };

--- a/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.update.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/routes/exchange-rates.update.ts
@@ -1,0 +1,109 @@
+/**
+ * Exchange Rates Update Route
+ *
+ * Allows manual updates of exchange rates.
+ * @module ExchangeRatesUpdate
+ */
+import { currencies, fxRates, fxRatesLatest } from "@/lib/db/schema";
+import { databaseMiddleware } from "@/orpc/middlewares/services/db.middleware";
+import { authRouter } from "@/orpc/procedures/auth.router";
+import { eq, sql } from "drizzle-orm";
+
+/**
+ * Exchange rate update route handler.
+ *
+ * Allows manual updates of exchange rates. This is useful for:
+ * - Overriding rates when external APIs are unavailable
+ * - Setting custom rates for testing
+ * - Correcting incorrect rates
+ *
+ * The handler validates the currencies exist and updates both
+ * the time-series and latest rates tables.
+ *
+ * Authentication: Required
+ * Permissions: Requires admin or issuer role
+ * Method: PUT /exchange-rates/:baseCurrency/:quoteCurrency
+ * @param input - Update parameters including the new rate
+ * @param context - Request context with database connection
+ * @returns Success status and updated rate details
+ */
+export const update = authRouter.exchangeRates.update
+  .use(databaseMiddleware)
+  .handler(async ({ input, context }) => {
+    const {
+      baseCurrency,
+      quoteCurrency,
+      rate,
+      effectiveAt = new Date(),
+    } = input;
+
+    // Validate currencies exist
+    const [baseCurrencyExists] = await context.db
+      .select()
+      .from(currencies)
+      .where(eq(currencies.code, baseCurrency))
+      .limit(1);
+
+    if (!baseCurrencyExists) {
+      throw new Error(`Base currency ${baseCurrency} not found`);
+    }
+
+    const [quoteCurrencyExists] = await context.db
+      .select()
+      .from(currencies)
+      .where(eq(currencies.code, quoteCurrency))
+      .limit(1);
+
+    if (!quoteCurrencyExists) {
+      throw new Error(`Quote currency ${quoteCurrency} not found`);
+    }
+
+    // Convert rate to string for storage
+    const rateString = rate.toFixed(18);
+
+    // Update in transaction
+    await context.db.transaction(async (tx) => {
+      // Insert into time-series table
+      await tx.insert(fxRates).values({
+        baseCode: baseCurrency,
+        quoteCode: quoteCurrency,
+        provider: "manual",
+        rate: rateString,
+        effectiveAt,
+      });
+
+      // Upsert into latest rates table
+      await tx
+        .insert(fxRatesLatest)
+        .values({
+          baseCode: baseCurrency,
+          quoteCode: quoteCurrency,
+          provider: "manual",
+          rate: rateString,
+          effectiveAt,
+        })
+        .onConflictDoUpdate({
+          target: [
+            fxRatesLatest.baseCode,
+            fxRatesLatest.quoteCode,
+            fxRatesLatest.provider,
+          ],
+          set: {
+            rate: rateString,
+            effectiveAt,
+            updatedAt: sql`NOW()`,
+          },
+        });
+    });
+
+    return {
+      success: true,
+      rate: {
+        baseCurrency,
+        quoteCurrency,
+        rate,
+        provider: "manual",
+        effectiveAt,
+      },
+    };
+  });

--- a/kit/dapp/src/orpc/routes/exchange-rates/schemas.ts
+++ b/kit/dapp/src/orpc/routes/exchange-rates/schemas.ts
@@ -1,0 +1,63 @@
+/**
+ * Exchange Rate Schemas
+ *
+ * Internal schemas for exchange rate operations.
+ * Kept close to the route implementations for better cohesion.
+ * @module ExchangeRateSchemas
+ */
+import { z } from "zod/v4";
+
+/**
+ * Supported exchange rate providers.
+ * Each provider has different data sources and update frequencies.
+ */
+export const exchangeRateProviders = ["er-api", "ECB", "manual"] as const;
+
+/**
+ * Schema for exchange rate provider validation.
+ */
+export const exchangeRateProvider = () =>
+  z.enum(exchangeRateProviders).describe("Exchange rate data provider");
+
+/**
+ * Type representing a validated exchange rate provider.
+ */
+export type ExchangeRateProvider = z.infer<
+  ReturnType<typeof exchangeRateProvider>
+>;
+
+/**
+ * Schema for the ExchangeRate-API response.
+ * Used when fetching rates from the er-api.com service.
+ */
+export const exchangeRateApiResponseSchema = z.object({
+  /** API result status */
+  result: z.literal("success"),
+  /** Data provider name */
+  provider: z.string(),
+  /** API documentation URL */
+  documentation: z.string(),
+  /** Terms of use URL */
+  terms_of_use: z.string(),
+  /** Unix timestamp of last update */
+  time_last_update_unix: z.number(),
+  /** UTC timestamp of last update */
+  time_last_update_utc: z.string(),
+  /** Unix timestamp of next update */
+  time_next_update_unix: z.number(),
+  /** UTC timestamp of next update */
+  time_next_update_utc: z.string(),
+  /** Unix timestamp when data expires */
+  time_eol_unix: z.number(),
+  /** Base currency code */
+  base_code: z.string(),
+  /** Exchange rates object */
+  rates: z.record(z.string(), z.number()),
+});
+
+/**
+ * Type representing the ExchangeRate-API response.
+ */
+export type ExchangeRateApiResponse = z.infer<
+  typeof exchangeRateApiResponseSchema
+>;

--- a/kit/dapp/src/orpc/routes/router.ts
+++ b/kit/dapp/src/orpc/routes/router.ts
@@ -28,6 +28,19 @@ export const router = baseRouter.router({
   ),
 
   /**
+   * Exchange rates API procedures.
+   *
+   * Lazy-loaded module containing foreign exchange rate management operations.
+   * Provides real-time currency conversion rates with automatic synchronization
+   * from external providers, manual rate overrides, and historical data access
+   * for analytics and charting.
+   * @see {@link ./exchange-rates/exchange-rates.router} - Exchange rates router implementation
+   */
+  exchangeRates: baseRouter.exchangeRates.lazy(
+    async () => import("./exchange-rates/exchange-rates.router")
+  ),
+
+  /**
    * Metrics-related API procedures.
    *
    * Lazy-loaded module containing aggregated metrics and analytics operations.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
     "extract-env": "bun run tools/extract-env.ts",
     "db:studio": "turbo run db:studio"
   },
-  "dependencies": {},
+  "dependencies": {
+    "currency-codes": "2.2.0",
+    "drizzle-zod": "0.8.2"
+  },
   "devDependencies": {
     "@prettier/plugin-oxc": "0.0.4",
     "@settlemint/sdk-cli": "2.4.1",


### PR DESCRIPTION
## Summary
- Remove `provider` field from exchange rates API responses
- Keep provider field in database schema for internal tracking only
- Provider should not be exposed to external consumers

## Changes
- Removed `provider` field from sync endpoint response
- Removed `provider` field from update endpoint response
- Updated API contract to reflect these changes

## Test plan
- [x] All existing tests pass
- [x] CI build passes
- [ ] Manual testing of exchange rates endpoints confirms provider is not exposed