### PR TITLE
fix: move imagePullSecrets outside of values.yaml

### DIFF
--- a/kit/charts/CLAUDE.md
+++ b/kit/charts/CLAUDE.md
@@ -79,12 +79,31 @@ When cleaning values for production (e.g., AWS Marketplace), empty YAML values m
 - Empty strings: Use `""` with comment (e.g., `password: ""  # Must be provided`)
 - Empty lists: Use `[]`
 
-### Image Pull Secrets Format
+### Image Pull Secrets Configuration
+
+**IMPORTANT**: Image pull secrets have been centralized in the environment-specific values files for better security and maintainability.
+
+#### Current Architecture (as of 2025-08-01)
+- **Main values.yaml**: No longer contains any imagePullSecrets - only empty registries configuration
+- **tools/values-orbstack.1p.yaml**: Contains all imagePullSecrets for local development with 1Password references
+- **Production deployments**: Should use their own values file with appropriate imagePullSecrets
+
+#### Format
 Always use the object format with `name` field:
 ```yaml
 imagePullSecrets:
   - name: image-pull-secret-docker  # Correct
 # NOT: - image-pull-secret-docker   # Wrong
+```
+
+#### Adding imagePullSecrets to a Service
+Add to the environment-specific values file (e.g., `tools/values-orbstack.1p.yaml`):
+```yaml
+service-name:
+  imagePullSecrets:
+    - name: image-pull-secret-docker
+    - name: image-pull-secret-ghcr
+    - name: image-pull-secret-harbor
 ```
 
 ## Common Pitfalls

--- a/kit/charts/atk/README.md
+++ b/kit/charts/atk/README.md
@@ -30,44 +30,26 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | besu-network.besu-rpc-1.enabled | bool | `true` |  |
-| besu-network.besu-rpc-1.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| besu-network.besu-rpc-1.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| besu-network.besu-rpc-1.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | besu-network.besu-rpc-1.resources | object | `{}` |  |
 | besu-network.besu-rpc-1.storage.pvcSizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-rpc-1.storage.sizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-rpc-2.enabled | bool | `false` |  |
-| besu-network.besu-rpc-2.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| besu-network.besu-rpc-2.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| besu-network.besu-rpc-2.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | besu-network.besu-rpc-2.resources | object | `{}` |  |
 | besu-network.besu-rpc-2.storage.pvcSizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-rpc-2.storage.sizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-1.enabled | bool | `true` |  |
-| besu-network.besu-validator-1.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| besu-network.besu-validator-1.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| besu-network.besu-validator-1.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | besu-network.besu-validator-1.resources | object | `{}` |  |
 | besu-network.besu-validator-1.storage.pvcSizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-1.storage.sizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-2.enabled | bool | `false` |  |
-| besu-network.besu-validator-2.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| besu-network.besu-validator-2.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| besu-network.besu-validator-2.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | besu-network.besu-validator-2.resources | object | `{}` |  |
 | besu-network.besu-validator-2.storage.pvcSizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-2.storage.sizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-3.enabled | bool | `false` |  |
-| besu-network.besu-validator-3.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| besu-network.besu-validator-3.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| besu-network.besu-validator-3.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | besu-network.besu-validator-3.resources | object | `{}` |  |
 | besu-network.besu-validator-3.storage.pvcSizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-3.storage.sizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-4.enabled | bool | `false` |  |
-| besu-network.besu-validator-4.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| besu-network.besu-validator-4.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| besu-network.besu-validator-4.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | besu-network.besu-validator-4.resources | object | `{}` |  |
 | besu-network.besu-validator-4.storage.pvcSizeLimit | string | `"5Gi"` |  |
 | besu-network.besu-validator-4.storage.sizeLimit | string | `"5Gi"` |  |
@@ -82,9 +64,6 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | blockscout.blockscout-stack.blockscout.init.enabled | bool | `true` |  |
 | blockscout.blockscout-stack.blockscout.resources | object | `{}` |  |
 | blockscout.blockscout-stack.frontend.ingress.hostname | string | `"explorer.k8s.orb.local"` |  |
-| blockscout.blockscout-stack.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| blockscout.blockscout-stack.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| blockscout.blockscout-stack.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | blockscout.blockscout-stack.podAnnotations."prometheus.io/path" | string | `"/metrics"` |  |
 | blockscout.blockscout-stack.podAnnotations."prometheus.io/port" | string | `"4000"` |  |
 | blockscout.blockscout-stack.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -154,9 +133,6 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | erpc.config.server.httpHostV4 | string | `"0.0.0.0"` |  |
 | erpc.config.server.httpPort | int | `4000` |  |
 | erpc.enabled | bool | `true` |  |
-| erpc.image.pullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| erpc.image.pullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| erpc.image.pullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | erpc.ingress.className | string | `"atk-nginx"` |  |
 | erpc.ingress.enabled | bool | `true` |  |
 | erpc.ingress.hosts[0].host | string | `"rpc.k8s.orb.local"` |  |
@@ -174,93 +150,40 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | global.labels."kots.io/app-slug" | string | `"settlemint-atk"` |  |
 | global.networkPolicy.enabled | bool | `false` |  |
 | graph-node.enabled | bool | `true` |  |
-| graph-node.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| graph-node.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| graph-node.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | graph-node.podAnnotations."prometheus.io/path" | string | `"/metrics"` |  |
 | graph-node.podAnnotations."prometheus.io/port" | string | `"8040"` |  |
 | graph-node.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | hasura.enabled | bool | `true` |  |
-| hasura.graphql-engine.global.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| hasura.graphql-engine.global.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| hasura.graphql-engine.global.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | hasura.graphql-engine.ingress.hostName | string | `"hasura.k8s.orb.local"` |  |
 | hasura.graphql-engine.labels."app.kubernetes.io/component" | string | `"hasura"` |  |
 | hasura.graphql-engine.labels."app.kubernetes.io/instance" | string | `"atk"` |  |
 | hasura.graphql-engine.labels."kots.io/app-slug" | string | `"settlemint-atk"` |  |
 | hasura.graphql-engine.replicas | int | `1` |  |
-| imagePullCredentials.registries.docker | object | `{"email":"","enabled":false,"password":"","registryUrl":"docker.io","username":""}` | lowercase, no points or special caracters unique identifier for the registry, harbor, ghcr and docker have special meaning, but you can add more |
-| imagePullCredentials.registries.docker.email | string | `""` | The email to access the registry |
-| imagePullCredentials.registries.docker.enabled | bool | `false` | Enable this if you want this chart to create an image pull secret for you |
-| imagePullCredentials.registries.docker.password | string | `""` | The password or access token to access the registry |
-| imagePullCredentials.registries.docker.registryUrl | string | `"docker.io"` | The registry hosting the packages, e.g docker.io or ghcr.io |
-| imagePullCredentials.registries.docker.username | string | `""` | The username to access the registry |
-| imagePullCredentials.registries.ghcr | object | `{"email":"","enabled":false,"password":"","registryUrl":"ghcr.io","username":""}` | lowercase, no points or special caracters unique identifier for the registry, harbor, ghcr and docker have special meaning, but you can add more |
-| imagePullCredentials.registries.ghcr.email | string | `""` | The email to access the registry |
-| imagePullCredentials.registries.ghcr.enabled | bool | `false` | Enable this if you want this chart to create an image pull secret for you |
-| imagePullCredentials.registries.ghcr.password | string | `""` | The password or access token to access the registry |
-| imagePullCredentials.registries.ghcr.registryUrl | string | `"ghcr.io"` | The registry hosting the packages, e.g docker.io or ghcr.io |
-| imagePullCredentials.registries.ghcr.username | string | `""` | The username to access the registry |
-| imagePullCredentials.registries.harbor | object | `{"email":"","enabled":false,"password":"","registryUrl":"harbor.settlemint.com","username":""}` | lowercase, no points or special caracters unique identifier for the registry, harbor, ghcr and docker have special meaning, but you can add more |
-| imagePullCredentials.registries.harbor.email | string | `""` | The email to access the registry |
-| imagePullCredentials.registries.harbor.enabled | bool | `false` | Enable this if you want this chart to create an image pull secret for you (harbor is the default registry for the platform) |
-| imagePullCredentials.registries.harbor.password | string | `""` | The password or access token to access the registry |
-| imagePullCredentials.registries.harbor.registryUrl | string | `"harbor.settlemint.com"` | The registry hosting the packages, e.g docker.io or ghcr.io |
-| imagePullCredentials.registries.harbor.username | string | `""` | The username to access the registry |
-| observability.alertmanager.alertmanager.global.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.alertmanager.alertmanager.global.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.alertmanager.alertmanager.global.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
+| imagePullCredentials.registries | object | `{}` |  |
+| observability.alertmanager.alertmanager.resources | object | `{}` |  |
 | observability.alloy.alloy.resources | object | `{}` |  |
-| observability.alloy.global.image.pullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.alloy.global.image.pullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.alloy.global.image.pullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | observability.enabled | bool | `true` |  |
 | observability.grafana.adminPassword | string | `"atk"` |  |
 | observability.grafana.adminUser | string | `"settlemint"` |  |
-| observability.grafana.global.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.grafana.global.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.grafana.global.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | observability.grafana.ingress.hosts[0] | string | `"grafana.k8s.orb.local"` |  |
-| observability.kube-state-metrics.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.kube-state-metrics.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.kube-state-metrics.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | observability.kube-state-metrics.resources | object | `{}` |  |
-| observability.loki.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.loki.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.loki.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
+| observability.loki.singleBinary.extraEnv | object | `{}` |  |
+| observability.loki.singleBinary.persistence.size | string | `"10Gi"` |  |
+| observability.loki.singleBinary.resources | object | `{}` |  |
 | observability.metrics-server.enabled | bool | `false` |  |
-| observability.metrics-server.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.metrics-server.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.metrics-server.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | observability.metrics-server.resources | object | `{}` |  |
-| observability.prometheus-stack.global.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.prometheus-stack.global.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.prometheus-stack.global.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
-| observability.singleBinary.extraEnv | object | `{}` |  |
-| observability.singleBinary.persistence.size | string | `"10Gi"` |  |
-| observability.singleBinary.resources | object | `{}` |  |
-| observability.tempo.global.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.tempo.global.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.tempo.global.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
-| observability.victoria-metrics-single.global.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| observability.victoria-metrics-single.global.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| observability.victoria-metrics-single.global.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
+| observability.prometheus-stack.prometheusOperator.resources | object | `{}` |  |
+| observability.tempo.server.resources | object | `{}` |  |
 | observability.victoria-metrics-single.server.persistentVolume.size | string | `"10Gi"` |  |
 | observability.victoria-metrics-single.server.persistentVolume.storageClass | string | `""` |  |
 | observability.victoria-metrics-single.server.resources | object | `{}` |  |
 | portal.enabled | bool | `true` |  |
-| portal.image.pullSecrets[0] | string | `"image-pull-secret-docker"` |  |
-| portal.image.pullSecrets[1] | string | `"image-pull-secret-ghcr"` |  |
-| portal.image.pullSecrets[2] | string | `"image-pull-secret-harbor"` |  |
 | portal.podAnnotations."prometheus.io/path" | string | `"/portal-metrics"` |  |
 | portal.podAnnotations."prometheus.io/port" | string | `"3000"` |  |
 | portal.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | portal.podLabels."app.kubernetes.io/component" | string | `"portal"` |  |
 | support.enabled | bool | `true` |  |
 | support.ingress-nginx.controller.resources | object | `{}` |  |
-| support.ingress-nginx.imagePullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| support.ingress-nginx.imagePullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| support.ingress-nginx.imagePullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | support.ingress-nginx.replicaCount | int | `1` |  |
 | support.minio.enabled | bool | `true` |  |
 | support.minio.image.repository | string | `"docker.io/minio/minio"` |  |
@@ -275,9 +198,6 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | support.redis.commonLabels."kots.io/app-slug" | string | `"settlemint-atk"` |  |
 | support.redis.enabled | bool | `true` |  |
 | support.redis.fullnameOverride | string | `"redis"` |  |
-| support.redis.image.pullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| support.redis.image.pullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| support.redis.image.pullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | support.redis.persistence.enabled | bool | `true` |  |
 | support.redis.persistence.size | string | `"1Gi"` |  |
 | support.redis.resources.limits.cpu | string | `"200m"` |  |
@@ -288,9 +208,6 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | txsigner.config.derivationPath | string | `"m/44'/60'/0'/0/0"` |  |
 | txsigner.config.mnemonic | string | `"gate yellow grunt wrestle disease obtain mixed nature mansion tape purchase awful"` |  |
 | txsigner.enabled | bool | `true` |  |
-| txsigner.image.pullSecrets[0].name | string | `"image-pull-secret-docker"` |  |
-| txsigner.image.pullSecrets[1].name | string | `"image-pull-secret-ghcr"` |  |
-| txsigner.image.pullSecrets[2].name | string | `"image-pull-secret-harbor"` |  |
 | txsigner.postgresql | string | `"postgresql://txsigner:atk@postgresql:5432/txsigner?sslmode=disable"` |  |
 | txsigner.replicaCount | int | `1` |  |
 | txsigner.resources | object | `{}` |  |

--- a/kit/charts/atk/templates/_helpers.tpl
+++ b/kit/charts/atk/templates/_helpers.tpl
@@ -74,7 +74,7 @@ Create the name of the service account to use
 Creates an image pull secret value
 */}}
 {{- define "atk.imagePullSecret" }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registryUrl .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 
 {{/*

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -23,102 +23,42 @@ global:
 
 
 imagePullCredentials:
-  registries:
-    # -- lowercase, no points or special caracters unique identifier for the registry, harbor, ghcr and docker have special meaning, but you can add more
-    harbor:
-      # -- Enable this if you want this chart to create an image pull secret for you (harbor is the default registry for the platform)
-      enabled: false
-      # -- The registry hosting the packages, e.g docker.io or ghcr.io
-      registryUrl: 'harbor.settlemint.com'
-      # -- The username to access the registry
-      username: ''
-      # -- The password or access token to access the registry
-      password: ''
-      # -- The email to access the registry
-      email: ''
-    # -- lowercase, no points or special caracters unique identifier for the registry, harbor, ghcr and docker have special meaning, but you can add more
-    ghcr:
-      # -- Enable this if you want this chart to create an image pull secret for you
-      enabled: false
-      # -- The registry hosting the packages, e.g docker.io or ghcr.io
-      registryUrl: 'ghcr.io'
-      # -- The username to access the registry
-      username: ''
-      # -- The password or access token to access the registry
-      password: ''
-      # -- The email to access the registry
-      email: ''
-    # -- lowercase, no points or special caracters unique identifier for the registry, harbor, ghcr and docker have special meaning, but you can add more
-    docker:
-      # -- Enable this if you want this chart to create an image pull secret for you
-      enabled: false
-      # -- The registry hosting the packages, e.g docker.io or ghcr.io
-      registryUrl: 'docker.io'
-      # -- The username to access the registry
-      username: ''
-      # -- The password or access token to access the registry
-      password: ''
-      # -- The email to access the registry
-      email: ''
+  registries: {}
 
 besu-network:
   enabled: true
   besu-validator-1:
     enabled: true
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     storage:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
   besu-validator-2:
     enabled: false
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     storage:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
   besu-validator-3:
     enabled: false
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     storage:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
   besu-validator-4:
     enabled: false
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     storage:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
   besu-rpc-1:
     enabled: true
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     storage:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
     resources: {}
   besu-rpc-2:
     enabled: false
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     storage:
       sizeLimit: "5Gi"
       pvcSizeLimit: "5Gi"
@@ -131,11 +71,6 @@ besu-network:
 erpc:
   enabled: true
   resources: {}
-  image:
-    pullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
   ingress:
     enabled: true
     className: "atk-nginx"
@@ -192,10 +127,6 @@ erpc:
 blockscout:
   enabled: true
   blockscout-stack:
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "4000"
@@ -228,10 +159,6 @@ blockscout:
 
 graph-node:
   enabled: true
-  imagePullSecrets:
-    - name: image-pull-secret-docker
-    - name: image-pull-secret-ghcr
-    - name: image-pull-secret-harbor
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8040"
@@ -241,11 +168,6 @@ hasura:
   enabled: true
   graphql-engine:
     replicas: 1
-    global:
-      imagePullSecrets:
-        - name: image-pull-secret-docker
-        - name: image-pull-secret-ghcr
-        - name: image-pull-secret-harbor
     ingress:
       hostName: "hasura.k8s.orb.local"
     labels:
@@ -255,11 +177,6 @@ hasura:
 
 portal:
   enabled: true
-  image:
-    pullSecrets:
-      - image-pull-secret-docker
-      - image-pull-secret-ghcr
-      - image-pull-secret-harbor
   podLabels:
     app.kubernetes.io/component: portal
   podAnnotations:
@@ -273,10 +190,6 @@ support:
   # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   ingress-nginx:
     replicaCount: 1
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     controller:
       resources: {}
   # https://github.com/stakater/Reloader/tree/master/deployments/kubernetes/chart/reloader
@@ -302,11 +215,6 @@ support:
     commonLabels:
       kots.io/app-slug: settlemint-atk
       app.kubernetes.io/managed-by: helm
-    image:
-      pullSecrets:
-        - name: image-pull-secret-docker
-        - name: image-pull-secret-ghcr
-        - name: image-pull-secret-harbor
     auth:
       enabled: true
       password: "atk"
@@ -327,27 +235,14 @@ observability:
   # https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
   metrics-server:
     enabled: false
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     resources: {}
 
   # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml
   kube-state-metrics:
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
     resources: {}
 
   # https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-single/values.yaml
   victoria-metrics-single:
-    global:
-      imagePullSecrets:
-        - name: image-pull-secret-docker
-        - name: image-pull-secret-ghcr
-        - name: image-pull-secret-harbor
     server:
       persistentVolume:
         storageClass: ""
@@ -356,69 +251,39 @@ observability:
 
   # https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
   loki:
-    imagePullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
-  singleBinary:
-    persistence:
-      size: 10Gi
-    resources: {}
-    extraEnv: {}
-      # Keep a little bit lower than memory limits
-      # - name: GOMEMLIMIT
-      #   value: 3750MiB
+    singleBinary:
+      persistence:
+        size: 10Gi
+      resources: {}
+      extraEnv: {}
+        # Keep a little bit lower than memory limits
+        # - name: GOMEMLIMIT
+        #   value: 3750MiB
 
   # https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/values.yaml
   alloy:
-    global:
-      image:
-        pullSecrets:
-          - name: image-pull-secret-docker
-          - name: image-pull-secret-ghcr
-          - name: image-pull-secret-harbor
     alloy:
       resources: {}
 
   alertmanager:
     alertmanager:
-      global:
-        imagePullSecrets:
-          - name: image-pull-secret-docker
-          - name: image-pull-secret-ghcr
-          - name: image-pull-secret-harbor
+      resources: {}
   prometheus-stack:
-    global:
-      imagePullSecrets:
-        - name: image-pull-secret-docker
-        - name: image-pull-secret-ghcr
-        - name: image-pull-secret-harbor
+    prometheusOperator:
+      resources: {}
   grafana:
-    global:
-      imagePullSecrets:
-        - name: image-pull-secret-docker
-        - name: image-pull-secret-ghcr
-        - name: image-pull-secret-harbor
     ingress:
       hosts:
         - grafana.k8s.orb.local
     adminUser: settlemint
     adminPassword: atk
   tempo:
-    global:
-      imagePullSecrets:
-        - name: image-pull-secret-docker
-        - name: image-pull-secret-ghcr
-        - name: image-pull-secret-harbor
+    server:
+      resources: {}
 
 # Transaction Signer Configuration
 txsigner:
   enabled: true
-  image:
-    pullSecrets:
-      - name: image-pull-secret-docker
-      - name: image-pull-secret-ghcr
-      - name: image-pull-secret-harbor
   # Configuration for the txsigner subchart
   config:
     mnemonic: "gate yellow grunt wrestle disease obtain mixed nature mansion tape purchase awful"

--- a/kit/charts/tools/values-orbstack.1p.yaml
+++ b/kit/charts/tools/values-orbstack.1p.yaml
@@ -43,11 +43,152 @@ imagePullCredentials:
 # PodDisruptionBudget configurations
 # For development, we typically don't need PDBs, but for production they should be enabled
 
-dapp:
-  enabled: false
+# Configure imagePullSecrets for all services
+besu-network:
+  besu-validator-1:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  besu-validator-2:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  besu-validator-3:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  besu-validator-4:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  besu-rpc-1:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  besu-rpc-2:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+
+erpc:
+  image:
+    pullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+
+blockscout:
+  blockscout-stack:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+
+graph-node:
+  imagePullSecrets:
+    - name: image-pull-secret-docker
+    - name: image-pull-secret-ghcr
+    - name: image-pull-secret-harbor
+
+hasura:
+  graphql-engine:
+    global:
+      imagePullSecrets:
+        - name: image-pull-secret-docker
+        - name: image-pull-secret-ghcr
+        - name: image-pull-secret-harbor
+
+portal:
+  image:
+    pullSecrets:
+      - image-pull-secret-docker
+      - image-pull-secret-ghcr
+      - image-pull-secret-harbor
+
+support:
+  ingress-nginx:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  redis:
+    image:
+      pullSecrets:
+        - name: image-pull-secret-docker
+        - name: image-pull-secret-ghcr
+        - name: image-pull-secret-harbor
+
+observability:
+  metrics-server:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  kube-state-metrics:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  victoria-metrics-single:
+    global:
+      imagePullSecrets:
+        - name: image-pull-secret-docker
+        - name: image-pull-secret-ghcr
+        - name: image-pull-secret-harbor
+  loki:
+    imagePullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
+  alloy:
+    global:
+      image:
+        pullSecrets:
+          - name: image-pull-secret-docker
+          - name: image-pull-secret-ghcr
+          - name: image-pull-secret-harbor
+  alertmanager:
+    alertmanager:
+      global:
+        imagePullSecrets:
+          - name: image-pull-secret-docker
+          - name: image-pull-secret-ghcr
+          - name: image-pull-secret-harbor
+  prometheus-stack:
+    global:
+      imagePullSecrets:
+        - name: image-pull-secret-docker
+        - name: image-pull-secret-ghcr
+        - name: image-pull-secret-harbor
+  grafana:
+    global:
+      imagePullSecrets:
+        - name: image-pull-secret-docker
+        - name: image-pull-secret-ghcr
+        - name: image-pull-secret-harbor
+  tempo:
+    global:
+      imagePullSecrets:
+        - name: image-pull-secret-docker
+        - name: image-pull-secret-ghcr
+        - name: image-pull-secret-harbor
 
 txsigner:
+  image:
+    pullSecrets:
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
   ingress:
     enabled: true
     hostname: txsigner.k8s.orb.local
+
+dapp:
+  enabled: false
 

--- a/kit/charts/tools/values-orbstack.1p.yaml
+++ b/kit/charts/tools/values-orbstack.1p.yaml
@@ -107,9 +107,9 @@ hasura:
 portal:
   image:
     pullSecrets:
-      - image-pull-secret-docker
-      - image-pull-secret-ghcr
-      - image-pull-secret-harbor
+      - name: image-pull-secret-docker
+      - name: image-pull-secret-ghcr
+      - name: image-pull-secret-harbor
 
 support:
   ingress-nginx:


### PR DESCRIPTION
## Summary by Sourcery

Centralize imagePullSecrets in environment-specific values files and remove them from the default values.yaml, update the Helm helper and documentation to reflect the new configuration

Enhancements:
- Remove all imagePullSecrets entries from kit/charts/atk/values.yaml and collapse registries into an empty object
- Populate tools/values-orbstack.1p.yaml with per-service imagePullSecrets for local development
- Modify the imagePullSecret helper to reference the registry key instead of registryUrl

Documentation:
- Update README.md to strip out default imagePullSecrets and reflect the new registries schema
- Revise CLAUDE.md to document the centralized imagePullSecrets configuration and usage instructions