### PR TITLE
fix: temp disable secret codes for onboarding

### DIFF
--- a/kit/dapp/src/lib/auth/plugins/utils.ts
+++ b/kit/dapp/src/lib/auth/plugins/utils.ts
@@ -85,7 +85,7 @@ export function isOnboarded(
     (user.pincodeEnabled && !!user.pincodeVerificationId) ?? false;
   const twoFactorSet =
     (user.twoFactorEnabled && !!user.twoFactorVerificationId) ?? false;
-  const secretCodeSet = !!user.secretCodeVerificationId;
-  const isVerificationSet = (pincodeSet || twoFactorSet) && secretCodeSet;
+  // const secretCodeSet = !!user.secretCodeVerificationId;
+  const isVerificationSet = pincodeSet || twoFactorSet; //&& secretCodeSet;
   return isVerificationSet;
 }


### PR DESCRIPTION
Actual fix coming in https://linear.app/settlemint/issue/ENG-3418/redirect-to-onboarding-wizard-after-local-version-update, this to unblock other devs

## Summary by Sourcery

Bug Fixes:
- Temporarily disable secret code requirement during user onboarding