### PR TITLE
feat(token): add extended token information and percentage formatting

### DIFF
--- a/kit/dapp/languine.lock
+++ b/kit/dapp/languine.lock
@@ -706,6 +706,13 @@ files:
     continue: a0bfb8e59e6c13fc8d990781f77694fe
     deploying: a51242b36009886a35d79b2c94644fb3
     generating: 530a6ed46ff9e1aa707e0af48a465be7
+    transactionHash.copyToClipboard: 07d18cf0faa495f96f68311009edcedd
+    transactionHash.copied: 6d6db52799620de23c1e87d00abde8c4
+    actions.cancel: ea4788705e6873b424c65e91c2846b19
+    verification.pincode.label: dfcbc97f1d21b9867e68fa7179492c4c
+    verification.pincode.description: 88fe2f22ddebcbf34b8318190846d852
+    transaction.waitingForMining: 836fac42d51f640bb9596eeec6193b2c
+    transaction.indexed: 1e2a6eb83ef02a51ca9f4e1300510ee4
   locales/en/dashboard.json:
     title: 2938c7f7e560ed972f8a4f68e80ff834
     subtitle: 7525fec727673326a4fc0363e1a315c7
@@ -1633,6 +1640,27 @@ files:
     actions.createToken: a8b758dea74b70495d59fc03d4f741aa
     actions.viewDetails: 5d5cd268b8acccf04f63d81c5d0d2cab
     actions.viewOnEtherscan: b4a95a0b3c4b23578d23edf3d20265ad
+    actions.viewEvents: 428b4fbeda709b7c79280c209ec09a25
+    actions.pause.label: 891ca908610c298ecb75fff617aab0b3
+    actions.pause.title: f356cde63fae196a41e746b199b17ffd
+    actions.pause.description: cb4ac4a81e5c68a8fd9865925b8701e0
+    actions.pause.submit: 891ca908610c298ecb75fff617aab0b3
+    actions.pause.submitting: b417c2663a27196a7939c1e45073f077
+    actions.pause.messages.preparing: 21ed0072254e33b9d3001e42975db46a
+    actions.pause.messages.submitting: 2a2be388607869b07c26cb3c9ec9275d
+    actions.pause.messages.success: f698948e8256087534eedba873a29240
+    actions.pause.messages.failed: 19ee6dcb9ef8d735e762f2cb35b56fd0
+    actions.pause.messages.error: 5c527ccf14b9d801e45f37da9df422d6
+    actions.unpause.label: f071194584c36a1819c9a520e4f4831e
+    actions.unpause.title: 0b5f03760ef27506258462acfcdff73b
+    actions.unpause.description: 3a233434511883bbe8c9b40a98fffe5e
+    actions.unpause.submit: f071194584c36a1819c9a520e4f4831e
+    actions.unpause.submitting: 1ace292b4389f29753524697190e26b1
+    actions.unpause.messages.preparing: a02dfb9328712fb3910b4439b455cd81
+    actions.unpause.messages.submitting: 280a0ec56016f6570d45edf534be4961
+    actions.unpause.messages.success: 914adb5389a88a54ee17301289f74fc0
+    actions.unpause.messages.failed: 128f98ab5e9c288f0a3727cdc3a0e1c8
+    actions.unpause.messages.error: c68bc6965b2b2a548ec8ddc76517166d
     asset-types.bond: b98e3a37b62f7207c8a0a27e0c0d8777
     asset-types.deposit: b14b4095cfda93c81686ac81dea4dbed
     asset-types.equity: f38992a52cef8611666b2db431b493a6
@@ -1652,7 +1680,9 @@ files:
     details.collateralInformation: 20288cb4d28958851ff9f7678b6dab3c
     details.holders: b099a5b6f9f22eac61e7e3176ff002c7
     details.tokenInformation: 3ec365dd533ddb7ef3d1c111186ce872
-    details\.collateralInformation: 20288cb4d28958851ff9f7678b6dab3c
+    details.events: 87f9f735a1d36793ceaecd4e47124b63
+    details.bondInformation: f4aed737455fe5e668553fc6a4e727d7
+    details.fundInformation: 49cdc84690b56e3b5fd0ac6c8697cd5d
     emptyState.description: 43198125adbbc9360df3baa3c27b64a1
     emptyState.title: 9e3d4f57df7b2dd1a9ce1845a928c2ae
     factory.create.all-completed: b66b74fca70055c14ca5b82433987cd8
@@ -1742,6 +1772,20 @@ files:
     fields.symbolInfo: 7b0d102060da94f561175ac427888fc2
     fields.totalSupply: 7ca9416c0e8045c2d9561012e42c4d15
     fields.totalSupplyInfo: 3ecae88650f3a06fcbcdc398a4de1219
+    fields.cap: 7d243629b266258f2a96321c479b067a
+    fields.capInfo: f40838156a50b70f921396a14b7fc807
+    fields.createdBy: 7b1255f8fdd0cb8751baee55621164e1
+    fields.createdByInfo: 3025041877626aade737a1e692422252
+    fields.redeemedAmount: fc833c8ac97dd4cefb6dcced0c52ed8b
+    fields.redeemedAmountInfo: 0c9de08b8e24f7160e654b36fba9f3fa
+    fields.faceValue: fcc8fc52678a2a1731db874ecaf7b963
+    fields.faceValueInfo: 93005d992e1ee660797a4654f27db7c6
+    fields.isMatured: 8bd12a58e6df5069c4ef452f5459acca
+    fields.isMaturedInfo: b442e48df42d9a1077364b0cee177536
+    fields.maturityDate: 5b4b95542e61bffad2f6d8c9d25d7be6
+    fields.maturityDateInfo: f7389d72164e863cd549f9f5dc70fe26
+    fields.managementFeeBps: 071bb32822e9bf25542b28f8f0676bb3
+    fields.managementFeeBpsInfo: 3b5b19829a4efc6baabc40258ef93f23
     holders.actions.addressCopied: 25c724a38d42cbc9744ae78987f0ec95
     holders.actions.copyAddress: 6b35e4c0b1b3d4d2aef429a90f84e1ab
     holders.actions.viewOnEtherscan: b4a95a0b3c4b23578d23edf3d20265ad
@@ -1757,9 +1801,29 @@ files:
     holders.searchPlaceholder: 115132668c9f3a76321f5d19a50f3e85
     holders.status.active: 4d3d769b812b6faa6b76e1a8abaece2d
     holders.status.frozen: 68abcc3d0869f8a52c2b286b3c511dd3
+    events.title: 86e90e44d3310ede96735064a7f5204e
+    events.description: 6fd9f2dc1f8e8aa189f6d6416a3f3ad5
+    events.actions.viewDetails: 5d5cd268b8acccf04f63d81c5d0d2cab
+    events.actions.copyTransactionHash: b19e2d2127e7b4b400ee4636eb7e9bb8
+    events.actions.transactionHashCopied: 04add36b4b3641de46e29bb9a95c37d2
+    events.actions.viewOnEtherscan: b4a95a0b3c4b23578d23edf3d20265ad
+    events.columns.timestamp: a3d5de3eac8bb00ae86fd1a1005f1500
+    events.columns.txIndex: dadb5eb03e7cc3e26ce09e1b6e3879d8
+    events.columns.event: a4ecfc70574394990cf17bd83df499f7
+    events.columns.sender: 8aace3ec18d83874d22850b7eee93c7d
+    events.details.title: 12ea1a38991aa3bc4992b10adac0f3bc
+    events.details.description: 885b457ae6c7d8d6f29a0a1c2baad9a8
+    events.details.timestamp: 44749712dbec183e983dcd78a7736c41
+    events.details.blockNumber: 56df102bf56600db55a78fe25b377115
+    events.details.transactionHash: a0bd1db035c6e85fbe6f3cbbf3ff28ee
+    events.details.sender: 8aace3ec18d83874d22850b7eee93c7d
+    events.details.asset: 26e9054be7f40079575582b7ad3f7363
+    events.details.eventParameters: 78dc5333bef11d4d5773a47cae409323
+    events.searchPlaceholder: 7e91a24aadbfefc504cc4d945beee2f9
     searchPlaceholder: dc1acdd37e8863627fda626a8a8fc0ce
     status.active: 4d3d769b812b6faa6b76e1a8abaece2d
     status.paused: e99180abf47a8b3a856e0bcb2656990a
+    manage: 34e34c43ec6b943c10a3cc1a1a16fb11
   locales/en/validation.json:
     common.required: 0511ee0d41117aa7b4abaaf102aa513d
     common.invalid: 746bb4d715d73e3619f797a7756096e3

--- a/kit/dapp/locales/ar/common.json
+++ b/kit/dapp/locales/ar/common.json
@@ -3,5 +3,22 @@
   "appName": "مجموعة توكين الأصول",
   "continue": "استمر",
   "deploying": "يتم النشر...",
-  "generating": "يتم التوليد..."
+  "generating": "يتم التوليد...",
+  "transactionHash": {
+    "copyToClipboard": "نسخ تجزئة المعاملة",
+    "copied": "تم النسخ!"
+  },
+  "actions": {
+    "cancel": "إلغاء"
+  },
+  "verification": {
+    "pincode": {
+      "label": "رمز التحقق",
+      "description": "أدخل رمز التحقق المكون من 6 أرقام"
+    }
+  },
+  "transaction": {
+    "waitingForMining": "في انتظار تعدين المعاملة...",
+    "indexed": "تم تأكيد المعاملة وفهرستها"
+  }
 }

--- a/kit/dapp/locales/ar/tokens.json
+++ b/kit/dapp/locales/ar/tokens.json
@@ -135,7 +135,10 @@
     "tokenInformation": "التفاصيل",
     "complianceInformation": "معلومات الامتثال",
     "collateralInformation": "الضمانات",
-    "holders": "الملاك"
+    "holders": "الملاك",
+    "events": "الأحداث",
+    "bondInformation": "معلومات السند",
+    "fundInformation": "معلومات الصندوق"
   },
   "holders": {
     "columns": {
@@ -184,7 +187,21 @@
     "collateralInfo": "مقدار الضمان الذي يدعم هذه العملة",
     "collateralExpiry": "تاريخ انتهاء الضمان",
     "collateralExpiryInfo": "التاريخ الذي تنتهي فيه الضمانات",
-    "noExpiry": "لا يوجد تاريخ انتهاء"
+    "noExpiry": "لا يوجد تاريخ انتهاء",
+    "cap": "الحد الأقصى للإمداد",
+    "capInfo": "الحد الأقصى لعدد الرموز التي يمكن سكها",
+    "createdBy": "أنشأه",
+    "createdByInfo": "عنوان المستخدم الذي أنشأ الرمز",
+    "redeemedAmount": "المبلغ المسترد",
+    "redeemedAmountInfo": "مبلغ الرموز المستردة",
+    "faceValue": "القيمة الاسمية",
+    "faceValueInfo": "القيمة الاسمية للسند",
+    "isMatured": "هل استحق",
+    "isMaturedInfo": "ما إذا كان السند قد استحق",
+    "maturityDate": "تاريخ الاستحقاق",
+    "maturityDateInfo": "تاريخ استحقاق السند",
+    "managementFeeBps": "رسوم الإدارة",
+    "managementFeeBpsInfo": "رسوم إدارة الصندوق"
   },
   "status": {
     "active": "نشط",
@@ -195,7 +212,36 @@
     "copyAddress": "نسخ العنوان",
     "createToken": "إنشاء رمز",
     "viewDetails": "عرض التفاصيل",
-    "viewOnEtherscan": "عرض على Etherscan"
+    "viewOnEtherscan": "عرض على Etherscan",
+    "viewEvents": "عرض الأحداث",
+    "pause": {
+      "label": "تجميد الرمز",
+      "title": "تجميد تحويلات الرمز",
+      "description": "تجميد هذا الرمز سيمنع جميع التحويلات حتى يتم إلغاء تجميده. هذه العملية تتطلب التحقق.",
+      "submit": "تجميد الرمز",
+      "submitting": "يتم التجميد...",
+      "messages": {
+        "preparing": "التحضير لتجميد الرمز...",
+        "submitting": "تقديم معاملة التجميد...",
+        "success": "تم تجميد الرمز بنجاح",
+        "failed": "فشل في تجميد الرمز",
+        "error": "حدث خطأ أثناء تجميد الرمز"
+      }
+    },
+    "unpause": {
+      "label": "إلغاء تجميد الرمز",
+      "title": "إلغاء تجميد تحويلات الرمز",
+      "description": "إلغاء تجميد هذا الرمز سيسمح باستئناف التحويلات. هذه العملية تتطلب التحقق.",
+      "submit": "إلغاء تجميد الرمز",
+      "submitting": "يتم إلغاء التجميد...",
+      "messages": {
+        "preparing": "التحضير لإلغاء تجميد الرمز...",
+        "submitting": "تقديم معاملة إلغاء التجميد...",
+        "success": "تم إلغاء تجميد الرمز بنجاح",
+        "failed": "فشل في إلغاء تجميد الرمز",
+        "error": "حدث خطأ أثناء إلغاء تجميد الرمز"
+      }
+    }
   },
   "bulkActions": {
     "archiveMessage": "سيتم أرشفة {{count}} رمز(رموز). هذا إجراء تجريبي.",
@@ -217,5 +263,33 @@
     "title": "لم يتم العثور على رموز"
   },
   "searchPlaceholder": "ابحث عن الرموز بالاسم أو الرمز أو العنوان...",
-  "details.collateralInformation": "الضمانات"
+  "details.collateralInformation": "الضمانات",
+  "events": {
+    "title": "أحداث الرمز",
+    "description": "النشاط والمعاملات التاريخية لهذا الرمز",
+    "actions": {
+      "viewDetails": "عرض التفاصيل",
+      "copyTransactionHash": "نسخ تجزئة المعاملة",
+      "transactionHashCopied": "تم نسخ تجزئة المعاملة إلى الحافظة",
+      "viewOnEtherscan": "عرض على Etherscan"
+    },
+    "columns": {
+      "timestamp": "الطابع الزمني",
+      "txIndex": "فهرس المعاملة",
+      "event": "الحدث",
+      "sender": "المرسل"
+    },
+    "details": {
+      "title": "تفاصيل الحدث",
+      "description": "{{eventName}} حدث لـ {{tokenName}}",
+      "timestamp": "التاريخ",
+      "blockNumber": "رقم الكتلة",
+      "transactionHash": "تجزئة المعاملة",
+      "sender": "المرسل",
+      "asset": "الأصل",
+      "eventParameters": "معلمات الحدث"
+    },
+    "searchPlaceholder": "ابحث عن الأحداث حسب النوع، المرسل..."
+  },
+  "manage": "إدارة"
 }

--- a/kit/dapp/locales/de/common.json
+++ b/kit/dapp/locales/de/common.json
@@ -3,5 +3,22 @@
   "appName": "Asset-Tokenisierungs-Kit",
   "continue": "Fortfahren",
   "deploying": "Wird bereitgestellt...",
-  "generating": "Wird generiert..."
+  "generating": "Wird generiert...",
+  "transactionHash": {
+    "copyToClipboard": "Transaktions-Hash kopieren",
+    "copied": "Kopiert!"
+  },
+  "actions": {
+    "cancel": "Abbrechen"
+  },
+  "verification": {
+    "pincode": {
+      "label": "Bestätigungscode",
+      "description": "Geben Sie Ihren 6-stelligen Bestätigungscode ein"
+    }
+  },
+  "transaction": {
+    "waitingForMining": "Warten auf das Mining der Transaktion...",
+    "indexed": "Transaktion bestätigt und indiziert"
+  }
 }

--- a/kit/dapp/locales/de/tokens.json
+++ b/kit/dapp/locales/de/tokens.json
@@ -4,7 +4,36 @@
     "copyAddress": "Adresse kopieren",
     "createToken": "Token erstellen",
     "viewDetails": "Details anzeigen",
-    "viewOnEtherscan": "Auf Etherscan anzeigen"
+    "viewOnEtherscan": "Auf Etherscan anzeigen",
+    "viewEvents": "Ereignisse anzeigen",
+    "pause": {
+      "label": "Token pausieren",
+      "title": "Token-Übertragungen pausieren",
+      "description": "Das Pausieren dieses Tokens verhindert alle Übertragungen, bis es wieder aktiviert wird. Diese Aktion erfordert eine Bestätigung.",
+      "submit": "Token pausieren",
+      "submitting": "Wird pausiert...",
+      "messages": {
+        "preparing": "Bereite das Pausieren des Tokens vor...",
+        "submitting": "Pausen-Transaktion wird eingereicht...",
+        "success": "Token erfolgreich pausiert",
+        "failed": "Fehler beim Pausieren des Tokens",
+        "error": "Ein Fehler ist beim Pausieren des Tokens aufgetreten"
+      }
+    },
+    "unpause": {
+      "label": "Token wieder aktivieren",
+      "title": "Token-Übertragungen wieder aktivieren",
+      "description": "Das Wiederaktivieren dieses Tokens ermöglicht es, die Übertragungen fortzusetzen. Diese Aktion erfordert eine Bestätigung.",
+      "submit": "Token wieder aktivieren",
+      "submitting": "Wird wieder aktiviert...",
+      "messages": {
+        "preparing": "Bereite das Wiederaktivieren des Tokens vor...",
+        "submitting": "Wiederaktivierungs-Transaktion wird eingereicht...",
+        "success": "Token erfolgreich wieder aktiviert",
+        "failed": "Fehler beim Wiederaktivieren des Tokens",
+        "error": "Ein Fehler ist beim Wiederaktivieren des Tokens aufgetreten"
+      }
+    }
   },
   "bulkActions": {
     "archiveMessage": "Würde {{count}} Token archivieren. Dies ist eine Demomaßnahme.",
@@ -162,7 +191,10 @@
     "tokenInformation": "Einzelheiten",
     "complianceInformation": "Compliance-Informationen",
     "collateralInformation": "Sicherheit",
-    "holders": "Inhaber"
+    "holders": "Inhaber",
+    "events": "Ereignisse",
+    "bondInformation": "Anleiheinformationen",
+    "fundInformation": "Fondinformationen"
   },
   "holders": {
     "columns": {
@@ -211,11 +243,53 @@
     "collateralInfo": "Der Betrag der Sicherheit, der dieses Token absichert",
     "collateralExpiry": "Ablaufdatum der Sicherheit",
     "collateralExpiryInfo": "Das Datum, an dem die Sicherheit abläuft",
-    "noExpiry": "Kein Ablauf"
+    "noExpiry": "Kein Ablauf",
+    "cap": "Maximale Versorgung",
+    "capInfo": "Die maximale Anzahl an Tokens, die geprägt werden kann",
+    "createdBy": "Erstellt von",
+    "createdByInfo": "Die Adresse des Benutzers, der das Token erstellt hat",
+    "redeemedAmount": "Eingelöste Menge",
+    "redeemedAmountInfo": "Die Menge an Tokens, die eingelöst wurden",
+    "faceValue": "Nennwert",
+    "faceValueInfo": "Der Nennwert der Anleihe",
+    "isMatured": "Ist fällig",
+    "isMaturedInfo": "Ob die Anleihe fällig ist",
+    "maturityDate": "Fälligkeitsdatum",
+    "maturityDateInfo": "Das Fälligkeitsdatum der Anleihe",
+    "managementFeeBps": "Verwaltungsgebühr",
+    "managementFeeBpsInfo": "Die Verwaltungsgebühr des Fonds"
   },
   "status": {
     "active": "Aktiv",
     "paused": "Pausiert"
   },
-  "details.collateralInformation": "Sicherheit"
+  "details.collateralInformation": "Sicherheit",
+  "events": {
+    "title": "Token-Ereignisse",
+    "description": "Historische Aktivitäten und Transaktionen für dieses Token",
+    "actions": {
+      "viewDetails": "Details anzeigen",
+      "copyTransactionHash": "Transaktions-Hash kopieren",
+      "transactionHashCopied": "Transaktions-Hash in die Zwischenablage kopiert",
+      "viewOnEtherscan": "Auf Etherscan anzeigen"
+    },
+    "columns": {
+      "timestamp": "Zeitstempel",
+      "txIndex": "Tx-Index",
+      "event": "Ereignis",
+      "sender": "Absender"
+    },
+    "details": {
+      "title": "Ereignisdetails",
+      "description": "{{eventName}}-Ereignis für {{tokenName}}",
+      "timestamp": "Datum",
+      "blockNumber": "Blocknummer",
+      "transactionHash": "Transaktions-Hash",
+      "sender": "Absender",
+      "asset": "Vermögenswert",
+      "eventParameters": "Ereignisparameter"
+    },
+    "searchPlaceholder": "Ereignisse nach Typ, Absender suchen..."
+  },
+  "manage": "Verwalten"
 }

--- a/kit/dapp/locales/en/tokens.json
+++ b/kit/dapp/locales/en/tokens.json
@@ -61,9 +61,10 @@
     "collateralInformation": "Collateral",
     "holders": "Holders",
     "tokenInformation": "Details",
-    "events": "Events"
+    "events": "Events",
+    "bondInformation": "Bond Information",
+    "fundInformation": "Fund Information"
   },
-  "details.collateralInformation": "Collateral",
   "emptyState": {
     "description": "This factory has not created any tokens yet. Create your first token to get started.",
     "title": "No tokens found"
@@ -215,7 +216,21 @@
     "symbol": "Symbol",
     "symbolInfo": "The trading symbol for this token",
     "totalSupply": "Total Supply",
-    "totalSupplyInfo": "The total amount of tokens in circulation"
+    "totalSupplyInfo": "The total amount of tokens in circulation",
+    "cap": "Max Supply",
+    "capInfo": "The maximum amount of tokens that can be minted",
+    "createdBy": "Created By",
+    "createdByInfo": "The address of the user who created the token",
+    "redeemedAmount": "Redeemed Amount",
+    "redeemedAmountInfo": "The amount of tokens redeemed",
+    "faceValue": "Face Value",
+    "faceValueInfo": "The face value of the bond",
+    "isMatured": "Is Matured",
+    "isMaturedInfo": "Whether the bond is matured",
+    "maturityDate": "Maturity Date",
+    "maturityDateInfo": "The maturity date of the bond",
+    "managementFeeBps": "Management Fee",
+    "managementFeeBpsInfo": "The management fee of the fund"
   },
   "holders": {
     "actions": {

--- a/kit/dapp/locales/ja/common.json
+++ b/kit/dapp/locales/ja/common.json
@@ -3,5 +3,22 @@
   "appName": "資産トークン化キット",
   "continue": "続行",
   "deploying": "展開中...",
-  "generating": "生成中..."
+  "generating": "生成中...",
+  "transactionHash": {
+    "copyToClipboard": "トランザクションハッシュをコピー",
+    "copied": "コピーしました！"
+  },
+  "actions": {
+    "cancel": "キャンセル"
+  },
+  "verification": {
+    "pincode": {
+      "label": "確認コード",
+      "description": "6桁の確認コードを入力してください"
+    }
+  },
+  "transaction": {
+    "waitingForMining": "トランザクションのマイニングを待っています...",
+    "indexed": "トランザクションが確認され、インデックス化されました"
+  }
 }

--- a/kit/dapp/locales/ja/tokens.json
+++ b/kit/dapp/locales/ja/tokens.json
@@ -135,7 +135,10 @@
     "tokenInformation": "詳細",
     "complianceInformation": "コンプライアンス情報",
     "collateralInformation": "担保",
-    "holders": "保有者"
+    "holders": "保有者",
+    "events": "イベント",
+    "bondInformation": "債券情報",
+    "fundInformation": "ファンド情報"
   },
   "holders": {
     "columns": {
@@ -184,7 +187,21 @@
     "collateralInfo": "このトークンを裏付ける担保の金額",
     "collateralExpiry": "担保の有効期限",
     "collateralExpiryInfo": "担保が期限切れになる日",
-    "noExpiry": "期限なし"
+    "noExpiry": "期限なし",
+    "cap": "最大供給量",
+    "capInfo": "発行可能なトークンの最大数",
+    "createdBy": "作成者",
+    "createdByInfo": "トークンを作成したユーザーのアドレス",
+    "redeemedAmount": "償還額",
+    "redeemedAmountInfo": "償還されたトークンの量",
+    "faceValue": "額面",
+    "faceValueInfo": "債券の額面",
+    "isMatured": "満期",
+    "isMaturedInfo": "債券が満期かどうか",
+    "maturityDate": "満期日",
+    "maturityDateInfo": "債券の満期日",
+    "managementFeeBps": "管理手数料",
+    "managementFeeBpsInfo": "ファンドの管理手数料"
   },
   "status": {
     "active": "アクティブ",
@@ -195,7 +212,36 @@
     "copyAddress": "アドレスをコピー",
     "createToken": "トークンを作成",
     "viewDetails": "詳細を表示",
-    "viewOnEtherscan": "Etherscanで表示"
+    "viewOnEtherscan": "Etherscanで表示",
+    "viewEvents": "イベントを表示",
+    "pause": {
+      "label": "トークンを一時停止",
+      "title": "トークンの転送を一時停止",
+      "description": "このトークンを一時停止すると、再開されるまで全ての転送が防止されます。この操作には確認が必要です。",
+      "submit": "トークンを一時停止",
+      "submitting": "一時停止中...",
+      "messages": {
+        "preparing": "トークンを一時停止する準備中...",
+        "submitting": "一時停止トランザクションを送信中...",
+        "success": "トークンが正常に一時停止されました",
+        "failed": "トークンの一時停止に失敗しました",
+        "error": "トークンを一時停止中にエラーが発生しました"
+      }
+    },
+    "unpause": {
+      "label": "トークンの再開",
+      "title": "トークンの転送を再開",
+      "description": "このトークンを再開すると、転送が再開されます。この操作には確認が必要です。",
+      "submit": "トークンの再開",
+      "submitting": "再開中...",
+      "messages": {
+        "preparing": "トークンを再開する準備中...",
+        "submitting": "再開トランザクションを送信中...",
+        "success": "トークンが正常に再開されました",
+        "failed": "トークンの再開に失敗しました",
+        "error": "トークンを再開中にエラーが発生しました"
+      }
+    }
   },
   "bulkActions": {
     "archiveMessage": "{{count}}個のトークンをアーカイブします。これはデモアクションです。",
@@ -217,5 +263,33 @@
     "title": "トークンが見つかりません"
   },
   "searchPlaceholder": "名前、シンボル、またはアドレスでトークンを検索...",
-  "details.collateralInformation": "担保"
+  "details.collateralInformation": "担保",
+  "events": {
+    "title": "トークンイベント",
+    "description": "このトークンの履歴活動とトランザクション",
+    "actions": {
+      "viewDetails": "詳細を表示",
+      "copyTransactionHash": "トランザクションハッシュをコピー",
+      "transactionHashCopied": "トランザクションハッシュがクリップボードにコピーされました",
+      "viewOnEtherscan": "Etherscanで表示"
+    },
+    "columns": {
+      "timestamp": "タイムスタンプ",
+      "txIndex": "Txインデックス",
+      "event": "イベント",
+      "sender": "送信者"
+    },
+    "details": {
+      "title": "イベントの詳細",
+      "description": "{{eventName}} イベント for {{tokenName}}",
+      "timestamp": "日付",
+      "blockNumber": "ブロック番号",
+      "transactionHash": "トランザクションハッシュ",
+      "sender": "送信者",
+      "asset": "資産",
+      "eventParameters": "イベントパラメータ"
+    },
+    "searchPlaceholder": "タイプ、送信者でイベントを検索..."
+  },
+  "manage": "管理"
 }

--- a/kit/dapp/src/lib/utils/format-value.tsx
+++ b/kit/dapp/src/lib/utils/format-value.tsx
@@ -291,6 +291,31 @@ export function formatValue(
       );
     }
 
+    case "percentage": {
+      // Check if value is a Dnum (big decimal) first
+      if (isDnum(value)) {
+        // Format Dnum with locale-aware formatting
+        const formatted = formatDnum(value, {
+          locale,
+          digits: 2,
+          trailingZeros: false,
+        });
+
+        return <span className="block tabular-nums">{formatted}%</span>;
+      }
+
+      // Use safe number conversion to handle large values without precision loss
+      const percentageValue = safeToNumber(value);
+
+      // Format with proper locale
+      const formatted = new Intl.NumberFormat(locale, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      }).format(percentageValue);
+
+      return <span className="block tabular-nums">{formatted}%</span>;
+    }
+
     case "number": {
       // Check if value is a Dnum (big decimal) first
       if (isDnum(value)) {

--- a/kit/dapp/src/orpc/middlewares/system/token.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/system/token.middleware.ts
@@ -17,6 +17,23 @@ const READ_TOKEN_QUERY = theGraphGraphql(
       pausable {
         paused
       }
+      capped {
+        cap
+      }
+      createdBy {
+        id
+      }
+      redeemable {
+        redeemedAmount
+      }
+      bond {
+        faceValue
+        isMatured
+        maturityDate
+      }
+      fund {
+        managementFeeBps
+      }
       requiredClaimTopics {
         name
       }

--- a/kit/dapp/src/orpc/routes/token/routes/token.list.schema.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/token.list.schema.ts
@@ -23,6 +23,11 @@ import { z } from "zod/v4";
 export const TokenListSchema = z.array(
   TokenSchema.omit({
     collateral: true,
+    fund: true,
+    bond: true,
+    redeemable: true,
+    capped: true,
+    createdBy: true,
   })
 );
 

--- a/kit/dapp/src/orpc/routes/token/routes/token.read.schema.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/token.read.schema.ts
@@ -110,6 +110,39 @@ export const RawTokenSchema = z.object({
     })
     .nullable()
     .describe("The collateral of the token"),
+  capped: z
+    .object({
+      cap: bigDecimal().describe("The cap of the token"),
+    })
+    .nullable()
+    .describe("The max supply of the token"),
+  createdBy: z
+    .object({
+      id: ethereumAddress.describe(
+        "The address of the user who created the token"
+      ),
+    })
+    .describe("The user who created the token"),
+  redeemable: z
+    .object({
+      redeemedAmount: bigDecimal().describe("The amount of tokens redeemed"),
+    })
+    .nullable()
+    .describe("The amount of tokens redeemed"),
+  bond: z
+    .object({
+      faceValue: bigDecimal().describe("The face value of the bond"),
+      isMatured: z.boolean().describe("Whether the bond is matured"),
+      maturityDate: timestamp().describe("The maturity date of the bond"),
+    })
+    .nullable()
+    .describe("The bond of the token"),
+  fund: z
+    .object({
+      managementFeeBps: bigDecimal().describe("The management fee of the fund"),
+    })
+    .nullable()
+    .describe("The fund of the token"),
   userPermissions: z
     .object({
       roles: z

--- a/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx
@@ -123,6 +123,33 @@ function RouteComponent() {
           type="currency"
           currency={token.symbol}
         />
+
+        <DetailGridItem
+          label={t("tokens:fields.createdBy")}
+          info={t("tokens:fields.createdByInfo")}
+          value={token.createdBy.id}
+          type="address"
+        />
+
+        {token.capped?.cap && (
+          <DetailGridItem
+            label={t("tokens:fields.cap")}
+            info={t("tokens:fields.capInfo")}
+            value={token.capped.cap}
+            type="currency"
+            currency={token.symbol}
+          />
+        )}
+
+        {token.redeemable?.redeemedAmount && (
+          <DetailGridItem
+            label={t("tokens:fields.redeemedAmount")}
+            info={t("tokens:fields.redeemedAmountInfo")}
+            value={token.redeemable.redeemedAmount}
+            type="currency"
+            currency={token.symbol}
+          />
+        )}
       </DetailGrid>
 
       {token.collateral && (
@@ -140,6 +167,42 @@ function RouteComponent() {
             value={token.collateral.expiryTimestamp}
             type="date"
             emptyValue={t("tokens:fields.noExpiry")}
+          />
+        </DetailGrid>
+      )}
+
+      {token.bond && (
+        <DetailGrid title={t("tokens:details.bondInformation")}>
+          <DetailGridItem
+            label={t("tokens:fields.faceValue")}
+            info={t("tokens:fields.faceValueInfo")}
+            value={token.bond.faceValue}
+            type="currency"
+            currency={token.symbol}
+          />
+          <DetailGridItem
+            label={t("tokens:fields.isMatured")}
+            info={t("tokens:fields.isMaturedInfo")}
+            value={token.bond.isMatured}
+            type="boolean"
+          />
+          <DetailGridItem
+            label={t("tokens:fields.maturityDate")}
+            info={t("tokens:fields.maturityDateInfo")}
+            value={token.bond.maturityDate}
+            type="date"
+            emptyValue={t("tokens:fields.noExpiry")}
+          />
+        </DetailGrid>
+      )}
+
+      {token.fund && (
+        <DetailGrid title={t("tokens:details.fundInformation")}>
+          <DetailGridItem
+            label={t("tokens:fields.managementFeeBps")}
+            info={t("tokens:fields.managementFeeBpsInfo")}
+            value={token.fund.managementFeeBps}
+            type="percentage"
           />
         </DetailGrid>
       )}


### PR DESCRIPTION
## Summary

This PR adds percentage formatting support to the formatValue utility and extends token information display with bond-specific and fund-specific fields.

## Key Changes

### 1. Percentage Formatting
- Added new "percentage" type to the `formatValue` utility function
- Supports both regular numbers and Dnum (big decimal) values
- Formats with 0-2 decimal places and appends "%" symbol
- Used for displaying management fees in basis points

### 2. Extended Token Information
- **General fields**: Max Supply (cap), Created By, Redeemed Amount
- **Bond-specific fields**: Face Value, Maturity Date, Is Matured status
- **Fund-specific fields**: Management Fee (displayed as percentage)

### 3. GraphQL & Schema Updates
- Extended GraphQL queries to fetch new token data
- Updated token schemas to include new fields
- Excluded detailed fields from list view for performance

### 4. UI Enhancements
- Added new DetailGrid sections for bond and fund information
- Proper field formatting based on data type (currency, date, percentage, boolean)
- Added comprehensive translations for all new fields

## Testing

✅ All CI checks passed:
- Format: ✅ PASS
- Lint: ✅ PASS  
- TypeScript: ✅ PASS
- Unit tests: ✅ PASS
- Build: ✅ PASS

## Screenshots

The changes add new information sections to the token detail page:
- Bond tokens now display face value, maturity date, and maturity status
- Fund tokens now display management fee as a percentage
- All tokens show additional metadata like creator address and max supply

## Related Issues

Enhances token information display as part of the Asset Tokenization Kit v2.0 feature set.

## Summary by Sourcery

Add percentage formatting support and extend token detail page with creator, supply, redeemed amount, bond, and fund-specific fields, alongside the necessary GraphQL/schema updates and translations.

New Features:
- Add "percentage" format type to formatValue for numeric and Dnum values with up to two decimals and "%" suffix
- Display creator address, max supply, and redeemed amount in token details
- Show bond details: face value, maturity date, and matured status
- Show fund details: management fee as a percentage

Enhancements:
- Update GraphQL queries and Zod schemas to include new token fields and omit them from the token list view
- Add translations for all new token fields across supported locales