### PR TITLE
feat: stepper component 

### DIFF
--- a/kit/dapp/locales/en/asset-designer.json
+++ b/kit/dapp/locales/en/asset-designer.json
@@ -9,6 +9,18 @@
       "token-details": {
         "title": "Token Details",
         "description": "Configure the basic properties of your token"
+      },
+      "selectAssetType": {
+        "title": "Select Asset Type",
+        "description": "Select the type of asset you want to create"
+      },
+      "assetBasics": {
+        "title": "Asset Basics",
+        "description": "Enter the basic details of the asset"
+      },
+      "summary": {
+        "title": "Summary",
+        "description": "Review the details of the asset"
       }
     }
   },

--- a/kit/dapp/src/components/asset-designer/asset-basics.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-basics.tsx
@@ -1,6 +1,6 @@
 import type { AssetDesignerFormData } from "@/components/asset-designer/shared-form";
 import { assetDesignerFormOptions } from "@/components/asset-designer/shared-form";
-import { steps } from "@/components/asset-designer/steps";
+import { useAssetDesignerSteps } from "@/components/asset-designer/steps";
 import { getNextStepName } from "@/components/stepper/utils";
 import { Button } from "@/components/ui/button";
 import { withForm } from "@/hooks/use-app-form";
@@ -12,6 +12,7 @@ export const AssetBasics = withForm({
   props: {},
   render: function Render({ form }) {
     const { t } = useTranslation(["asset-designer"]);
+    const steps = useAssetDesignerSteps();
 
     return (
       <>

--- a/kit/dapp/src/components/asset-designer/asset-basics.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-basics.tsx
@@ -1,7 +1,7 @@
 import type { AssetDesignerFormData } from "@/components/asset-designer/shared-form";
 import { assetDesignerFormOptions } from "@/components/asset-designer/shared-form";
-import { assetDesignerSteps } from "@/components/asset-designer/steps";
-
+import { steps } from "@/components/asset-designer/steps";
+import { getNextStepName } from "@/components/stepper/utils";
 import { Button } from "@/components/ui/button";
 import { withForm } from "@/hooks/use-app-form";
 import { AssetTypeEnum } from "@/lib/zod/validators/asset-types";
@@ -53,7 +53,7 @@ export const AssetBasics = withForm({
         />
         <Button
           onClick={() => {
-            form.setFieldValue("step", assetDesignerSteps.assetBasics.nextStep);
+            form.setFieldValue("step", getNextStepName(steps, "assetBasics"));
           }}
         >
           Next

--- a/kit/dapp/src/components/asset-designer/asset-basics.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-basics.tsx
@@ -1,7 +1,7 @@
 import type { AssetDesignerFormData } from "@/components/asset-designer/shared-form";
 import { assetDesignerFormOptions } from "@/components/asset-designer/shared-form";
 import { useAssetDesignerSteps } from "@/components/asset-designer/steps";
-import { getNextStepName } from "@/components/stepper/utils";
+import { getNextStepId } from "@/components/stepper/utils";
 import { Button } from "@/components/ui/button";
 import { withForm } from "@/hooks/use-app-form";
 import { AssetTypeEnum } from "@/lib/zod/validators/asset-types";
@@ -54,7 +54,7 @@ export const AssetBasics = withForm({
         />
         <Button
           onClick={() => {
-            form.setFieldValue("step", getNextStepName(steps, "assetBasics"));
+            form.setFieldValue("step", getNextStepId(steps, "assetBasics"));
           }}
         >
           Next

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -9,7 +9,7 @@ import {
   type AssetDesignerStepsType,
 } from "@/components/asset-designer/steps";
 import { StepLayout } from "@/components/stepper/step-layout";
-import { getStepByName } from "@/components/stepper/utils";
+import { getStepById } from "@/components/stepper/utils";
 import { useAppForm } from "@/hooks/use-app-form";
 import { useStore } from "@tanstack/react-store";
 import type { JSX } from "react";
@@ -31,7 +31,7 @@ export const AssetDesignerForm = () => {
   });
 
   const stepId = useStore(form.store, (state) => state.values.step);
-  const currentStep = getStepByName(steps, stepId);
+  const currentStep = getStepById(steps, stepId);
 
   const stepComponent: Record<AssetDesignerStepsType, JSX.Element> = {
     selectAssetType: <SelectAssetType form={form} />,

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -40,7 +40,7 @@ export const AssetDesignerForm = () => {
   return (
     <form.AppForm>
       <StepLayout
-        steps={steps}
+        stepsOrGroups={steps}
         currentStep={currentStep}
         onStepChange={(step) => {
           form.setFieldValue("step", step.name);

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -30,13 +30,14 @@ export const AssetDesignerForm = () => {
     },
   });
 
-  const formStep = useStore(form.store, (state) => state.values.step);
+  const stepId = useStore(form.store, (state) => state.values.step);
+  const currentStep = getStepByName(steps, stepId);
+
   const stepComponent: Record<AssetDesignerStepsType, JSX.Element> = {
     selectAssetType: <SelectAssetType form={form} />,
     assetBasics: <AssetBasics form={form} />,
     summary: <div>Summary</div>,
   };
-  const currentStep = getStepByName(steps, formStep);
 
   return (
     <form.AppForm>
@@ -44,12 +45,12 @@ export const AssetDesignerForm = () => {
         stepsOrGroups={steps}
         currentStep={currentStep}
         onStepSelect={(step) => {
-          form.setFieldValue("step", step.name);
+          form.setFieldValue("step", step.id);
         }}
-        navigation="next-and-previous"
+        navigation="next-and-completed"
       >
         {({ currentStep }) => {
-          return stepComponent[currentStep.name];
+          return stepComponent[currentStep.id];
         }}
       </StepLayout>
     </form.AppForm>

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -43,10 +43,10 @@ export const AssetDesignerForm = () => {
       <StepLayout
         stepsOrGroups={steps}
         currentStep={currentStep}
-        onStepChange={(step) => {
+        onStepSelect={(step) => {
           form.setFieldValue("step", step.name);
         }}
-        navigation="bidirectional"
+        navigation="next-and-previous"
       >
         {({ currentStep }) => {
           return stepComponent[currentStep.name];

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -5,7 +5,7 @@ import {
   AssetDesignerFormSchema,
 } from "@/components/asset-designer/shared-form";
 import {
-  steps,
+  useAssetDesignerSteps,
   type AssetDesignerStepsType,
 } from "@/components/asset-designer/steps";
 import { StepLayout } from "@/components/stepper/step-layout";
@@ -15,6 +15,7 @@ import { useStore } from "@tanstack/react-store";
 import type { JSX } from "react";
 
 export const AssetDesignerForm = () => {
+  const steps = useAssetDesignerSteps();
   const form = useAppForm({
     ...assetDesignerFormOptions,
     validators: {
@@ -29,13 +30,13 @@ export const AssetDesignerForm = () => {
     },
   });
 
-  const step = useStore(form.store, (state) => state.values.step);
+  const formStep = useStore(form.store, (state) => state.values.step);
   const stepComponent: Record<AssetDesignerStepsType, JSX.Element> = {
     selectAssetType: <SelectAssetType form={form} />,
     assetBasics: <AssetBasics form={form} />,
     summary: <div>Summary</div>,
   };
-  const currentStep = getStepByName(steps, step);
+  const currentStep = getStepByName(steps, formStep);
 
   return (
     <form.AppForm>

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -47,7 +47,7 @@ export const AssetDesignerForm = () => {
         onStepSelect={(step) => {
           form.setFieldValue("step", step.id);
         }}
-        navigation="next-and-completed"
+        navigationMode="next-and-completed"
       >
         {({ currentStep }) => {
           return stepComponent[currentStep.id];

--- a/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
+++ b/kit/dapp/src/components/asset-designer/asset-designer-form.tsx
@@ -4,8 +4,14 @@ import {
   assetDesignerFormOptions,
   AssetDesignerFormSchema,
 } from "@/components/asset-designer/shared-form";
-import type { AssetDesignerStepsType } from "@/components/asset-designer/steps";
+import {
+  steps,
+  type AssetDesignerStepsType,
+} from "@/components/asset-designer/steps";
+import { StepLayout } from "@/components/stepper/step-layout";
+import { getStepByName } from "@/components/stepper/utils";
 import { useAppForm } from "@/hooks/use-app-form";
+import { useStore } from "@tanstack/react-store";
 import type { JSX } from "react";
 
 export const AssetDesignerForm = () => {
@@ -22,19 +28,29 @@ export const AssetDesignerForm = () => {
       },
     },
   });
+
+  const step = useStore(form.store, (state) => state.values.step);
+  const stepComponent: Record<AssetDesignerStepsType, JSX.Element> = {
+    selectAssetType: <SelectAssetType form={form} />,
+    assetBasics: <AssetBasics form={form} />,
+    summary: <div>Summary</div>,
+  };
+  const currentStep = getStepByName(steps, step);
+
   return (
     <form.AppForm>
-      <form.Subscribe selector={(state) => state.values.step}>
-        {(step) => {
-          const stepComponent: Record<AssetDesignerStepsType, JSX.Element> = {
-            selectAssetType: <SelectAssetType form={form} />,
-            assetBasics: <AssetBasics form={form} />,
-            summary: <div>Summary</div>,
-          };
-
-          return stepComponent[step];
+      <StepLayout
+        steps={steps}
+        currentStep={currentStep}
+        onStepChange={(step) => {
+          form.setFieldValue("step", step.name);
         }}
-      </form.Subscribe>
+        navigation="bidirectional"
+      >
+        {({ currentStep }) => {
+          return stepComponent[currentStep.name];
+        }}
+      </StepLayout>
     </form.AppForm>
   );
 };

--- a/kit/dapp/src/components/asset-designer/select-asset-type.tsx
+++ b/kit/dapp/src/components/asset-designer/select-asset-type.tsx
@@ -1,6 +1,6 @@
 import { assetDesignerFormOptions } from "@/components/asset-designer/shared-form";
 import { useAssetDesignerSteps } from "@/components/asset-designer/steps";
-import { getNextStepName } from "@/components/stepper/utils";
+import { getNextStepId } from "@/components/stepper/utils";
 import { withForm } from "@/hooks/use-app-form";
 import { useSettings } from "@/hooks/use-settings";
 import type { AssetFactoryTypeId } from "@/lib/zod/validators/asset-types";
@@ -54,10 +54,7 @@ export const SelectAssetType = withForm({
         />
         <Button
           onClick={() => {
-            form.setFieldValue(
-              "step",
-              getNextStepName(steps, "selectAssetType")
-            );
+            form.setFieldValue("step", getNextStepId(steps, "selectAssetType"));
           }}
         >
           Next

--- a/kit/dapp/src/components/asset-designer/select-asset-type.tsx
+++ b/kit/dapp/src/components/asset-designer/select-asset-type.tsx
@@ -1,5 +1,5 @@
 import { assetDesignerFormOptions } from "@/components/asset-designer/shared-form";
-import { steps } from "@/components/asset-designer/steps";
+import { useAssetDesignerSteps } from "@/components/asset-designer/steps";
 import { getNextStepName } from "@/components/stepper/utils";
 import { withForm } from "@/hooks/use-app-form";
 import { useSettings } from "@/hooks/use-settings";
@@ -16,6 +16,7 @@ export const SelectAssetType = withForm({
   props: {},
   render: function Render({ form }) {
     const { t } = useTranslation(["asset-designer", "asset-types"]);
+    const steps = useAssetDesignerSteps();
     const [systemAddress] = useSettings("SYSTEM_ADDRESS");
     const { data: systemDetails } = useQuery({
       ...orpc.system.read.queryOptions({

--- a/kit/dapp/src/components/asset-designer/select-asset-type.tsx
+++ b/kit/dapp/src/components/asset-designer/select-asset-type.tsx
@@ -1,5 +1,6 @@
 import { assetDesignerFormOptions } from "@/components/asset-designer/shared-form";
-import { assetDesignerSteps } from "@/components/asset-designer/steps";
+import { steps } from "@/components/asset-designer/steps";
+import { getNextStepName } from "@/components/stepper/utils";
 import { withForm } from "@/hooks/use-app-form";
 import { useSettings } from "@/hooks/use-settings";
 import type { AssetFactoryTypeId } from "@/lib/zod/validators/asset-types";
@@ -54,7 +55,7 @@ export const SelectAssetType = withForm({
           onClick={() => {
             form.setFieldValue(
               "step",
-              assetDesignerSteps.selectAssetType.nextStep
+              getNextStepName(steps, "selectAssetType")
             );
           }}
         >

--- a/kit/dapp/src/components/asset-designer/steps.ts
+++ b/kit/dapp/src/components/asset-designer/steps.ts
@@ -36,20 +36,20 @@ export function useAssetDesignerSteps(): Step<AssetDesignerStepsType>[] {
 
   return [
     {
-      id: 1,
-      name: "selectAssetType",
+      step: 1,
+      id: "selectAssetType",
       label: t("wizard.steps.selectAssetType.title"),
       description: t("wizard.steps.selectAssetType.description"),
     },
     {
-      id: 2,
-      name: "assetBasics",
+      step: 2,
+      id: "assetBasics",
       label: t("wizard.steps.assetBasics.title"),
       description: t("wizard.steps.assetBasics.description"),
     },
     {
-      id: 3,
-      name: "summary",
+      step: 3,
+      id: "summary",
       label: t("wizard.steps.summary.title"),
       description: t("wizard.steps.summary.description"),
     },

--- a/kit/dapp/src/components/asset-designer/steps.ts
+++ b/kit/dapp/src/components/asset-designer/steps.ts
@@ -1,3 +1,4 @@
+import type { Step } from "@/components/stepper/types";
 import { z } from "zod";
 
 export const AssetDesignerSteps = [
@@ -13,19 +14,23 @@ export const AssetDesignerStepSchema = z.object({
   step: AssetDesignerStepsSchema,
 });
 
-export const assetDesignerSteps: Record<
-  AssetDesignerStepsType,
+export const steps: Step<AssetDesignerStepsType>[] = [
   {
-    nextStep: AssetDesignerStepsType;
-  }
-> = {
-  selectAssetType: {
-    nextStep: "assetBasics",
+    id: 1,
+    name: "selectAssetType",
+    label: "Select Asset Type",
+    description: "Select the type of asset you want to create",
   },
-  assetBasics: {
-    nextStep: "summary",
+  {
+    id: 2,
+    name: "assetBasics",
+    label: "Asset Basics",
+    description: "Enter the basic details of the asset",
   },
-  summary: {
-    nextStep: "summary",
+  {
+    id: 3,
+    name: "summary",
+    label: "Summary",
+    description: "Review the details of the asset",
   },
-};
+];

--- a/kit/dapp/src/components/asset-designer/steps.ts
+++ b/kit/dapp/src/components/asset-designer/steps.ts
@@ -1,4 +1,5 @@
 import type { Step } from "@/components/stepper/types";
+import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
 export const AssetDesignerSteps = [
@@ -14,23 +15,43 @@ export const AssetDesignerStepSchema = z.object({
   step: AssetDesignerStepsSchema,
 });
 
-export const steps: Step<AssetDesignerStepsType>[] = [
-  {
-    id: 1,
-    name: "selectAssetType",
-    label: "Select Asset Type",
-    description: "Select the type of asset you want to create",
-  },
-  {
-    id: 2,
-    name: "assetBasics",
-    label: "Asset Basics",
-    description: "Enter the basic details of the asset",
-  },
-  {
-    id: 3,
-    name: "summary",
-    label: "Summary",
-    description: "Review the details of the asset",
-  },
-];
+/**
+ * Hook that provides translated steps for the Asset Designer wizard.
+ *
+ * @returns Array of steps with translated labels and descriptions
+ *
+ * @example
+ * ```tsx
+ * function AssetDesignerWizard() {
+ *   const steps = useAssetDesignerSteps();
+ *
+ *   return (
+ *     <Stepper steps={steps} currentStep="selectAssetType" />
+ *   );
+ * }
+ * ```
+ */
+export function useAssetDesignerSteps(): Step<AssetDesignerStepsType>[] {
+  const { t } = useTranslation("asset-designer");
+
+  return [
+    {
+      id: 1,
+      name: "selectAssetType",
+      label: t("wizard.steps.selectAssetType.title"),
+      description: t("wizard.steps.selectAssetType.description"),
+    },
+    {
+      id: 2,
+      name: "assetBasics",
+      label: t("wizard.steps.assetBasics.title"),
+      description: t("wizard.steps.assetBasics.description"),
+    },
+    {
+      id: 3,
+      name: "summary",
+      label: t("wizard.steps.summary.title"),
+      description: t("wizard.steps.summary.description"),
+    },
+  ];
+}

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -1,5 +1,9 @@
 import { StepComponent } from "@/components/stepper/step";
-import type { Navigation, Step, StepGroup } from "@/components/stepper/types";
+import type {
+  NavigationMode,
+  Step,
+  StepGroup,
+} from "@/components/stepper/types";
 import { CollapsibleChevron } from "@/components/ui/collapsible-chevron";
 import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
@@ -10,7 +14,7 @@ export interface StepGroupProps<StepId, GroupId> {
   group: StepGroup<StepId, GroupId>;
   currentStep: Step<StepId>;
   allSteps: Step<StepId>[];
-  navigation: Navigation;
+  navigation: NavigationMode;
   onStepSelect: (step: Step<StepId>) => void;
 }
 

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -5,10 +5,7 @@ import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
 import { isGroupCompleted } from "./utils";
 
-export interface StepGroupProps<
-  StepName extends string = string,
-  GroupName extends string = string,
-> {
+export interface StepGroupProps<StepName, GroupName> {
   group: StepGroup<StepName, GroupName>;
   currentStep: Step<StepName>;
   allSteps: Step<StepName>[];
@@ -16,10 +13,7 @@ export interface StepGroupProps<
   onStepChange: (step: Step<StepName>) => void;
 }
 
-export function StepGroupComponent<
-  StepName extends string = string,
-  GroupName extends string = string,
->({
+export function StepGroupComponent<StepName, GroupName>({
   group,
   currentStep,
   allSteps,
@@ -43,7 +37,7 @@ export function StepGroupComponent<
               hasActiveStep ? "text-primary" : "text-foreground"
             )}
           >
-            {group.name}
+            {group.label}
           </span>
           {isCompleted && (
             <div className="flex items-center justify-center w-5 h-5 bg-primary rounded-full">

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -3,6 +3,7 @@ import type { Step, StepGroup } from "@/components/stepper/types";
 import { CollapsibleChevron } from "@/components/ui/collapsible-chevron";
 import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
+import { useEffect, useState } from "react";
 import { isGroupCompleted } from "./utils";
 
 export interface StepGroupProps<StepName, GroupName> {
@@ -20,12 +21,26 @@ export function StepGroupComponent<StepName, GroupName>({
   navigation,
   onStepChange,
 }: StepGroupProps<StepName, GroupName>) {
+  const [open, setOpen] = useState(false);
   const hasActiveStep = group.steps.some((step) => step.id === currentStep.id);
   const isCompleted = isGroupCompleted(group, currentStep);
 
+  useEffect(() => {
+    if (hasActiveStep) {
+      setOpen(true);
+    }
+  }, [hasActiveStep]);
+
+  useEffect(() => {
+    if (isCompleted) {
+      setOpen(false);
+    }
+  }, [isCompleted]);
+
   return (
     <CollapsibleChevron
-      defaultOpen={hasActiveStep}
+      open={open}
+      onOpenChange={setOpen}
       className={cn(
         hasActiveStep && "bg-primary/5 border border-primary/20 rounded-lg"
       )}
@@ -47,12 +62,10 @@ export function StepGroupComponent<StepName, GroupName>({
         </div>
       )}
     >
-      {(isExpanded) => {
-        const expanded = isExpanded;
-        const collapsed = !isExpanded;
+      {(open) => {
         return (
           <>
-            {expanded && (
+            {open && (
               <div className="pl-6 space-y-1">
                 {group.steps.map((step, index) => {
                   const isLastInGroup = index === group.steps.length - 1;
@@ -75,7 +88,7 @@ export function StepGroupComponent<StepName, GroupName>({
                 })}
               </div>
             )}
-            {collapsed && <></>}
+            {!open && <></>}
           </>
         );
       }}

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -22,7 +22,9 @@ export function StepGroupComponent<StepName, GroupName>({
   onStepSelect,
 }: StepGroupProps<StepName, GroupName>) {
   const [open, setOpen] = useState(false);
-  const hasActiveStep = group.steps.some((step) => step.id === currentStep.id);
+  const hasActiveStep = group.steps.some(
+    (step) => step.step === currentStep.step
+  );
   const isCompleted = isGroupCompleted(group, currentStep);
 
   useEffect(() => {
@@ -71,7 +73,7 @@ export function StepGroupComponent<StepName, GroupName>({
                   const isLastInGroup = index === group.steps.length - 1;
 
                   return (
-                    <div key={step.id} className="relative">
+                    <div key={step.step} className="relative">
                       <StepComponent<StepName>
                         step={step}
                         currentStep={currentStep}

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -1,5 +1,5 @@
 import { StepComponent } from "@/components/stepper/step";
-import type { Step, StepGroup } from "@/components/stepper/types";
+import type { Navigation, Step, StepGroup } from "@/components/stepper/types";
 import { CollapsibleChevron } from "@/components/ui/collapsible-chevron";
 import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
@@ -10,8 +10,8 @@ export interface StepGroupProps<StepName, GroupName> {
   group: StepGroup<StepName, GroupName>;
   currentStep: Step<StepName>;
   allSteps: Step<StepName>[];
-  navigation: "forward-only" | "bidirectional";
-  onStepChange: (step: Step<StepName>) => void;
+  navigation: Navigation;
+  onStepSelect: (step: Step<StepName>) => void;
 }
 
 export function StepGroupComponent<StepName, GroupName>({
@@ -19,7 +19,7 @@ export function StepGroupComponent<StepName, GroupName>({
   currentStep,
   allSteps,
   navigation,
-  onStepChange,
+  onStepSelect,
 }: StepGroupProps<StepName, GroupName>) {
   const [open, setOpen] = useState(false);
   const hasActiveStep = group.steps.some((step) => step.id === currentStep.id);
@@ -77,7 +77,7 @@ export function StepGroupComponent<StepName, GroupName>({
                         currentStep={currentStep}
                         allSteps={allSteps}
                         navigation={navigation}
-                        onStepChange={onStepChange}
+                        onStepSelect={onStepSelect}
                       />
 
                       {!isLastInGroup && (

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -1,0 +1,90 @@
+import { StepComponent } from "@/components/stepper/step";
+import type { Step, StepGroup } from "@/components/stepper/types";
+import { CollapsibleChevron } from "@/components/ui/collapsible-chevron";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+import { isGroupCompleted } from "./utils";
+
+export interface StepGroupProps<
+  StepName extends string = string,
+  GroupName extends string = string,
+> {
+  group: StepGroup<StepName, GroupName>;
+  currentStep: Step<StepName>;
+  allSteps: Step<StepName>[];
+  navigation: "forward-only" | "bidirectional";
+  onStepChange: (step: Step<StepName>) => void;
+}
+
+export function StepGroupComponent<
+  StepName extends string = string,
+  GroupName extends string = string,
+>({
+  group,
+  currentStep,
+  allSteps,
+  navigation,
+  onStepChange,
+}: StepGroupProps<StepName, GroupName>) {
+  const hasActiveStep = group.steps.some((step) => step.id === currentStep.id);
+  const isCompleted = isGroupCompleted(group, currentStep);
+
+  return (
+    <CollapsibleChevron
+      defaultOpen={hasActiveStep}
+      className={cn(
+        hasActiveStep && "bg-primary/5 border border-primary/20 rounded-lg"
+      )}
+      trigger={() => (
+        <div className="flex items-center space-x-3">
+          <span
+            className={cn(
+              "font-semibold text-sm",
+              hasActiveStep ? "text-primary" : "text-foreground"
+            )}
+          >
+            {group.name}
+          </span>
+          {isCompleted && (
+            <div className="flex items-center justify-center w-5 h-5 bg-primary rounded-full">
+              <Check className="w-3 h-3 text-primary-foreground" />
+            </div>
+          )}
+        </div>
+      )}
+    >
+      {(isExpanded) => {
+        const expanded = isExpanded;
+        const collapsed = !isExpanded;
+        return (
+          <>
+            {expanded && (
+              <div className="pl-6 space-y-1">
+                {group.steps.map((step, index) => {
+                  const isLastInGroup = index === group.steps.length - 1;
+
+                  return (
+                    <div key={step.id} className="relative">
+                      <StepComponent<StepName>
+                        step={step}
+                        currentStep={currentStep}
+                        allSteps={allSteps}
+                        navigation={navigation}
+                        onStepChange={onStepChange}
+                      />
+
+                      {!isLastInGroup && (
+                        <div className="absolute left-6 top-16 w-px h-4 bg-border" />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {collapsed && <></>}
+          </>
+        );
+      }}
+    </CollapsibleChevron>
+  );
+}

--- a/kit/dapp/src/components/stepper/step-group.tsx
+++ b/kit/dapp/src/components/stepper/step-group.tsx
@@ -6,21 +6,21 @@ import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
 import { isGroupCompleted } from "./utils";
 
-export interface StepGroupProps<StepName, GroupName> {
-  group: StepGroup<StepName, GroupName>;
-  currentStep: Step<StepName>;
-  allSteps: Step<StepName>[];
+export interface StepGroupProps<StepId, GroupId> {
+  group: StepGroup<StepId, GroupId>;
+  currentStep: Step<StepId>;
+  allSteps: Step<StepId>[];
   navigation: Navigation;
-  onStepSelect: (step: Step<StepName>) => void;
+  onStepSelect: (step: Step<StepId>) => void;
 }
 
-export function StepGroupComponent<StepName, GroupName>({
+export function StepGroupComponent<StepId, GroupId>({
   group,
   currentStep,
   allSteps,
   navigation,
   onStepSelect,
-}: StepGroupProps<StepName, GroupName>) {
+}: StepGroupProps<StepId, GroupId>) {
   const [open, setOpen] = useState(false);
   const hasActiveStep = group.steps.some(
     (step) => step.step === currentStep.step
@@ -74,7 +74,7 @@ export function StepGroupComponent<StepName, GroupName>({
 
                   return (
                     <div key={step.step} className="relative">
-                      <StepComponent<StepName>
+                      <StepComponent<StepId>
                         step={step}
                         currentStep={currentStep}
                         allSteps={allSteps}

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -7,7 +7,7 @@ import type { Step, StepOrGroup } from "./types";
 import { flattenSteps, getNextStep, isStepGroup } from "./utils";
 
 export interface StepLayoutProps<StepName, GroupName> {
-  steps: StepOrGroup<StepName, GroupName>[];
+  stepsOrGroups: StepOrGroup<StepName, GroupName>[];
   currentStep: Step<StepName>;
   onStepChange: (step: Step<StepName>) => void;
 
@@ -20,24 +20,24 @@ export interface StepLayoutProps<StepName, GroupName> {
 }
 
 export function StepLayout<StepName, GroupName>({
-  steps,
+  stepsOrGroups,
   currentStep,
   onStepChange,
   children,
   className,
   navigation = "forward-only",
 }: StepLayoutProps<StepName, GroupName>) {
-  const allSteps = useMemo(() => flattenSteps(steps), [steps]);
+  const allSteps = useMemo(() => flattenSteps(stepsOrGroups), [stepsOrGroups]);
 
   return (
     <div className={cn("step-layout space-y-4", className)}>
       <div className="space-y-2">
-        {steps.map((step) => {
-          if (isStepGroup(step)) {
+        {stepsOrGroups.map((item) => {
+          if (isStepGroup(item)) {
             return (
               <StepGroupComponent
-                key={step.id}
-                group={step}
+                key={item.label}
+                group={item}
                 currentStep={currentStep}
                 allSteps={allSteps}
                 onStepChange={onStepChange}
@@ -48,8 +48,8 @@ export function StepLayout<StepName, GroupName>({
 
           return (
             <StepComponent
-              key={step.id}
-              step={step}
+              key={item.id}
+              step={item}
               allSteps={allSteps}
               onStepChange={onStepChange}
               navigation={navigation}

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 
 import { StepComponent } from "@/components/stepper/step";
 import { StepGroupComponent } from "@/components/stepper/step-group";
-import type { Navigation } from "@/components/stepper/types";
+import type { NavigationMode } from "@/components/stepper/types";
 import type { Step, StepOrGroup } from "./types";
 import { flattenSteps, getNextStep, isStepGroup } from "./utils";
 
@@ -16,7 +16,7 @@ export interface StepLayoutProps<StepId, GroupId> {
     currentStep: Step<StepId>;
     nextStep: Step<StepId>;
   }) => React.ReactNode;
-  navigation?: Navigation;
+  navigationMode?: NavigationMode;
   className?: string;
 }
 
@@ -26,7 +26,7 @@ export function StepLayout<StepId, GroupId>({
   onStepSelect,
   children,
   className,
-  navigation = "next-only",
+  navigationMode = "next-only",
 }: StepLayoutProps<StepId, GroupId>) {
   const allSteps = useMemo(() => flattenSteps(stepsOrGroups), [stepsOrGroups]);
 
@@ -42,7 +42,7 @@ export function StepLayout<StepId, GroupId>({
                 currentStep={currentStep}
                 allSteps={allSteps}
                 onStepSelect={onStepSelect}
-                navigation={navigation}
+                navigation={navigationMode}
               />
             );
           }
@@ -53,7 +53,7 @@ export function StepLayout<StepId, GroupId>({
               step={item}
               allSteps={allSteps}
               onStepSelect={onStepSelect}
-              navigation={navigation}
+              navigation={navigationMode}
               currentStep={currentStep}
             />
           );

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -1,17 +1,14 @@
 import { cn } from "@/lib/utils";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 import { StepComponent } from "@/components/stepper/step";
 import { StepGroupComponent } from "@/components/stepper/step-group";
 import type { Step, StepOrGroup } from "./types";
-import { flattenSteps, isStepGroup } from "./utils";
+import { flattenSteps, getNextStep, isStepGroup } from "./utils";
 
-export interface StepLayoutProps<
-  StepName extends string = string,
-  GroupName extends string = never,
-> {
+export interface StepLayoutProps<StepName, GroupName> {
   steps: StepOrGroup<StepName, GroupName>[];
-  defaultStep: Step<StepName>;
+  currentStep: Step<StepName>;
   onStepChange: (step: StepOrGroup<StepName, GroupName>) => void;
 
   children: (props: {
@@ -23,22 +20,20 @@ export interface StepLayoutProps<
 }
 
 export function StepLayout<
-  StepName extends string = string,
+  StepName extends string = never,
   GroupName extends string = never,
 >({
   steps,
-  defaultStep,
+  currentStep,
   onStepChange,
   children,
   className,
   navigation = "forward-only",
 }: StepLayoutProps<StepName, GroupName>) {
   const allSteps = useMemo(() => flattenSteps(steps), [steps]);
-  const [currentStep, setCurrentStep] = useState<Step<StepName>>(defaultStep);
 
   const handleStepChange = useCallback(
     (step: Step<StepName>) => {
-      setCurrentStep(step);
       onStepChange(step);
     },
     [onStepChange]
@@ -76,7 +71,7 @@ export function StepLayout<
 
       {children({
         currentStep,
-        nextStep: currentStep,
+        nextStep: getNextStep(allSteps, currentStep),
       })}
     </div>
   );

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 
 import { StepComponent } from "@/components/stepper/step";
 import { StepGroupComponent } from "@/components/stepper/step-group";
@@ -9,7 +9,7 @@ import { flattenSteps, getNextStep, isStepGroup } from "./utils";
 export interface StepLayoutProps<StepName, GroupName> {
   steps: StepOrGroup<StepName, GroupName>[];
   currentStep: Step<StepName>;
-  onStepChange: (step: StepOrGroup<StepName, GroupName>) => void;
+  onStepChange: (step: Step<StepName>) => void;
 
   children: (props: {
     currentStep: Step<StepName>;
@@ -19,10 +19,7 @@ export interface StepLayoutProps<StepName, GroupName> {
   className?: string;
 }
 
-export function StepLayout<
-  StepName extends string = never,
-  GroupName extends string = never,
->({
+export function StepLayout<StepName, GroupName>({
   steps,
   currentStep,
   onStepChange,
@@ -32,36 +29,29 @@ export function StepLayout<
 }: StepLayoutProps<StepName, GroupName>) {
   const allSteps = useMemo(() => flattenSteps(steps), [steps]);
 
-  const handleStepChange = useCallback(
-    (step: Step<StepName>) => {
-      onStepChange(step);
-    },
-    [onStepChange]
-  );
-
   return (
     <div className={cn("step-layout space-y-4", className)}>
       <div className="space-y-2">
         {steps.map((step) => {
           if (isStepGroup(step)) {
             return (
-              <StepGroupComponent<StepName, GroupName>
+              <StepGroupComponent
                 key={step.id}
                 group={step}
                 currentStep={currentStep}
                 allSteps={allSteps}
-                onStepChange={handleStepChange}
+                onStepChange={onStepChange}
                 navigation={navigation}
               />
             );
           }
 
           return (
-            <StepComponent<StepName>
+            <StepComponent
               key={step.id}
               step={step}
               allSteps={allSteps}
-              onStepChange={handleStepChange}
+              onStepChange={onStepChange}
               navigation={navigation}
               currentStep={currentStep}
             />

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -3,29 +3,30 @@ import { useMemo } from "react";
 
 import { StepComponent } from "@/components/stepper/step";
 import { StepGroupComponent } from "@/components/stepper/step-group";
+import type { Navigation } from "@/components/stepper/types";
 import type { Step, StepOrGroup } from "./types";
 import { flattenSteps, getNextStep, isStepGroup } from "./utils";
 
 export interface StepLayoutProps<StepName, GroupName> {
   stepsOrGroups: StepOrGroup<StepName, GroupName>[];
   currentStep: Step<StepName>;
-  onStepChange: (step: Step<StepName>) => void;
+  onStepSelect: (step: Step<StepName>) => void;
 
   children: (props: {
     currentStep: Step<StepName>;
     nextStep: Step<StepName>;
   }) => React.ReactNode;
-  navigation?: "forward-only" | "bidirectional";
+  navigation?: Navigation;
   className?: string;
 }
 
 export function StepLayout<StepName, GroupName>({
   stepsOrGroups,
   currentStep,
-  onStepChange,
+  onStepSelect,
   children,
   className,
-  navigation = "forward-only",
+  navigation = "next-only",
 }: StepLayoutProps<StepName, GroupName>) {
   const allSteps = useMemo(() => flattenSteps(stepsOrGroups), [stepsOrGroups]);
 
@@ -40,7 +41,7 @@ export function StepLayout<StepName, GroupName>({
                 group={item}
                 currentStep={currentStep}
                 allSteps={allSteps}
-                onStepChange={onStepChange}
+                onStepSelect={onStepSelect}
                 navigation={navigation}
               />
             );
@@ -51,7 +52,7 @@ export function StepLayout<StepName, GroupName>({
               key={item.id}
               step={item}
               allSteps={allSteps}
-              onStepChange={onStepChange}
+              onStepSelect={onStepSelect}
               navigation={navigation}
               currentStep={currentStep}
             />

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -1,0 +1,83 @@
+import { cn } from "@/lib/utils";
+import { useCallback, useMemo, useState } from "react";
+
+import { StepComponent } from "@/components/stepper/step";
+import { StepGroupComponent } from "@/components/stepper/step-group";
+import type { Step, StepOrGroup } from "./types";
+import { flattenSteps, isStepGroup } from "./utils";
+
+export interface StepLayoutProps<
+  StepName extends string = string,
+  GroupName extends string = never,
+> {
+  steps: StepOrGroup<StepName, GroupName>[];
+  defaultStep: Step<StepName>;
+  onStepChange: (step: StepOrGroup<StepName, GroupName>) => void;
+
+  children: (props: {
+    currentStep: Step<StepName>;
+    nextStep: Step<StepName>;
+  }) => React.ReactNode;
+  navigation?: "forward-only" | "bidirectional";
+  className?: string;
+}
+
+export function StepLayout<
+  StepName extends string = string,
+  GroupName extends string = never,
+>({
+  steps,
+  defaultStep,
+  onStepChange,
+  children,
+  className,
+  navigation = "forward-only",
+}: StepLayoutProps<StepName, GroupName>) {
+  const allSteps = useMemo(() => flattenSteps(steps), [steps]);
+  const [currentStep, setCurrentStep] = useState<Step<StepName>>(defaultStep);
+
+  const handleStepChange = useCallback(
+    (step: Step<StepName>) => {
+      setCurrentStep(step);
+      onStepChange(step);
+    },
+    [onStepChange]
+  );
+
+  return (
+    <div className={cn("step-layout space-y-4", className)}>
+      <div className="space-y-2">
+        {steps.map((step) => {
+          if (isStepGroup(step)) {
+            return (
+              <StepGroupComponent<StepName, GroupName>
+                key={step.id}
+                group={step}
+                currentStep={currentStep}
+                allSteps={allSteps}
+                onStepChange={handleStepChange}
+                navigation={navigation}
+              />
+            );
+          }
+
+          return (
+            <StepComponent<StepName>
+              key={step.id}
+              step={step}
+              allSteps={allSteps}
+              onStepChange={handleStepChange}
+              navigation={navigation}
+              currentStep={currentStep}
+            />
+          );
+        })}
+      </div>
+
+      {children({
+        currentStep,
+        nextStep: currentStep,
+      })}
+    </div>
+  );
+}

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -49,7 +49,7 @@ export function StepLayout<StepName, GroupName>({
 
           return (
             <StepComponent
-              key={item.id}
+              key={item.step}
               step={item}
               allSteps={allSteps}
               onStepSelect={onStepSelect}

--- a/kit/dapp/src/components/stepper/step-layout.tsx
+++ b/kit/dapp/src/components/stepper/step-layout.tsx
@@ -7,27 +7,27 @@ import type { Navigation } from "@/components/stepper/types";
 import type { Step, StepOrGroup } from "./types";
 import { flattenSteps, getNextStep, isStepGroup } from "./utils";
 
-export interface StepLayoutProps<StepName, GroupName> {
-  stepsOrGroups: StepOrGroup<StepName, GroupName>[];
-  currentStep: Step<StepName>;
-  onStepSelect: (step: Step<StepName>) => void;
+export interface StepLayoutProps<StepId, GroupId> {
+  stepsOrGroups: StepOrGroup<StepId, GroupId>[];
+  currentStep: Step<StepId>;
+  onStepSelect: (step: Step<StepId>) => void;
 
   children: (props: {
-    currentStep: Step<StepName>;
-    nextStep: Step<StepName>;
+    currentStep: Step<StepId>;
+    nextStep: Step<StepId>;
   }) => React.ReactNode;
   navigation?: Navigation;
   className?: string;
 }
 
-export function StepLayout<StepName, GroupName>({
+export function StepLayout<StepId, GroupId>({
   stepsOrGroups,
   currentStep,
   onStepSelect,
   children,
   className,
   navigation = "next-only",
-}: StepLayoutProps<StepName, GroupName>) {
+}: StepLayoutProps<StepId, GroupId>) {
   const allSteps = useMemo(() => flattenSteps(stepsOrGroups), [stepsOrGroups]);
 
   return (

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -3,7 +3,7 @@ import type { Step } from "@/components/stepper/types";
 import { cn } from "@/lib/utils";
 import { isStepCompleted } from "./utils";
 
-export interface StepItemProps<StepName extends string = string> {
+export interface StepItemProps<StepName> {
   step: Step<StepName>;
   currentStep: Step<StepName>;
   allSteps: Step<StepName>[];
@@ -11,14 +11,14 @@ export interface StepItemProps<StepName extends string = string> {
   onStepChange: (step: Step<StepName>) => void;
 }
 
-export function StepComponent<StepName extends string = string>({
+export function StepComponent<StepName>({
   step,
   currentStep,
   navigation,
   onStepChange,
 }: StepItemProps<StepName>) {
   const isActive = step.id === currentStep.id;
-  const isCompleted = isStepCompleted(step, currentStep);
+  const isCompleted = isStepCompleted<StepName>(step, currentStep);
   const canSelect = isActive || (isCompleted && navigation === "bidirectional");
   const status = isCompleted ? "completed" : isActive ? "active" : "pending";
 

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -17,10 +17,10 @@ export function StepComponent<StepName>({
   navigation,
   onStepSelect,
 }: StepItemProps<StepName>) {
-  const isActive = step.id === currentStep.id;
+  const isActive = step.step === currentStep.step;
   const isCompleted = isStepCompleted<StepName>(step, currentStep);
   const canSelect =
-    isActive || (isCompleted && navigation === "next-and-previous");
+    isActive || (isCompleted && navigation === "next-and-completed");
   const status = isCompleted ? "completed" : isActive ? "active" : "pending";
 
   return (

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -18,7 +18,7 @@ export function StepComponent<StepId>({
   onStepSelect,
 }: StepItemProps<StepId>) {
   const isActive = step.step === currentStep.step;
-  const isCompleted = isStepCompleted<StepId>(step, currentStep);
+  const isCompleted = isStepCompleted({ step, currentStep });
   const canSelect =
     isActive || (isCompleted && navigation === "next-and-completed");
   const status = isCompleted ? "completed" : isActive ? "active" : "pending";

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -1,0 +1,65 @@
+import { StepperIndicator, StepperTrigger } from "@/components/stepper/stepper";
+import type { Step } from "@/components/stepper/types";
+import { cn } from "@/lib/utils";
+import { isStepCompleted } from "./utils";
+
+export interface StepItemProps<StepName extends string = string> {
+  step: Step<StepName>;
+  currentStep: Step<StepName>;
+  allSteps: Step<StepName>[];
+  navigation: "forward-only" | "bidirectional";
+  onStepChange: (step: Step<StepName>) => void;
+}
+
+export function StepComponent<StepName extends string = string>({
+  step,
+  currentStep,
+  navigation,
+  onStepChange,
+}: StepItemProps<StepName>) {
+  const isActive = step.id === currentStep.id;
+  const isCompleted = isStepCompleted(step, currentStep);
+  const canSelect = isActive || (isCompleted && navigation === "bidirectional");
+  const status = isCompleted ? "completed" : isActive ? "active" : "pending";
+
+  return (
+    <div className="flex items-center space-x-3 py-2">
+      <StepperTrigger
+        disabled={!canSelect}
+        onClick={() => {
+          onStepChange(step);
+        }}
+        className={cn(
+          "flex items-center space-x-3 p-3 rounded-lg transition-all duration-200 text-left w-full",
+          isActive && "bg-primary/10 border border-primary/20",
+          !canSelect && "opacity-60 cursor-not-allowed",
+          canSelect && !isActive && "hover:bg-muted/50"
+        )}
+      >
+        <StepperIndicator
+          status={status}
+          className={cn(
+            "w-6 h-6 shrink-0",
+            status === "completed" && "bg-primary",
+            status === "active" && "border-2 border-primary",
+            status === "pending" && "border-2 border-muted-foreground/30"
+          )}
+        />
+
+        <div className="flex-1 min-w-0">
+          <div
+            className={cn(
+              "font-medium text-sm transition-colors",
+              isActive ? "text-primary" : "text-foreground"
+            )}
+          >
+            {step.label}
+          </div>
+          <div className="text-xs text-muted-foreground mt-1">
+            {step.description}
+          </div>
+        </div>
+      </StepperTrigger>
+    </div>
+  );
+}

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -1,5 +1,5 @@
 import { StepperIndicator, StepperTrigger } from "@/components/stepper/stepper";
-import type { Navigation, Step } from "@/components/stepper/types";
+import type { NavigationMode, Step } from "@/components/stepper/types";
 import { cn } from "@/lib/utils";
 import { isStepCompleted } from "./utils";
 
@@ -7,7 +7,7 @@ export interface StepItemProps<StepId> {
   step: Step<StepId>;
   currentStep: Step<StepId>;
   allSteps: Step<StepId>[];
-  navigation: Navigation;
+  navigation: NavigationMode;
   onStepSelect: (step: Step<StepId>) => void;
 }
 

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -3,22 +3,22 @@ import type { Navigation, Step } from "@/components/stepper/types";
 import { cn } from "@/lib/utils";
 import { isStepCompleted } from "./utils";
 
-export interface StepItemProps<StepName> {
-  step: Step<StepName>;
-  currentStep: Step<StepName>;
-  allSteps: Step<StepName>[];
+export interface StepItemProps<StepId> {
+  step: Step<StepId>;
+  currentStep: Step<StepId>;
+  allSteps: Step<StepId>[];
   navigation: Navigation;
-  onStepSelect: (step: Step<StepName>) => void;
+  onStepSelect: (step: Step<StepId>) => void;
 }
 
-export function StepComponent<StepName>({
+export function StepComponent<StepId>({
   step,
   currentStep,
   navigation,
   onStepSelect,
-}: StepItemProps<StepName>) {
+}: StepItemProps<StepId>) {
   const isActive = step.step === currentStep.step;
-  const isCompleted = isStepCompleted<StepName>(step, currentStep);
+  const isCompleted = isStepCompleted<StepId>(step, currentStep);
   const canSelect =
     isActive || (isCompleted && navigation === "next-and-completed");
   const status = isCompleted ? "completed" : isActive ? "active" : "pending";

--- a/kit/dapp/src/components/stepper/step.tsx
+++ b/kit/dapp/src/components/stepper/step.tsx
@@ -1,5 +1,5 @@
 import { StepperIndicator, StepperTrigger } from "@/components/stepper/stepper";
-import type { Step } from "@/components/stepper/types";
+import type { Navigation, Step } from "@/components/stepper/types";
 import { cn } from "@/lib/utils";
 import { isStepCompleted } from "./utils";
 
@@ -7,19 +7,20 @@ export interface StepItemProps<StepName> {
   step: Step<StepName>;
   currentStep: Step<StepName>;
   allSteps: Step<StepName>[];
-  navigation: "forward-only" | "bidirectional";
-  onStepChange: (step: Step<StepName>) => void;
+  navigation: Navigation;
+  onStepSelect: (step: Step<StepName>) => void;
 }
 
 export function StepComponent<StepName>({
   step,
   currentStep,
   navigation,
-  onStepChange,
+  onStepSelect,
 }: StepItemProps<StepName>) {
   const isActive = step.id === currentStep.id;
   const isCompleted = isStepCompleted<StepName>(step, currentStep);
-  const canSelect = isActive || (isCompleted && navigation === "bidirectional");
+  const canSelect =
+    isActive || (isCompleted && navigation === "next-and-previous");
   const status = isCompleted ? "completed" : isActive ? "active" : "pending";
 
   return (
@@ -27,7 +28,7 @@ export function StepComponent<StepName>({
       <StepperTrigger
         disabled={!canSelect}
         onClick={() => {
-          onStepChange(step);
+          onStepSelect(step);
         }}
         className={cn(
           "flex items-center space-x-3 p-3 rounded-lg transition-all duration-200 text-left w-full",

--- a/kit/dapp/src/components/stepper/stepper.tsx
+++ b/kit/dapp/src/components/stepper/stepper.tsx
@@ -1,0 +1,98 @@
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+import React from "react";
+
+export interface StepperProps extends React.HTMLAttributes<HTMLDivElement> {
+  defaultValue?: string;
+}
+
+export interface StepperItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  step: string;
+}
+
+export interface StepperIndicatorProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  status?: "pending" | "active" | "completed";
+}
+
+export interface StepperSeparatorProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+}
+
+export interface StepperTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string;
+}
+
+export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center", className)} {...props} />
+  )
+);
+Stepper.displayName = "Stepper";
+
+export const StepperItem = React.forwardRef<HTMLDivElement, StepperItemProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center", className)} {...props} />
+  )
+);
+StepperItem.displayName = "StepperItem";
+
+export const StepperIndicator = React.forwardRef<
+  HTMLDivElement,
+  StepperIndicatorProps
+>(({ className, status = "pending", ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "flex items-center justify-center rounded-full transition-all duration-300",
+      status === "completed" && "bg-primary",
+      status === "active" && "border-2 border-primary bg-transparent",
+      status === "pending" &&
+        "border-2 border-muted-foreground/30 bg-transparent",
+      className
+    )}
+    {...props}
+  >
+    {status === "completed" ? (
+      <Check className="w-3 h-3 text-primary-foreground" />
+    ) : status === "active" ? (
+      <div className="w-2 h-2 rounded-full bg-primary" />
+    ) : (
+      <span className="sr-only">Pending</span>
+    )}
+  </div>
+));
+StepperIndicator.displayName = "StepperIndicator";
+
+export const StepperSeparator = React.forwardRef<
+  HTMLDivElement,
+  StepperSeparatorProps
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("h-px bg-border flex-1 mx-2", className)}
+    {...props}
+  />
+));
+StepperSeparator.displayName = "StepperSeparator";
+
+export const StepperTrigger = React.forwardRef<
+  HTMLButtonElement,
+  StepperTriggerProps
+>(({ className, disabled, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    disabled={disabled}
+    className={cn(
+      "inline-flex items-center justify-center rounded-md transition-colors",
+      "hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+      "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+      className
+    )}
+    {...props}
+  />
+));
+StepperTrigger.displayName = "StepperTrigger";

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -12,6 +12,6 @@ export interface StepGroup<StepName, GroupName> {
   steps: Step<StepName>[];
 }
 
-export type StepOrGroup<StepName, GroupName = never> =
+export type StepOrGroup<StepName, GroupName> =
   | Step<StepName>
   | StepGroup<StepName, GroupName>;

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -1,0 +1,20 @@
+export interface Step<StepName extends string = string> {
+  id: number;
+  name: StepName[];
+  label: string;
+  description: string;
+}
+
+export interface StepGroup<
+  StepName extends string = string,
+  GroupName extends string = string,
+> {
+  id: number;
+  name: GroupName[];
+  steps: Step<StepName>[];
+}
+
+export type StepOrGroup<
+  StepName extends string = string,
+  GroupName extends string = string,
+> = Step<StepName> | StepGroup<StepName, GroupName>;

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -6,7 +6,6 @@ export interface Step<StepName> {
 }
 
 export interface StepGroup<StepName, GroupName> {
-  id: number;
   name: GroupName;
   label: string;
   steps: Step<StepName>[];

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -1,6 +1,6 @@
 export interface Step<StepName> {
-  id: number;
-  name: StepName;
+  step: number;
+  id: StepName;
   label: string;
   description: string;
 }
@@ -15,4 +15,4 @@ export type StepOrGroup<StepName, GroupName> =
   | Step<StepName>
   | StepGroup<StepName, GroupName>;
 
-export type Navigation = "next-only" | "next-and-previous";
+export type Navigation = "next-only" | "next-and-completed";

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -14,3 +14,5 @@ export interface StepGroup<StepName, GroupName> {
 export type StepOrGroup<StepName, GroupName> =
   | Step<StepName>
   | StepGroup<StepName, GroupName>;
+
+export type Navigation = "next-only" | "next-and-previous";

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -1,18 +1,18 @@
-export interface Step<StepName> {
+export interface Step<StepId> {
   step: number;
-  id: StepName;
+  id: StepId;
   label: string;
   description: string;
 }
 
-export interface StepGroup<StepName, GroupName> {
-  name: GroupName;
+export interface StepGroup<StepId, GroupId> {
+  id: GroupId;
   label: string;
-  steps: Step<StepName>[];
+  steps: Step<StepId>[];
 }
 
-export type StepOrGroup<StepName, GroupName> =
-  | Step<StepName>
-  | StepGroup<StepName, GroupName>;
+export type StepOrGroup<StepId, GroupId> =
+  | Step<StepId>
+  | StepGroup<StepId, GroupId>;
 
 export type Navigation = "next-only" | "next-and-completed";

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -1,20 +1,17 @@
-export interface Step<StepName extends string = string> {
+export interface Step<StepName> {
   id: number;
-  name: StepName[];
+  name: StepName;
   label: string;
   description: string;
 }
 
-export interface StepGroup<
-  StepName extends string = string,
-  GroupName extends string = string,
-> {
+export interface StepGroup<StepName, GroupName> {
   id: number;
-  name: GroupName[];
+  name: GroupName;
+  label: string;
   steps: Step<StepName>[];
 }
 
-export type StepOrGroup<
-  StepName extends string = string,
-  GroupName extends string = string,
-> = Step<StepName> | StepGroup<StepName, GroupName>;
+export type StepOrGroup<StepName, GroupName = never> =
+  | Step<StepName>
+  | StepGroup<StepName, GroupName>;

--- a/kit/dapp/src/components/stepper/types.ts
+++ b/kit/dapp/src/components/stepper/types.ts
@@ -15,4 +15,4 @@ export type StepOrGroup<StepId, GroupId> =
   | Step<StepId>
   | StepGroup<StepId, GroupId>;
 
-export type Navigation = "next-only" | "next-and-completed";
+export type NavigationMode = "next-only" | "next-and-completed";

--- a/kit/dapp/src/components/stepper/utils.test.ts
+++ b/kit/dapp/src/components/stepper/utils.test.ts
@@ -119,7 +119,7 @@ describe("stepper utils", () => {
   });
 
   describe("isStepCompleted", () => {
-    it("should return true when current step is before target step", () => {
+    it("should return true when current step is after target step", () => {
       const targetStep = stepA;
       const currentStep = stepB;
       const result = isStepCompleted({ step: targetStep, currentStep });
@@ -133,7 +133,7 @@ describe("stepper utils", () => {
       expect(result).toBe(false);
     });
 
-    it("should return false when current step is after target step", () => {
+    it("should return false when current step is before target step", () => {
       const targetStep = stepC;
       const currentStep = stepB;
       const result = isStepCompleted({ step: targetStep, currentStep });

--- a/kit/dapp/src/components/stepper/utils.test.ts
+++ b/kit/dapp/src/components/stepper/utils.test.ts
@@ -74,7 +74,7 @@ describe("stepper utils", () => {
     });
 
     it("should handle unsorted input steps", () => {
-      const steps = [stepC, stepA, stepB];
+      const steps = [stepB, stepC, stepA];
       const currentStep = stepA;
       const result = getNextStep(steps, currentStep);
       expect(result).toEqual(stepB);
@@ -119,7 +119,7 @@ describe("stepper utils", () => {
   });
 
   describe("isStepCompleted", () => {
-    it("should return true when current step is after target step", () => {
+    it("should return true when current step is before target step", () => {
       const targetStep = stepA;
       const currentStep = stepB;
       const result = isStepCompleted({ step: targetStep, currentStep });
@@ -142,7 +142,7 @@ describe("stepper utils", () => {
   });
 
   describe("isGroupCompleted", () => {
-    it("should return true when current step is past last step in group", () => {
+    it("should return true when current step is after last step in group", () => {
       const currentStep = stepF;
       const result = isGroupCompleted(group, currentStep);
       expect(result).toBe(true);

--- a/kit/dapp/src/components/stepper/utils.test.ts
+++ b/kit/dapp/src/components/stepper/utils.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getLastStep,
+  getNextStep,
+  getStepById,
+  isGroupCompleted,
+  isStepCompleted,
+  isStepGroup,
+} from "./utils";
+
+describe("stepper utils", () => {
+  const info = {
+    label: "Example step",
+    description: "This is an example step",
+  };
+  const stepA = {
+    step: 1,
+    id: "a" as const,
+    ...info,
+  };
+  const stepB = {
+    step: 5,
+    id: "b" as const,
+    ...info,
+  };
+  const stepC = {
+    step: 9,
+    id: "c" as const,
+    ...info,
+  };
+  const stepD = {
+    step: 13,
+    id: "d" as const,
+    ...info,
+  };
+  const stepE = {
+    step: 17,
+    id: "e" as const,
+    ...info,
+  };
+  const stepF = {
+    step: 21,
+    id: "f" as const,
+    ...info,
+  };
+
+  const group = {
+    id: "group1",
+    label: "Group 1",
+    steps: [stepD, stepE],
+  };
+
+  describe("getStepById", () => {
+    it("should find step by id", () => {
+      const steps = [stepA, stepB, stepC];
+      const result = getStepById(steps, "b");
+      expect(result).toEqual(stepB);
+    });
+
+    it("should throw error for non-existent step", () => {
+      const steps = [stepA, stepB];
+
+      // @ts-expect-error - 'c' is not a valid step id
+      expect(() => getStepById(steps, "c")).toThrow("Step with id c not found");
+    });
+  });
+
+  describe("getNextStep", () => {
+    it("should return next step for non-sequential steps", () => {
+      const steps = [stepA, stepB, stepC];
+      const currentStep = stepB;
+      const result = getNextStep(steps, currentStep);
+      expect(result).toEqual(stepC);
+    });
+
+    it("should handle unsorted input steps", () => {
+      const steps = [stepC, stepA, stepB];
+      const currentStep = stepA;
+      const result = getNextStep(steps, currentStep);
+      expect(result).toEqual(stepB);
+    });
+
+    it("should return same step for last step", () => {
+      const steps = [stepB, stepC, stepA];
+      const currentStep = stepC;
+      const result = getNextStep(steps, currentStep);
+      expect(result).toEqual(stepC);
+    });
+
+    it("should throw error for non-existent current step", () => {
+      const steps = [stepA, stepB];
+      const currentStep = stepC;
+
+      // @ts-expect-error - stepC is not a valid step
+      expect(() => getNextStep(steps, currentStep)).toThrow(
+        "Current step c not found in steps array"
+      );
+    });
+  });
+
+  describe("getLastStep", () => {
+    it("should return last step from non-sequential steps", () => {
+      const steps = [stepA, stepB, stepC];
+      const result = getLastStep(steps);
+      expect(result).toEqual(stepC);
+    });
+
+    it("should handle single step", () => {
+      const steps = [stepA];
+      const result = getLastStep(steps);
+      expect(result).toEqual(stepA);
+    });
+
+    it("should work with unsorted input", () => {
+      const steps = [stepC, stepA, stepB];
+      const result = getLastStep(steps);
+      expect(result).toEqual(stepC);
+    });
+  });
+
+  describe("isStepCompleted", () => {
+    it("should return true when current step is after target step", () => {
+      const targetStep = stepA;
+      const currentStep = stepB;
+      const result = isStepCompleted(targetStep, currentStep);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when current step is at target step", () => {
+      const targetStep = stepB;
+      const currentStep = stepB;
+      const result = isStepCompleted(targetStep, currentStep);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when current step is after target step", () => {
+      const targetStep = stepC;
+      const currentStep = stepB;
+      const result = isStepCompleted(targetStep, currentStep);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isGroupCompleted", () => {
+    it("should return true when current step is past last step in group", () => {
+      const currentStep = stepF;
+      const result = isGroupCompleted(group, currentStep);
+      expect(result).toBe(true);
+    });
+
+    it("should return false when current step is at last step in group", () => {
+      const currentStep = stepE;
+      const result = isGroupCompleted(group, currentStep);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when current step is before last step in group", () => {
+      const currentStep = stepD;
+      const result = isGroupCompleted(group, currentStep);
+      expect(result).toBe(false);
+    });
+
+    it("should handle group with single step", () => {
+      const group = {
+        id: "group1",
+        label: "Group 1",
+        steps: [stepA],
+      };
+      const currentStep = stepB;
+      const result = isGroupCompleted(group, currentStep);
+      expect(result).toBe(true);
+    });
+
+    it("should handle group with non-sequential steps", () => {
+      const group = {
+        id: "group1",
+        label: "Group 1",
+        steps: [stepA, stepB, stepC],
+      };
+      const currentStep = stepD;
+      const result = isGroupCompleted(group, currentStep);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("isStepGroup", () => {
+    it("should return true for step group", () => {
+      const result = isStepGroup(group);
+      expect(result).toBe(true);
+    });
+
+    it("should return false for step", () => {
+      const result = isStepGroup(stepA);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/kit/dapp/src/components/stepper/utils.test.ts
+++ b/kit/dapp/src/components/stepper/utils.test.ts
@@ -122,21 +122,21 @@ describe("stepper utils", () => {
     it("should return true when current step is after target step", () => {
       const targetStep = stepA;
       const currentStep = stepB;
-      const result = isStepCompleted(targetStep, currentStep);
+      const result = isStepCompleted({ step: targetStep, currentStep });
       expect(result).toBe(true);
     });
 
     it("should return false when current step is at target step", () => {
       const targetStep = stepB;
       const currentStep = stepB;
-      const result = isStepCompleted(targetStep, currentStep);
+      const result = isStepCompleted({ step: targetStep, currentStep });
       expect(result).toBe(false);
     });
 
     it("should return false when current step is after target step", () => {
       const targetStep = stepC;
       const currentStep = stepB;
-      const result = isStepCompleted(targetStep, currentStep);
+      const result = isStepCompleted({ step: targetStep, currentStep });
       expect(result).toBe(false);
     });
   });

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -1,0 +1,72 @@
+import type { StepOrGroup } from "@/components/stepper/types";
+import type { Step, StepGroup } from "./types";
+
+export function isStepGroup(config: StepOrGroup): config is StepGroup {
+  return "steps" in config;
+}
+
+export function flattenSteps<
+  StepName extends string = string,
+  GroupName extends string = string,
+>(configs: readonly StepOrGroup<StepName, GroupName>[]): Step<StepName>[] {
+  return configs.reduce<Step<StepName>[]>((acc, config) => {
+    if (isStepGroup(config)) {
+      acc.push(...config.steps);
+    } else {
+      acc.push(config);
+    }
+    return acc;
+  }, []);
+}
+
+export function findGroupContainingStep(
+  configs: readonly Step[],
+  stepId: number
+): StepGroup | null {
+  for (const config of configs) {
+    if (
+      isStepGroup(config) &&
+      config.steps.some((step) => step.id === stepId)
+    ) {
+      return config;
+    }
+  }
+  return null;
+}
+
+export function getStepIndex(step: Step): number {
+  return step.id - 1;
+}
+
+export function getStepAtIndex(steps: Step[], index: number): Step {
+  const step = steps[index];
+  if (!step) {
+    throw new Error("Step not found");
+  }
+  return step;
+}
+
+export function getNextStep(steps: Step[], currentStep: Step): Step {
+  const currentStepIndex = getStepIndex(currentStep);
+  const isLastStep = currentStepIndex === steps.length - 1;
+  if (isLastStep) {
+    return currentStep;
+  }
+  return getStepAtIndex(steps, currentStepIndex + 1);
+}
+
+export function isGroupCompleted(group: StepGroup, currentStep: Step): boolean {
+  const lastStepInGroup = getStepAtIndex(group.steps, group.steps.length - 1);
+
+  const lastStepIndex = getStepIndex(lastStepInGroup);
+  const currentStepIndex = getStepIndex(currentStep);
+
+  return currentStepIndex > lastStepIndex;
+}
+
+export function isStepCompleted(step: Step, currentStep: Step): boolean {
+  const stepIndex = getStepIndex(step);
+  const currentStepIndex = getStepIndex(currentStep);
+
+  return stepIndex < currentStepIndex;
+}

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -1,94 +1,88 @@
 import type { StepOrGroup } from "@/components/stepper/types";
+import { getElementAtIndex } from "@/lib/utils/array";
 import type { Step, StepGroup } from "./types";
 
 export function getStepById<StepId>(
   steps: Step<StepId>[],
-  name: StepId
+  id: StepId
 ): Step<StepId> {
-  const step = steps.find((s) => s.id === name);
+  const step = steps.find((s) => s.id === id);
   if (!step) {
-    throw new Error("Step not found");
+    throw new Error(`Step with id ${id} not found`);
   }
   return step;
 }
 
-export function getStepByIndex<StepId>(
-  steps: Step<StepId>[],
-  index: number
-): Step<StepId> {
-  const step = steps[index];
-  if (!step) {
-    throw new Error("Step not found");
-  }
-  return step;
-}
-
-export function getStepIndex<StepId>(step: Step<StepId>): number {
-  return step.step - 1;
-}
-
-export function getNextStepName<StepId>(
-  steps: Step<StepId>[],
-  currentStepName: StepId
+export function getNextStepId<StepId>(
+  allSteps: Step<StepId>[],
+  currentStepId: StepId
 ): StepId {
-  const currentStep = getStepById(steps, currentStepName);
-  const currentStepIndex = getStepIndex(currentStep);
-  const isLastStep = currentStepIndex === steps.length - 1;
-  if (isLastStep) {
-    return currentStep.id;
-  }
-  return getStepByIndex(steps, currentStepIndex + 1).id;
+  const currentStep = getStepById(allSteps, currentStepId);
+  const nextStep = getNextStep(allSteps, currentStep);
+  return nextStep.id;
 }
 
 export function getNextStep<StepId>(
-  steps: Step<StepId>[],
+  allSteps: Step<StepId>[],
   currentStep: Step<StepId>
 ): Step<StepId> {
-  const currentStepIndex = getStepIndex(currentStep);
-  const isLastStep = currentStepIndex === steps.length - 1;
+  const sortedSteps = sortByStep(allSteps);
+  const currentIndex = sortedSteps.findIndex(
+    (step) => step.id === currentStep.id
+  );
+
+  if (currentIndex === -1) {
+    throw new Error(`Current step ${currentStep.id} not found in steps array`);
+  }
+
+  const isLastStep = currentIndex === sortedSteps.length - 1;
   if (isLastStep) {
     return currentStep;
   }
-  return getStepByIndex(steps, currentStepIndex + 1);
+
+  const nextStep = getElementAtIndex(sortedSteps, currentIndex + 1);
+  return nextStep;
+}
+
+export function getLastStep<StepId>(steps: Step<StepId>[]): Step<StepId> {
+  const sortedSteps = sortByStep(steps);
+  return getElementAtIndex(sortedSteps, sortedSteps.length - 1);
 }
 
 export function isStepCompleted<StepId>(
   step: Step<StepId>,
   currentStep: Step<StepId>
 ): boolean {
-  const stepIndex = getStepIndex(step);
-  const currentStepIndex = getStepIndex(currentStep);
-
-  return currentStepIndex > stepIndex;
+  return currentStep.step > step.step;
 }
 
 export function isGroupCompleted<StepId, GroupId>(
   group: StepGroup<StepId, GroupId>,
   currentStep: Step<StepId>
 ): boolean {
-  const lastStepInGroup = getStepByIndex(group.steps, group.steps.length - 1);
-
-  const lastStepIndex = getStepIndex(lastStepInGroup);
-  const currentStepIndex = getStepIndex(currentStep);
-
-  return currentStepIndex > lastStepIndex;
-}
-
-export function flattenSteps<StepId, GroupId>(
-  configs: readonly StepOrGroup<StepId, GroupId>[]
-): Step<StepId>[] {
-  return configs.reduce<Step<StepId>[]>((acc, config) => {
-    if (isStepGroup(config)) {
-      acc.push(...config.steps);
-    } else {
-      acc.push(config);
-    }
-    return acc;
-  }, []);
+  const lastStepInGroup = getLastStep(group.steps);
+  return isStepCompleted(lastStepInGroup, currentStep);
 }
 
 export function isStepGroup<StepId, GroupId>(
-  config: StepOrGroup<StepId, GroupId>
-): config is StepGroup<StepId, GroupId> {
-  return "steps" in config;
+  item: StepOrGroup<StepId, GroupId>
+): item is StepGroup<StepId, GroupId> {
+  return "steps" in item;
+}
+
+export function sortByStep<StepId>(steps: Step<StepId>[]): Step<StepId>[] {
+  return steps.sort((a, b) => a.step - b.step);
+}
+
+export function flattenSteps<StepId, GroupId>(
+  stepOrGroup: readonly StepOrGroup<StepId, GroupId>[]
+): Step<StepId>[] {
+  return stepOrGroup.reduce<Step<StepId>[]>((acc, item) => {
+    if (isStepGroup(item)) {
+      acc.push(...item.steps);
+    } else {
+      acc.push(item);
+    }
+    return acc;
+  }, []);
 }

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -51,11 +51,14 @@ export function getLastStep<StepId, Steps extends Step<StepId>[]>(
   return getElementAtIndex(sortedSteps, sortedSteps.length - 1);
 }
 
-export function isStepCompleted<StepId>(
-  step: Step<StepId>,
-  currentStep: Step<StepId>
-): boolean {
-  return currentStep.step > step.step;
+export function isStepCompleted<StepId>({
+  step,
+  currentStep,
+}: {
+  step: Step<StepId>;
+  currentStep: Step<StepId>;
+}): boolean {
+  return step.step < currentStep.step;
 }
 
 export function isGroupCompleted<StepId, GroupId>(
@@ -63,7 +66,7 @@ export function isGroupCompleted<StepId, GroupId>(
   currentStep: Step<StepId>
 ): boolean {
   const lastStepInGroup = getLastStep(group.steps);
-  return isStepCompleted(lastStepInGroup, currentStep);
+  return isStepCompleted({ step: lastStepInGroup, currentStep });
 }
 
 export function isStepGroup<StepId, GroupId>(

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -1,10 +1,10 @@
 import type { StepOrGroup } from "@/components/stepper/types";
 import type { Step, StepGroup } from "./types";
 
-export function getStepByName<StepName>(
-  steps: Step<StepName>[],
-  name: StepName
-): Step<StepName> {
+export function getStepById<StepId>(
+  steps: Step<StepId>[],
+  name: StepId
+): Step<StepId> {
   const step = steps.find((s) => s.id === name);
   if (!step) {
     throw new Error("Step not found");
@@ -12,10 +12,10 @@ export function getStepByName<StepName>(
   return step;
 }
 
-export function getStepByIndex<StepName>(
-  steps: Step<StepName>[],
+export function getStepByIndex<StepId>(
+  steps: Step<StepId>[],
   index: number
-): Step<StepName> {
+): Step<StepId> {
   const step = steps[index];
   if (!step) {
     throw new Error("Step not found");
@@ -23,15 +23,15 @@ export function getStepByIndex<StepName>(
   return step;
 }
 
-export function getStepIndex<StepName>(step: Step<StepName>): number {
+export function getStepIndex<StepId>(step: Step<StepId>): number {
   return step.step - 1;
 }
 
-export function getNextStepName<StepName>(
-  steps: Step<StepName>[],
-  currentStepName: StepName
-): StepName {
-  const currentStep = getStepByName(steps, currentStepName);
+export function getNextStepName<StepId>(
+  steps: Step<StepId>[],
+  currentStepName: StepId
+): StepId {
+  const currentStep = getStepById(steps, currentStepName);
   const currentStepIndex = getStepIndex(currentStep);
   const isLastStep = currentStepIndex === steps.length - 1;
   if (isLastStep) {
@@ -40,10 +40,10 @@ export function getNextStepName<StepName>(
   return getStepByIndex(steps, currentStepIndex + 1).id;
 }
 
-export function getNextStep<StepName>(
-  steps: Step<StepName>[],
-  currentStep: Step<StepName>
-): Step<StepName> {
+export function getNextStep<StepId>(
+  steps: Step<StepId>[],
+  currentStep: Step<StepId>
+): Step<StepId> {
   const currentStepIndex = getStepIndex(currentStep);
   const isLastStep = currentStepIndex === steps.length - 1;
   if (isLastStep) {
@@ -52,9 +52,9 @@ export function getNextStep<StepName>(
   return getStepByIndex(steps, currentStepIndex + 1);
 }
 
-export function isStepCompleted<StepName>(
-  step: Step<StepName>,
-  currentStep: Step<StepName>
+export function isStepCompleted<StepId>(
+  step: Step<StepId>,
+  currentStep: Step<StepId>
 ): boolean {
   const stepIndex = getStepIndex(step);
   const currentStepIndex = getStepIndex(currentStep);
@@ -62,9 +62,9 @@ export function isStepCompleted<StepName>(
   return currentStepIndex > stepIndex;
 }
 
-export function isGroupCompleted<StepName, GroupName>(
-  group: StepGroup<StepName, GroupName>,
-  currentStep: Step<StepName>
+export function isGroupCompleted<StepId, GroupId>(
+  group: StepGroup<StepId, GroupId>,
+  currentStep: Step<StepId>
 ): boolean {
   const lastStepInGroup = getStepByIndex(group.steps, group.steps.length - 1);
 
@@ -74,10 +74,10 @@ export function isGroupCompleted<StepName, GroupName>(
   return currentStepIndex > lastStepIndex;
 }
 
-export function flattenSteps<StepName, GroupName>(
-  configs: readonly StepOrGroup<StepName, GroupName>[]
-): Step<StepName>[] {
-  return configs.reduce<Step<StepName>[]>((acc, config) => {
+export function flattenSteps<StepId, GroupId>(
+  configs: readonly StepOrGroup<StepId, GroupId>[]
+): Step<StepId>[] {
+  return configs.reduce<Step<StepId>[]>((acc, config) => {
     if (isStepGroup(config)) {
       acc.push(...config.steps);
     } else {
@@ -87,8 +87,8 @@ export function flattenSteps<StepName, GroupName>(
   }, []);
 }
 
-export function isStepGroup<StepName, GroupName>(
-  config: StepOrGroup<StepName, GroupName>
-): config is StepGroup<StepName, GroupName> {
+export function isStepGroup<StepId, GroupId>(
+  config: StepOrGroup<StepId, GroupId>
+): config is StepGroup<StepId, GroupId> {
   return "steps" in config;
 }

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -59,7 +59,7 @@ export function isStepCompleted<StepName>(
   const stepIndex = getStepIndex(step);
   const currentStepIndex = getStepIndex(currentStep);
 
-  return stepIndex < currentStepIndex;
+  return currentStepIndex > stepIndex;
 }
 
 export function isGroupCompleted<StepName, GroupName>(

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -5,7 +5,7 @@ export function getStepByName<StepName>(
   steps: Step<StepName>[],
   name: StepName
 ): Step<StepName> {
-  const step = steps.find((s) => s.name === name);
+  const step = steps.find((s) => s.id === name);
   if (!step) {
     throw new Error("Step not found");
   }
@@ -24,7 +24,7 @@ export function getStepByIndex<StepName>(
 }
 
 export function getStepIndex<StepName>(step: Step<StepName>): number {
-  return step.id - 1;
+  return step.step - 1;
 }
 
 export function getNextStepName<StepName>(
@@ -35,9 +35,9 @@ export function getNextStepName<StepName>(
   const currentStepIndex = getStepIndex(currentStep);
   const isLastStep = currentStepIndex === steps.length - 1;
   if (isLastStep) {
-    return currentStep.name;
+    return currentStep.id;
   }
-  return getStepByIndex(steps, currentStepIndex + 1).name;
+  return getStepByIndex(steps, currentStepIndex + 1).id;
 }
 
 export function getNextStep<StepName>(

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -2,10 +2,10 @@ import type { StepOrGroup } from "@/components/stepper/types";
 import { getElementAtIndex } from "@/lib/utils/array";
 import type { Step, StepGroup } from "./types";
 
-export function getStepById<StepId>(
-  steps: Step<StepId>[],
-  id: StepId
-): Step<StepId> {
+export function getStepById<StepId, Steps extends Step<StepId>[]>(
+  steps: Steps,
+  id: Steps[number]["id"]
+): Steps[number] {
   const step = steps.find((s) => s.id === id);
   if (!step) {
     throw new Error(`Step with id ${id} not found`);
@@ -13,19 +13,19 @@ export function getStepById<StepId>(
   return step;
 }
 
-export function getNextStepId<StepId>(
-  allSteps: Step<StepId>[],
-  currentStepId: StepId
-): StepId {
+export function getNextStepId<StepId, Steps extends Step<StepId>[]>(
+  allSteps: Steps,
+  currentStepId: Steps[number]["id"]
+): Steps[number]["id"] {
   const currentStep = getStepById(allSteps, currentStepId);
   const nextStep = getNextStep(allSteps, currentStep);
   return nextStep.id;
 }
 
-export function getNextStep<StepId>(
-  allSteps: Step<StepId>[],
-  currentStep: Step<StepId>
-): Step<StepId> {
+export function getNextStep<StepId, Steps extends Step<StepId>[]>(
+  allSteps: Steps,
+  currentStep: Steps[number]
+): Steps[number] {
   const sortedSteps = sortByStep(allSteps);
   const currentIndex = sortedSteps.findIndex(
     (step) => step.id === currentStep.id
@@ -44,7 +44,9 @@ export function getNextStep<StepId>(
   return nextStep;
 }
 
-export function getLastStep<StepId>(steps: Step<StepId>[]): Step<StepId> {
+export function getLastStep<StepId, Steps extends Step<StepId>[]>(
+  steps: Steps
+): Steps[number] {
   const sortedSteps = sortByStep(steps);
   return getElementAtIndex(sortedSteps, sortedSteps.length - 1);
 }

--- a/kit/dapp/src/components/stepper/utils.ts
+++ b/kit/dapp/src/components/stepper/utils.ts
@@ -1,14 +1,82 @@
 import type { StepOrGroup } from "@/components/stepper/types";
 import type { Step, StepGroup } from "./types";
 
-export function isStepGroup(config: StepOrGroup): config is StepGroup {
-  return "steps" in config;
+export function getStepByName<StepName>(
+  steps: Step<StepName>[],
+  name: StepName
+): Step<StepName> {
+  const step = steps.find((s) => s.name === name);
+  if (!step) {
+    throw new Error("Step not found");
+  }
+  return step;
 }
 
-export function flattenSteps<
-  StepName extends string = string,
-  GroupName extends string = string,
->(configs: readonly StepOrGroup<StepName, GroupName>[]): Step<StepName>[] {
+export function getStepByIndex<StepName>(
+  steps: Step<StepName>[],
+  index: number
+): Step<StepName> {
+  const step = steps[index];
+  if (!step) {
+    throw new Error("Step not found");
+  }
+  return step;
+}
+
+export function getStepIndex<StepName>(step: Step<StepName>): number {
+  return step.id - 1;
+}
+
+export function getNextStepName<StepName>(
+  steps: Step<StepName>[],
+  currentStepName: StepName
+): StepName {
+  const currentStep = getStepByName(steps, currentStepName);
+  const currentStepIndex = getStepIndex(currentStep);
+  const isLastStep = currentStepIndex === steps.length - 1;
+  if (isLastStep) {
+    return currentStep.name;
+  }
+  return getStepByIndex(steps, currentStepIndex + 1).name;
+}
+
+export function getNextStep<StepName>(
+  steps: Step<StepName>[],
+  currentStep: Step<StepName>
+): Step<StepName> {
+  const currentStepIndex = getStepIndex(currentStep);
+  const isLastStep = currentStepIndex === steps.length - 1;
+  if (isLastStep) {
+    return currentStep;
+  }
+  return getStepByIndex(steps, currentStepIndex + 1);
+}
+
+export function isStepCompleted<StepName>(
+  step: Step<StepName>,
+  currentStep: Step<StepName>
+): boolean {
+  const stepIndex = getStepIndex(step);
+  const currentStepIndex = getStepIndex(currentStep);
+
+  return stepIndex < currentStepIndex;
+}
+
+export function isGroupCompleted<StepName, GroupName>(
+  group: StepGroup<StepName, GroupName>,
+  currentStep: Step<StepName>
+): boolean {
+  const lastStepInGroup = getStepByIndex(group.steps, group.steps.length - 1);
+
+  const lastStepIndex = getStepIndex(lastStepInGroup);
+  const currentStepIndex = getStepIndex(currentStep);
+
+  return currentStepIndex > lastStepIndex;
+}
+
+export function flattenSteps<StepName, GroupName>(
+  configs: readonly StepOrGroup<StepName, GroupName>[]
+): Step<StepName>[] {
   return configs.reduce<Step<StepName>[]>((acc, config) => {
     if (isStepGroup(config)) {
       acc.push(...config.steps);
@@ -19,54 +87,8 @@ export function flattenSteps<
   }, []);
 }
 
-export function findGroupContainingStep(
-  configs: readonly Step[],
-  stepId: number
-): StepGroup | null {
-  for (const config of configs) {
-    if (
-      isStepGroup(config) &&
-      config.steps.some((step) => step.id === stepId)
-    ) {
-      return config;
-    }
-  }
-  return null;
-}
-
-export function getStepIndex(step: Step): number {
-  return step.id - 1;
-}
-
-export function getStepAtIndex(steps: Step[], index: number): Step {
-  const step = steps[index];
-  if (!step) {
-    throw new Error("Step not found");
-  }
-  return step;
-}
-
-export function getNextStep(steps: Step[], currentStep: Step): Step {
-  const currentStepIndex = getStepIndex(currentStep);
-  const isLastStep = currentStepIndex === steps.length - 1;
-  if (isLastStep) {
-    return currentStep;
-  }
-  return getStepAtIndex(steps, currentStepIndex + 1);
-}
-
-export function isGroupCompleted(group: StepGroup, currentStep: Step): boolean {
-  const lastStepInGroup = getStepAtIndex(group.steps, group.steps.length - 1);
-
-  const lastStepIndex = getStepIndex(lastStepInGroup);
-  const currentStepIndex = getStepIndex(currentStep);
-
-  return currentStepIndex > lastStepIndex;
-}
-
-export function isStepCompleted(step: Step, currentStep: Step): boolean {
-  const stepIndex = getStepIndex(step);
-  const currentStepIndex = getStepIndex(currentStep);
-
-  return stepIndex < currentStepIndex;
+export function isStepGroup<StepName, GroupName>(
+  config: StepOrGroup<StepName, GroupName>
+): config is StepGroup<StepName, GroupName> {
+  return "steps" in config;
 }

--- a/kit/dapp/src/components/ui/collapsible-chevron.tsx
+++ b/kit/dapp/src/components/ui/collapsible-chevron.tsx
@@ -1,0 +1,60 @@
+import { ChevronDown } from "lucide-react";
+import React, { useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./collapsible";
+
+export interface CollapsibleChevronProps {
+  children: (isExpanded: boolean) => React.ReactNode;
+  trigger: (isExpanded: boolean) => React.ReactNode;
+  defaultOpen?: boolean;
+  className?: string;
+}
+
+export function CollapsibleChevron({
+  children,
+  trigger,
+  defaultOpen = false,
+  className,
+}: CollapsibleChevronProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultOpen);
+
+  const toggleExpanded = () => {
+    setIsExpanded((prev) => !prev);
+  };
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <CollapsibleTrigger
+        onClick={toggleExpanded}
+        aria-expanded={isExpanded}
+        aria-controls="expandable-content"
+        className={cn(
+          "flex items-center justify-between w-full p-3 rounded-lg transition-all duration-200",
+          "hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        )}
+      >
+        {trigger(isExpanded)}
+        <ChevronDown
+          className={cn(
+            "w-4 h-4 text-muted-foreground transition-transform duration-200",
+            isExpanded && "rotate-180"
+          )}
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+
+      <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+        <CollapsibleContent
+          id="expandable-content"
+          className="overflow-hidden transition-all duration-300 ease-in-out"
+        >
+          <div className="pb-2">{children(isExpanded)}</div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/kit/dapp/src/components/ui/collapsible-chevron.tsx
+++ b/kit/dapp/src/components/ui/collapsible-chevron.tsx
@@ -1,6 +1,6 @@
+import { cn } from "@/lib/utils";
 import { ChevronDown } from "lucide-react";
 import React, { useState } from "react";
-import { cn } from "@/lib/utils";
 import {
   Collapsible,
   CollapsibleContent,
@@ -10,17 +10,17 @@ import {
 export interface CollapsibleChevronProps {
   children: (isExpanded: boolean) => React.ReactNode;
   trigger: (isExpanded: boolean) => React.ReactNode;
-  defaultOpen?: boolean;
+  open?: boolean;
   className?: string;
 }
 
 export function CollapsibleChevron({
   children,
   trigger,
-  defaultOpen = false,
   className,
+  open = false,
 }: CollapsibleChevronProps) {
-  const [isExpanded, setIsExpanded] = useState(defaultOpen);
+  const [isExpanded, setIsExpanded] = useState(open);
 
   const toggleExpanded = () => {
     setIsExpanded((prev) => !prev);
@@ -28,26 +28,25 @@ export function CollapsibleChevron({
 
   return (
     <div className={cn("space-y-2", className)}>
-      <CollapsibleTrigger
-        onClick={toggleExpanded}
-        aria-expanded={isExpanded}
-        aria-controls="expandable-content"
-        className={cn(
-          "flex items-center justify-between w-full p-3 rounded-lg transition-all duration-200",
-          "hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-        )}
-      >
-        {trigger(isExpanded)}
-        <ChevronDown
-          className={cn(
-            "w-4 h-4 text-muted-foreground transition-transform duration-200",
-            isExpanded && "rotate-180"
-          )}
-          aria-hidden="true"
-        />
-      </CollapsibleTrigger>
-
       <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+        <CollapsibleTrigger
+          onClick={toggleExpanded}
+          aria-expanded={isExpanded}
+          aria-controls="expandable-content"
+          className={cn(
+            "flex items-center justify-between w-full p-3 rounded-lg transition-all duration-200",
+            "hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          )}
+        >
+          {trigger(isExpanded)}
+          <ChevronDown
+            className={cn(
+              "w-4 h-4 text-muted-foreground transition-transform duration-200",
+              isExpanded && "rotate-180"
+            )}
+            aria-hidden="true"
+          />
+        </CollapsibleTrigger>
         <CollapsibleContent
           id="expandable-content"
           className="overflow-hidden transition-all duration-300 ease-in-out"

--- a/kit/dapp/src/components/ui/collapsible-chevron.tsx
+++ b/kit/dapp/src/components/ui/collapsible-chevron.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import { ChevronDown } from "lucide-react";
-import React, { useState } from "react";
+import React from "react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -8,9 +8,10 @@ import {
 } from "./collapsible";
 
 export interface CollapsibleChevronProps {
-  children: (isExpanded: boolean) => React.ReactNode;
-  trigger: (isExpanded: boolean) => React.ReactNode;
-  open?: boolean;
+  children: (open: boolean) => React.ReactNode;
+  trigger: (open: boolean) => React.ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   className?: string;
 }
 
@@ -18,31 +19,25 @@ export function CollapsibleChevron({
   children,
   trigger,
   className,
-  open = false,
+  open,
+  onOpenChange,
 }: CollapsibleChevronProps) {
-  const [isExpanded, setIsExpanded] = useState(open);
-
-  const toggleExpanded = () => {
-    setIsExpanded((prev) => !prev);
-  };
-
   return (
     <div className={cn("space-y-2", className)}>
-      <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+      <Collapsible open={open} onOpenChange={onOpenChange}>
         <CollapsibleTrigger
-          onClick={toggleExpanded}
-          aria-expanded={isExpanded}
+          aria-expanded={open}
           aria-controls="expandable-content"
           className={cn(
             "flex items-center justify-between w-full p-3 rounded-lg transition-all duration-200",
             "hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
           )}
         >
-          {trigger(isExpanded)}
+          {trigger(open)}
           <ChevronDown
             className={cn(
               "w-4 h-4 text-muted-foreground transition-transform duration-200",
-              isExpanded && "rotate-180"
+              open && "rotate-180"
             )}
             aria-hidden="true"
           />
@@ -51,7 +46,7 @@ export function CollapsibleChevron({
           id="expandable-content"
           className="overflow-hidden transition-all duration-300 ease-in-out"
         >
-          <div className="pb-2">{children(isExpanded)}</div>
+          <div className="pb-2">{children(open)}</div>
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/kit/dapp/src/lib/interface-ids.ts
+++ b/kit/dapp/src/lib/interface-ids.ts
@@ -16,15 +16,15 @@ const STANDARD_INTERFACE_IDS = {
 
 // Generated interface IDs
 export const INTERFACE_IDS = {
-    ISMARTBurnable: "0xd7ae59db",
-    ISMARTCapped: "0x722a19dd",
-    ISMARTCollateral: "0xb5cb9db3",
-    ISMARTCustodian: "0x25e5ad79",
-    ISMARTPausable: "0xe78a39d8",
-    ISMARTRedeemable: "0xf4433ab7",
-    ISMARTYield: "0x85ebbbb4",
-    IERC3643: "0xb97d944c",
-  } as const;
+  ISMARTBurnable: "0xd7ae59db",
+  ISMARTCapped: "0x722a19dd",
+  ISMARTCollateral: "0xb5cb9db3",
+  ISMARTCustodian: "0x25e5ad79",
+  ISMARTPausable: "0xe78a39d8",
+  ISMARTRedeemable: "0xf4433ab7",
+  ISMARTYield: "0x85ebbbb4",
+  IERC3643: "0xb97d944c",
+} as const;
 
 // Merged interface IDs for easy access
 export const ALL_INTERFACE_IDS = {

--- a/kit/dapp/src/lib/utils/array.ts
+++ b/kit/dapp/src/lib/utils/array.ts
@@ -10,11 +10,15 @@
  * @throws {Error} When the element at the given index doesn't exist
  */
 export function getElementAtIndex<T>(elements: T[], index: number): T {
-  const element = elements[index];
-  if (!element) {
+  if (index < 0 || index >= elements.length) {
     throw new Error(
-      `Element at index ${index} not found in array (length: ${elements.length})`
+      `Invalid index ${index} for array of length ${elements.length}`
     );
+  }
+  const element = elements[index];
+  // This never happens, but we check for type safety
+  if (element === undefined) {
+    throw new Error(`Element at index ${index} is undefined`);
   }
   return element;
 }

--- a/kit/dapp/src/lib/utils/array.ts
+++ b/kit/dapp/src/lib/utils/array.ts
@@ -1,7 +1,20 @@
+/**
+ * Type-safe array element access that throws an error for invalid indices.
+ *
+ * Unlike native array access, this throws an explicit error instead of returning
+ * undefined, following the "fail fast" principle to catch bugs early.
+ *
+ * @param elements - The array to access
+ * @param index - The zero-based index of the element to retrieve
+ * @returns The element at the specified index
+ * @throws {Error} When the element at the given index doesn't exist
+ */
 export function getElementAtIndex<T>(elements: T[], index: number): T {
   const element = elements[index];
   if (!element) {
-    throw new Error(`Element at index ${index} not found`);
+    throw new Error(
+      `Element at index ${index} not found in array (length: ${elements.length})`
+    );
   }
   return element;
 }

--- a/kit/dapp/src/lib/utils/array.ts
+++ b/kit/dapp/src/lib/utils/array.ts
@@ -1,0 +1,7 @@
+export function getElementAtIndex<T>(elements: T[], index: number): T {
+  const element = elements[index];
+  if (!element) {
+    throw new Error(`Element at index ${index} not found`);
+  }
+  return element;
+}

--- a/kit/dapp/src/routes/_private/_onboarded.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded.tsx
@@ -1,4 +1,3 @@
-import { OnboardingGuard } from "@/components/onboarding/onboarding-guard";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/_onboarded")({
@@ -7,8 +6,8 @@ export const Route = createFileRoute("/_private/_onboarded")({
 
 function LayoutComponent() {
   return (
-    <OnboardingGuard require="onboarded">
-      <Outlet />
-    </OnboardingGuard>
+    // <OnboardingGuard require="onboarded">
+    <Outlet />
+    // </OnboardingGuard>
   );
 }

--- a/kit/dapp/src/routes/_private/_onboarded.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded.tsx
@@ -1,3 +1,4 @@
+import { OnboardingGuard } from "@/components/onboarding/onboarding-guard";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/_onboarded")({
@@ -6,8 +7,8 @@ export const Route = createFileRoute("/_private/_onboarded")({
 
 function LayoutComponent() {
   return (
-    // <OnboardingGuard require="onboarded">
-    <Outlet />
-    // </OnboardingGuard>
+    <OnboardingGuard require="onboarded">
+      <Outlet />
+    </OnboardingGuard>
   );
 }

--- a/kit/dapp/tsconfig.json
+++ b/kit/dapp/tsconfig.json
@@ -1,14 +1,7 @@
 {
-  "include": [
-    "**/*.ts",
-    "**/*.tsx"
-  ],
+  "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "target": "es2022",
     "module": "esnext",
     "jsx": "react-jsx",
@@ -34,15 +27,9 @@
     "allowArbitraryExtensions": true,
     "baseUrl": "./",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@schemas/*": [
-        "./*.d.ts"
-      ],
-      "@/locales/*": [
-        "./locales/*"
-      ]
+      "@/*": ["./src/*"],
+      "@schemas/*": ["./*.d.ts"],
+      "@/locales/*": ["./locales/*"]
     },
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Implements the logic for a stepper component which supports steps & steps or groups. It's partially styled, goal here was to structure the interface with typings. 


https://github.com/user-attachments/assets/9c7eea70-fee2-4848-8306-93e8fe9130e7



## Summary by Sourcery

Introduce a reusable stepper component and integrate it into the asset designer form to manage multi-step workflows declaratively.

New Features:
- Add generic stepper components (Stepper, StepItem, StepIndicator, StepSeparator, StepTrigger) along with StepLayout, StepGroup, and CollapsibleChevron for structured multi-step UIs
- Provide stepper utility functions (getStepByName, getNextStepName, isStepCompleted, flattenSteps, etc.) with associated TypeScript types
- Refactor the asset designer form to use the new StepLayout and stepper utilities, redefine steps as a typed array with id, name, label, and description, and replace inline next-step logic with getNextStepName

## Summary by Sourcery

Introduce a reusable stepper component suite with typed utilities and migrate the asset designer wizard to a declarative step layout with localized step definitions.

New Features:
- Add generic stepper components (Stepper, StepperItem, StepperIndicator, StepperSeparator, StepperTrigger) for building step-based UIs
- Introduce StepGroupComponent, StepLayout, and CollapsibleChevron for handling grouped and collapsible steps
- Add TypeScript utility functions for step navigation (getStepByName, getNextStepName, isStepCompleted, flattenSteps, etc.)
- Provide useAssetDesignerSteps hook for generating translated step definitions

Enhancements:
- Refactor asset-designer form to use StepLayout and stepper utilities instead of inline step logic
- Replace manual form.Subscribe and nextStep mapping with declarative step navigation via getNextStepName

Documentation:
- Add asset-designer localization entries for step titles and descriptions

Chores:
- Reformat tsconfig.json include and paths arrays for consistency