### PR TITLE
fix: empty subgraph env after compile

### DIFF
--- a/kit/subgraph/tools/compile.sh
+++ b/kit/subgraph/tools/compile.sh
@@ -13,7 +13,7 @@ if grep -q '0x5e771e1417100000000000000000000000020088' subgraph.yaml; then
 
     echo "SystemFactory address is the default, building and updating generated files"
     # Build and capture IPFS hash
-    BUILD_OUTPUT=$(bunx settlemint scs subgraph build --ipfs=https://ipfs.console.settlemint.com)
+    BUILD_OUTPUT=$(bunx settlemint scs subgraph build --ipfs=https://ipfs.console.settlemint.com) || { echo "Error: Subgraph build failed." >&2; exit 1; }
     echo "$BUILD_OUTPUT"
 
     # Extract subgraph hash and save to files

--- a/kit/subgraph/tools/compile.sh
+++ b/kit/subgraph/tools/compile.sh
@@ -11,12 +11,22 @@ if grep -q '0x5e771e1417100000000000000000000000020088' subgraph.yaml; then
         echo 'SUBGRAPH=kit:' > .generated/subgraph-env
     fi
 
+    echo "SystemFactory address is the default, building and updating generated files"
     # Build and capture IPFS hash
-    bunx settlemint scs subgraph build --ipfs=https://ipfs.console.settlemint.com | \
-        tee >(grep -o 'Qm[a-zA-Z0-9]*' | tail -1 | \
-            tee .generated/subgraph-hash.txt | \
-            xargs -I {} echo 'SUBGRAPH=kit:{}' > .generated/subgraph-env)
+    BUILD_OUTPUT=$(bunx settlemint scs subgraph build --ipfs=https://ipfs.console.settlemint.com)
+    echo "$BUILD_OUTPUT"
+
+    # Extract IPFS hash and save to files
+    IPFS_HASH=$(echo "$BUILD_OUTPUT" | grep -o 'Qm[a-zA-Z0-9]*' | tail -1)
+    if [ -n "$IPFS_HASH" ]; then
+        echo "$IPFS_HASH" > .generated/subgraph-hash.txt
+        echo "SUBGRAPH=kit:$IPFS_HASH" > .generated/subgraph-env
+        echo "Saved IPFS hash: $IPFS_HASH"
+    else
+        echo "Warning: No IPFS hash found in build output"
+    fi
 else
     # Address doesn't match, just build without updating generated files
+    echo "SystemFactory address doesn't match the default, just building without updating generated files"
     bunx settlemint scs subgraph build --ipfs=https://ipfs.console.settlemint.com
 fi

--- a/kit/subgraph/tools/compile.sh
+++ b/kit/subgraph/tools/compile.sh
@@ -16,12 +16,12 @@ if grep -q '0x5e771e1417100000000000000000000000020088' subgraph.yaml; then
     BUILD_OUTPUT=$(bunx settlemint scs subgraph build --ipfs=https://ipfs.console.settlemint.com)
     echo "$BUILD_OUTPUT"
 
-    # Extract IPFS hash and save to files
-    IPFS_HASH=$(echo "$BUILD_OUTPUT" | grep -o 'Qm[a-zA-Z0-9]*' | tail -1)
-    if [ -n "$IPFS_HASH" ]; then
-        echo "$IPFS_HASH" > .generated/subgraph-hash.txt
-        echo "SUBGRAPH=kit:$IPFS_HASH" > .generated/subgraph-env
-        echo "Saved IPFS hash: $IPFS_HASH"
+    # Extract subgraph hash and save to files
+    SUBGRAPH_HASH=$(echo "$BUILD_OUTPUT" | grep -o 'Qm[a-zA-Z0-9]*' | tail -1)
+    if [ -n "$SUBGRAPH_HASH" ]; then
+        echo "$SUBGRAPH_HASH" > .generated/subgraph-hash.txt
+        echo "SUBGRAPH=kit:$SUBGRAPH_HASH" > .generated/subgraph-env
+        echo "Saved IPFS hash: $SUBGRAPH_HASH"
     else
         echo "Warning: No IPFS hash found in build output"
     fi

--- a/kit/subgraph/tools/compile.sh
+++ b/kit/subgraph/tools/compile.sh
@@ -21,9 +21,9 @@ if grep -q '0x5e771e1417100000000000000000000000020088' subgraph.yaml; then
     if [ -n "$SUBGRAPH_HASH" ]; then
         echo "$SUBGRAPH_HASH" > .generated/subgraph-hash.txt
         echo "SUBGRAPH=kit:$SUBGRAPH_HASH" > .generated/subgraph-env
-        echo "Saved IPFS hash: $SUBGRAPH_HASH"
+        echo "Saved subgraph hash: $SUBGRAPH_HASH"
     else
-        echo "Warning: No IPFS hash found in build output"
+        echo "Warning: No subgraph hash found in build output"
     fi
 else
     # Address doesn't match, just build without updating generated files


### PR DESCRIPTION
## Summary by Sourcery

Improve the subgraph compile script to reliably extract and persist the IPFS hash, add logging, and handle build failures.

Bug Fixes:
- Prevent writing an empty .generated/subgraph-env by correctly extracting and saving the subgraph IPFS hash

Enhancements:
- Capture the build output in a variable and exit on failure
- Add informative logging for the default address branch, saved hashes, and missing hash scenarios