### PR TITLE
fix: resolve Solidity compiler warnings

### DIFF
--- a/kit/contracts/contracts/assets/bond/ATKBondImplementation.sol
+++ b/kit/contracts/contracts/assets/bond/ATKBondImplementation.sol
@@ -558,9 +558,8 @@ contract ATKBondImplementation is
 
     /// @notice Returns the yield basis per unit for a given address
     /// @dev Returns the face value of the bond. The address parameter is unused in this implementation.
-    /// @param holder The address to query yield basis for (unused in this implementation)
     /// @return The face value representing the yield basis per unit
-    function yieldBasisPerUnit(address holder) external view override returns (uint256) {
+    function yieldBasisPerUnit(address /* holder */ ) external view override returns (uint256) {
         return _faceValue;
     }
 

--- a/kit/contracts/contracts/system/access-manager/ATKSystemAccessManagerProxy.sol
+++ b/kit/contracts/contracts/system/access-manager/ATKSystemAccessManagerProxy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 pragma solidity ^0.8.28;
 
 import { AbstractATKSystemProxy } from "../AbstractATKSystemProxy.sol";


### PR DESCRIPTION
## Summary
- Added FSL-1.1-MIT license identifier to ATKSystemAccessManagerProxy.sol
- Fixed unused parameter warning in ATKBondImplementation.sol by commenting out the parameter name

## Changes
1. **License Compliance**: Added the missing SPDX license identifier to ensure all contracts have proper license declarations
2. **Compiler Warning**: Suppressed the unused parameter warning by using Solidity convention of commenting out the parameter name while keeping the type

## Test plan
- [x] Verified smart contracts compile without warnings using `bun run compile`
- [x] Confirmed CI passes with `bun run ci`
- [x] Ensured no functional changes were made to the contracts