### PR TITLE
fox: imagePullSecrets for common helm charts

### DIFF
--- a/kit/charts/atk/charts/erpc/templates/deployment.yaml
+++ b/kit/charts/atk/charts/erpc/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "common.images.renderPullSecrets" ( dict "images" (list .Values.image) "context" $) | nindent 6 }}
+      {{- include "atk.common.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "erpc.serviceAccountName" . }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}

--- a/kit/charts/atk/charts/portal/templates/deployment.yaml
+++ b/kit/charts/atk/charts/portal/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "common.images.renderPullSecrets" ( dict "images" (list .Values.image) "context" $) | nindent 6 }}
+      {{- include "atk.common.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "portal.serviceAccountName" . }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}

--- a/kit/charts/atk/charts/txsigner/templates/deployment.yaml
+++ b/kit/charts/atk/charts/txsigner/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "common.images.renderPullSecrets" ( dict "images" (list .Values.image) "context" $) | nindent 6 }}
+      {{- include "atk.common.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "txsigner.serviceAccountName" . }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace individual common.images.renderPullSecrets calls with the shared atk.common.imagePullSecrets helper across the erpc, portal, and txsigner charts