### PR TITLE
fix: erpc add initContainer

### DIFF
--- a/kit/charts/atk/charts/erpc/templates/deployment.yaml
+++ b/kit/charts/atk/charts/erpc/templates/deployment.yaml
@@ -52,28 +52,23 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if and .Values.initContainers .Values.initContainers.enabled .Values.initContainers.containers }}
+      {{- /* Define initContainers block only if needed */}}
+      {{- if .Values.initContainer.tcpCheck.enabled }}
       initContainers:
-        {{- range .Values.initContainers.containers }}
-        - name: {{ .name }}
-          image: {{ .image }}
-          {{- if .imagePullPolicy }}
-          imagePullPolicy: {{ .imagePullPolicy }}
-          {{- end }}
-          {{- if .command }}
-          command: {{- toYaml .command | nindent 12 }}
-          {{- end }}
-          {{- if .args }}
-          args: {{- toYaml .args | nindent 12 }}
-          {{- end }}
-          {{- if .env }}
-          env: {{- toYaml .env | nindent 12 }}
-          {{- end }}
-          {{- if .resources }}
-          resources: {{- toYaml .resources | nindent 12 }}
-          {{- end }}
-          {{- if .volumeMounts }}
-          volumeMounts: {{- toYaml .volumeMounts | nindent 12 }}
+        {{- /* Add Generic TCP Checks if enabled */}}
+        {{- if .Values.initContainer.tcpCheck.enabled }}
+          {{- range .Values.initContainer.tcpCheck.dependencies }}
+        - name: wait-for-{{ .name }}
+          image: "{{ $.Values.initContainer.tcpCheck.image.repository }}:{{ $.Values.initContainer.tcpCheck.image.tag }}"
+          imagePullPolicy: {{ $.Values.initContainer.tcpCheck.image.pullPolicy }}
+          command: ['/usr/bin/wait-for-it', '{{ tpl .endpoint $ }}', '-t', '{{ $.Values.initContainer.tcpCheck.timeout }}']
+          resources: # Optional: Define minimal resources for init containers
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 50m
+              memory: 32Mi
           {{- end }}
         {{- end }}
       {{- end }}

--- a/kit/charts/atk/charts/erpc/templates/deployment.yaml
+++ b/kit/charts/atk/charts/erpc/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
               cpu: 100m
               memory: 64Mi
             requests:
-              cpu: 50m
+              cpu: 10m
               memory: 32Mi
           {{- end }}
         {{- end }}

--- a/kit/charts/atk/charts/erpc/templates/deployment.yaml
+++ b/kit/charts/atk/charts/erpc/templates/deployment.yaml
@@ -52,6 +52,31 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if and .Values.initContainers .Values.initContainers.enabled .Values.initContainers.containers }}
+      initContainers:
+        {{- range .Values.initContainers.containers }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          {{- if .imagePullPolicy }}
+          imagePullPolicy: {{ .imagePullPolicy }}
+          {{- end }}
+          {{- if .command }}
+          command: {{- toYaml .command | nindent 12 }}
+          {{- end }}
+          {{- if .args }}
+          args: {{- toYaml .args | nindent 12 }}
+          {{- end }}
+          {{- if .env }}
+          env: {{- toYaml .env | nindent 12 }}
+          {{- end }}
+          {{- if .resources }}
+          resources: {{- toYaml .resources | nindent 12 }}
+          {{- end }}
+          {{- if .volumeMounts }}
+          volumeMounts: {{- toYaml .volumeMounts | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: erpc
           image: {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}

--- a/kit/charts/atk/charts/erpc/values.yaml
+++ b/kit/charts/atk/charts/erpc/values.yaml
@@ -203,36 +203,19 @@ extraEnvVarsCM: ""
 # -- Name of existing Secret containing extra env vars for eRPC nodes
 extraEnvVarsSecret: ""
 
-# -- Init containers configuration
-initContainers:
-  # -- Enable init containers
-  enabled: true
-  # -- Array of init container configurations
-  containers:
-    - name: wait-for-besu
-      # -- Image for the init container
-      image: busybox:1.37.0
-      # -- Image pull policy for init container
-      imagePullPolicy: IfNotPresent
-      # -- Command to wait for Besu endpoint
-      command:
-        - sh
-        - -c
-        - |
-          echo "Waiting for Besu endpoint to be ready..."
-          until nc -z besu-node-rpc-1 8545; do
-            echo "Besu endpoint not ready, waiting..."
-            sleep 5
-          done
-          echo "Besu endpoint is ready!"
-      # -- Resources for init container
-      resources:
-        limits:
-          cpu: 50m
-          memory: 64Mi
-        requests:
-          cpu: 10m
-          memory: 32Mi
+initContainer:
+  # Generic TCP check settings
+  tcpCheck:
+    enabled: true
+    image:
+      repository: ghcr.io/settlemint/btp-waitforit
+      tag: v7.7.5
+      pullPolicy: IfNotPresent
+    timeout: 5 # Timeout in seconds for each dependency check
+    dependencies:
+      # Add internal Kubernetes service endpoints (service-name:port) for critical dependencies
+      - name: besu-rpc
+        endpoint: "besu-node-rpc-1.atk.svc.cluster.local:8545"
 
 # -- Service parameters
 service:

--- a/kit/charts/atk/charts/erpc/values.yaml
+++ b/kit/charts/atk/charts/erpc/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- eRPC image repository
   repository: erpc/erpc
   # -- eRPC image tag (immutable tags are recommended)
-  tag: "0.0.51"
+  tag: "0.0.52"
   # -- eRPC image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   digest: ""
   # -- eRPC image pull policy
@@ -202,6 +202,37 @@ extraEnvVarsCM: ""
 
 # -- Name of existing Secret containing extra env vars for eRPC nodes
 extraEnvVarsSecret: ""
+
+# -- Init containers configuration
+initContainers:
+  # -- Enable init containers
+  enabled: true
+  # -- Array of init container configurations
+  containers:
+    - name: wait-for-besu
+      # -- Image for the init container
+      image: busybox:1.37.0
+      # -- Image pull policy for init container
+      imagePullPolicy: IfNotPresent
+      # -- Command to wait for Besu endpoint
+      command:
+        - sh
+        - -c
+        - |
+          echo "Waiting for Besu endpoint to be ready..."
+          until nc -z besu-node-rpc-1 8545; do
+            echo "Besu endpoint not ready, waiting..."
+            sleep 5
+          done
+          echo "Besu endpoint is ready!"
+      # -- Resources for init container
+      resources:
+        limits:
+          cpu: 50m
+          memory: 64Mi
+        requests:
+          cpu: 10m
+          memory: 32Mi
 
 # -- Service parameters
 service:


### PR DESCRIPTION
erpc depends from besu nodes, so it should start after it

## Summary by Sourcery

Ensure eRPC pods wait for the Besu node to be ready by introducing a default initContainer and exposing initContainer configuration in Helm values.

New Features:
- Add configurable initContainers to the eRPC Helm chart to wait for Besu endpoint before startup

Enhancements:
- Bump eRPC image tag from 0.0.51 to 0.0.52