### PR TITLE
fix: add proxy-busy-buffers-size for ingress-nginx

### DIFF
--- a/kit/charts/atk/charts/support/values.yaml
+++ b/kit/charts/atk/charts/support/values.yaml
@@ -178,6 +178,7 @@ ingress-nginx:
       proxy-read-timeout: '3600'
       proxy-buffering: 'on'
       proxy-buffer-size: '128k'
+      proxy-busy-buffers-size: '128k'
       proxy-buffers-number: '4'
       proxy-max-temp-file-size: '1024m'
       client-body-buffer-size: '128k'


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add `proxy-busy-buffers-size` with a default value of '128k' to the ingress-nginx values.yaml