### PR TITLE
feat(dapp): add bond yield coverage chart

### DIFF
--- a/kit/dapp/locales/en-US/stats.json
+++ b/kit/dapp/locales/en-US/stats.json
@@ -72,6 +72,18 @@
       "available": "Available collateral",
       "used": "Used collateral",
       "ratio": "Collateralization: {{ratio}}%"
+    },
+    "yieldCoverage": {
+      "title": "Yield Coverage",
+      "description": "Coverage of yield payments by underlying assets",
+      "notBond": "This asset is not a bond",
+      "noSchedule": "No yield schedule configured",
+      "notActive": "Yield schedule is not active",
+      "covered": "Covered",
+      "uncovered": "Uncovered",
+      "insufficient": "Insufficient Coverage",
+      "currentPeriod": "Current Period Covered",
+      "fullCoverage": "Full Coverage"
     }
   },
   "title": "Statistics",

--- a/kit/dapp/src/components/stats/charts/asset-bond-yield-coverage-chart.tsx
+++ b/kit/dapp/src/components/stats/charts/asset-bond-yield-coverage-chart.tsx
@@ -3,7 +3,7 @@ import { ComponentErrorBoundary } from "@/components/error/component-error-bound
 import { useBondYieldCoverageData } from "@/hooks/use-bond-yield-coverage-data";
 import { CHART_QUERY_OPTIONS } from "@/lib/query-options";
 import { orpc } from "@/orpc/orpc-client";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries } from "@tanstack/react-query";
 
 export interface AssetBondYieldCoverageChartProps {
   assetAddress: string;
@@ -29,19 +29,18 @@ export function AssetBondYieldCoverageChart({
   assetAddress,
 }: AssetBondYieldCoverageChartProps) {
   // Fetch token data and bond yield coverage data in parallel
-  const { data: token } = useSuspenseQuery(
-    orpc.token.read.queryOptions({
-      input: { tokenAddress: assetAddress },
-      ...CHART_QUERY_OPTIONS,
-    })
-  );
-
-  const { data: yieldCoverage } = useSuspenseQuery(
-    orpc.token.statsBondYieldCoverage.queryOptions({
-      input: { tokenAddress: assetAddress },
-      ...CHART_QUERY_OPTIONS,
-    })
-  );
+  const [{ data: token }, { data: yieldCoverage }] = useSuspenseQueries({
+    queries: [
+      orpc.token.read.queryOptions({
+        input: { tokenAddress: assetAddress },
+        ...CHART_QUERY_OPTIONS,
+      }),
+      orpc.token.statsBondYieldCoverage.queryOptions({
+        input: { tokenAddress: assetAddress },
+        ...CHART_QUERY_OPTIONS,
+      }),
+    ],
+  });
 
   // Transform data using our custom hook
   const chartData = useBondYieldCoverageData(token, yieldCoverage);

--- a/kit/dapp/src/components/stats/charts/asset-bond-yield-coverage-chart.tsx
+++ b/kit/dapp/src/components/stats/charts/asset-bond-yield-coverage-chart.tsx
@@ -1,0 +1,77 @@
+import { PieChartComponent } from "@/components/charts/pie-chart";
+import { ComponentErrorBoundary } from "@/components/error/component-error-boundary";
+import { useBondYieldCoverageData } from "@/hooks/use-bond-yield-coverage-data";
+import { CHART_QUERY_OPTIONS } from "@/lib/query-options";
+import { orpc } from "@/orpc/orpc-client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export interface AssetBondYieldCoverageChartProps {
+  assetAddress: string;
+}
+
+/**
+ * Asset Bond Yield Coverage Chart Component
+ *
+ * Displays bond yield coverage as a donut chart showing:
+ * - Coverage percentage (how much underlying asset is available to cover yield payments)
+ * - Visual representation of coverage status with color coding:
+ *   - Red: <100% (insufficient coverage)
+ *   - Yellow: 100-199% (covers current but not next period)
+ *   - Green: ≥200% (covers current and next period)
+ *
+ * This component follows the same pattern as AssetBondStatusProgressChart:
+ * - Clean separation of concerns between UI and business logic
+ * - Memoized data transformation for optimal performance
+ * - Type-safe with comprehensive interfaces
+ * - Easily testable with isolated business logic
+ */
+export function AssetBondYieldCoverageChart({
+  assetAddress,
+}: AssetBondYieldCoverageChartProps) {
+  // Fetch token data and bond yield coverage data in parallel
+  const { data: token } = useSuspenseQuery(
+    orpc.token.read.queryOptions({
+      input: { tokenAddress: assetAddress },
+      ...CHART_QUERY_OPTIONS,
+    })
+  );
+
+  const { data: yieldCoverage } = useSuspenseQuery(
+    orpc.token.statsBondYieldCoverage.queryOptions({
+      input: { tokenAddress: assetAddress },
+      ...CHART_QUERY_OPTIONS,
+    })
+  );
+
+  // Transform data using our custom hook
+  const chartData = useBondYieldCoverageData(token, yieldCoverage);
+
+  // Create footer JSX from footer data
+  const chartFooter = chartData.footerData ? (
+    <div className="flex flex-col items-center justify-center space-y-2">
+      <div className="text-2xl font-bold">
+        {chartData.footerData.percentage}%
+      </div>
+      <div className="text-sm text-muted-foreground text-center">
+        <div className="capitalize font-medium text-foreground">
+          {chartData.footerData.label}
+        </div>
+      </div>
+    </div>
+  ) : null;
+
+  // Render the chart with processed data
+  return (
+    <ComponentErrorBoundary componentName="Asset Bond Yield Coverage Chart">
+      <PieChartComponent
+        title={chartData.title}
+        description={chartData.description}
+        data={chartData.data}
+        config={chartData.config}
+        dataKey="value"
+        nameKey="name"
+        footer={chartFooter}
+      />
+    </ComponentErrorBoundary>
+  );
+}

--- a/kit/dapp/src/hooks/use-bond-yield-coverage-data.ts
+++ b/kit/dapp/src/hooks/use-bond-yield-coverage-data.ts
@@ -1,0 +1,150 @@
+import type { ChartConfig } from "@/components/ui/chart";
+import type { StatsBondYieldCoverageOutput } from "@/orpc/routes/token/routes/stats/bond-yield-coverage.schema";
+import type { Token } from "@/orpc/routes/token/routes/token.read.schema";
+import { toNumber } from "dnum";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+type ChartDataPoint = {
+  name: "covered" | "uncovered";
+  value: number;
+  fill: string;
+};
+
+export interface YieldCoverageChartData {
+  data: ChartDataPoint[];
+  config: ChartConfig;
+  title: string;
+  description: string;
+  footerData?: {
+    percentage: number;
+    label: string;
+  };
+  isEmpty: boolean;
+}
+
+/**
+ * Custom hook for processing bond yield coverage data into chart-ready format
+ *
+ * Transforms yield coverage data into a donut chart visualization showing:
+ * - Coverage percentage with color-coded thresholds
+ * - Empty state for tokens without yield schedules
+ * - Inactive state for non-running yield schedules
+ *
+ * @param token - Token data from orpc.token.read
+ * @param yieldCoverage - Yield coverage data from orpc.token.statsBondYieldCoverage
+ * @returns Chart-ready data with appropriate visualization state
+ */
+export function useBondYieldCoverageData(
+  token: Token,
+  yieldCoverage: StatsBondYieldCoverageOutput
+): YieldCoverageChartData {
+  const { t } = useTranslation(["stats", "tokens"]);
+
+  return useMemo(() => {
+    // Handle empty states
+    if (!token.bond) {
+      return {
+        data: [],
+        config: {},
+        title: t("stats:charts.yieldCoverage.title"),
+        description: t("stats:charts.yieldCoverage.notBond"),
+        isEmpty: true,
+      };
+    }
+
+    if (!yieldCoverage.hasYieldSchedule) {
+      return {
+        data: [],
+        config: {},
+        title: t("stats:charts.yieldCoverage.title"),
+        description: t("stats:charts.yieldCoverage.noSchedule"),
+        isEmpty: true,
+      };
+    }
+
+    if (!yieldCoverage.isRunning) {
+      return {
+        data: [],
+        config: {},
+        title: t("stats:charts.yieldCoverage.title"),
+        description: t("stats:charts.yieldCoverage.notActive"),
+        isEmpty: true,
+      };
+    }
+
+    // Calculate coverage percentage - don't cap at 100% as bonds can have >200% coverage
+    const rawCoveragePercent = toNumber(yieldCoverage.yieldCoverage);
+    // Ensure non-negative values for display
+    const coveragePercent = Math.max(0, rawCoveragePercent);
+
+    // Determine color based on thresholds
+    // Red: <100% (insufficient coverage)
+    // Yellow: 100-199% (covers current but not next period)
+    // Green: ≥200% (covers current and next period)
+    let color: string;
+    let statusLabel: string;
+
+    if (coveragePercent < 100) {
+      color = "hsl(var(--destructive))";
+      statusLabel = t("stats:charts.yieldCoverage.insufficient");
+    } else if (coveragePercent < 200) {
+      color = "hsl(var(--warning))";
+      statusLabel = t("stats:charts.yieldCoverage.currentPeriod");
+    } else {
+      color = "hsl(var(--success))";
+      statusLabel = t("stats:charts.yieldCoverage.fullCoverage");
+    }
+
+    // Create chart data for donut visualization
+    // For coverage > 100%, show 100% covered with no uncovered portion
+    const displayCovered = Math.min(100, coveragePercent);
+    const displayUncovered = Math.max(0, 100 - coveragePercent);
+
+    const chartData = [
+      {
+        name: "covered" as const,
+        value: displayCovered,
+        fill: color,
+      },
+      {
+        name: "uncovered" as const,
+        value: displayUncovered,
+        fill: "hsl(var(--muted))",
+      },
+    ];
+
+    // Create chart configuration
+    const config: ChartConfig = {
+      covered: {
+        label: t("stats:charts.yieldCoverage.covered"),
+        color,
+      },
+      uncovered: {
+        label: t("stats:charts.yieldCoverage.uncovered"),
+        color: "hsl(var(--muted))",
+      },
+    };
+
+    // Return footer data
+    const footerData = {
+      percentage: Math.round(coveragePercent),
+      label: statusLabel,
+    };
+
+    return {
+      data: chartData,
+      config,
+      title: t("stats:charts.yieldCoverage.title"),
+      description: t("stats:charts.yieldCoverage.description"),
+      footerData,
+      isEmpty: false,
+    };
+  }, [
+    token.bond,
+    yieldCoverage.hasYieldSchedule,
+    yieldCoverage.isRunning,
+    yieldCoverage.yieldCoverage,
+    t,
+  ]);
+}

--- a/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.contract.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.contract.ts
@@ -1,0 +1,17 @@
+import { baseContract } from "@/orpc/procedures/base.contract";
+import {
+  StatsBondYieldCoverageInputSchema,
+  StatsBondYieldCoverageOutputSchema,
+} from "./bond-yield-coverage.schema";
+
+export const statsBondYieldCoverageContract = baseContract
+  .route({
+    method: "GET",
+    path: "/token/{tokenAddress}/stats/bond-yield-coverage",
+    description: "Get bond yield coverage statistics for a specific token",
+    successDescription:
+      "Bond yield coverage statistics including yield schedule information",
+    tags: ["token", "stats", "bond", "yield"],
+  })
+  .input(StatsBondYieldCoverageInputSchema)
+  .output(StatsBondYieldCoverageOutputSchema);

--- a/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.schema.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { bigDecimal } from "@/lib/zod/validators/bigdecimal";
+
+// Input schema
+export const StatsBondYieldCoverageInputSchema = z.object({
+  tokenAddress: z.string(),
+});
+
+export type StatsBondYieldCoverageInput = z.infer<
+  typeof StatsBondYieldCoverageInputSchema
+>;
+
+// Output schema
+export const StatsBondYieldCoverageOutputSchema = z.object({
+  hasYieldSchedule: z.boolean(),
+  isRunning: z.boolean(),
+  yieldCoverage: bigDecimal(),
+});
+
+export type StatsBondYieldCoverageOutput = z.infer<
+  typeof StatsBondYieldCoverageOutputSchema
+>;

--- a/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.ts
@@ -102,15 +102,15 @@ export const statsBondYieldCoverage = tokenRouter.token.statsBondYieldCoverage
       }
     );
 
-    // Check if yield schedule exists
-    const hasYieldSchedule = !!response.token.yield_?.schedule;
-
     // Check if yield schedule is running (current time is between start and end date)
+    const schedule = response.token.yield_?.schedule;
+    const hasYieldSchedule = !!schedule;
+
     let isRunning = false;
-    if (hasYieldSchedule && response.token.yield_?.schedule) {
+    if (schedule) {
       const now = Math.floor(Date.now() / 1000);
-      const startDate = Number(response.token.yield_.schedule.startDate);
-      const endDate = Number(response.token.yield_.schedule.endDate);
+      const startDate = Number(schedule.startDate);
+      const endDate = Number(schedule.endDate);
       isRunning = now >= startDate && now <= endDate;
     }
 

--- a/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/stats/bond-yield-coverage.ts
@@ -1,0 +1,139 @@
+import { theGraphGraphql } from "@/lib/settlemint/the-graph";
+import { theGraphMiddleware } from "@/orpc/middlewares/services/the-graph.middleware";
+import { tokenRouter } from "@/orpc/procedures/token.router";
+import { from } from "dnum";
+import { z } from "zod";
+
+/**
+ * GraphQL query to fetch bond yield coverage statistics for a specific token
+ * Retrieves yield schedule information and coverage data
+ */
+const TOKEN_BOND_YIELD_COVERAGE_QUERY = theGraphGraphql(`
+  query TokenBondYieldCoverage($tokenId: ID!) {
+    token(id: $tokenId) {
+      id
+      bond {
+        stats {
+          coveredPercentage
+        }
+      }
+      yield_ {
+        schedule {
+          id
+          startDate
+          endDate
+        }
+      }
+    }
+  }
+`);
+
+// Schema for the GraphQL response
+const StatsBondYieldCoverageResponseSchema = z.object({
+  token: z.object({
+    id: z.string(),
+    bond: z
+      .object({
+        stats: z
+          .object({
+            coveredPercentage: z.string().nullable(),
+          })
+          .nullable(),
+      })
+      .nullable(),
+    yield_: z
+      .object({
+        schedule: z
+          .object({
+            id: z.string(),
+            startDate: z.string(),
+            endDate: z.string(),
+          })
+          .nullable(),
+      })
+      .nullable(),
+  }),
+});
+
+/**
+ * Bond yield coverage statistics route handler.
+ *
+ * Fetches yield coverage information including:
+ * - Current coverage percentage (available / required * 100)
+ * - Yield schedule existence
+ * - Whether yield schedule is currently running
+ *
+ * This endpoint is optimized for bond yield coverage gauge charts.
+ *
+ * Authentication: Required
+ * Permissions: Requires "read" permission on the specific token
+ * Method: GET /token/stats/{tokenAddress}/bond-yield-coverage
+ *
+ * @param input.tokenAddress - The bond token contract address to query
+ * @returns Promise<StatsBondYieldCoverageOutput> - Bond yield coverage statistics
+ * @throws UNAUTHORIZED - If user is not authenticated
+ * @throws FORBIDDEN - If user lacks required read permissions on the token
+ * @throws NOT_FOUND - If token is not a bond
+ * @throws INTERNAL_SERVER_ERROR - If TheGraph query fails
+ *
+ * @example
+ * ```typescript
+ * // Get bond yield coverage for chart display
+ * const yieldCoverage = await orpc.token.statsBondYieldCoverage.query({
+ *   input: { tokenAddress: '0x1234...' }
+ * });
+ * console.log(`Coverage: ${yieldCoverage.yieldCoverage}%`);
+ * ```
+ */
+export const statsBondYieldCoverage = tokenRouter.token.statsBondYieldCoverage
+  .use(theGraphMiddleware)
+  .handler(async ({ context, input }) => {
+    // Token context is guaranteed by tokenRouter middleware
+    const { tokenAddress } = input;
+
+    // Fetch bond yield coverage from TheGraph
+    const response = await context.theGraphClient.query(
+      TOKEN_BOND_YIELD_COVERAGE_QUERY,
+      {
+        input: {
+          tokenId: tokenAddress.toLowerCase(),
+        },
+        output: StatsBondYieldCoverageResponseSchema,
+      }
+    );
+
+    // Check if yield schedule exists
+    const hasYieldSchedule = !!response.token.yield_?.schedule;
+
+    // Check if yield schedule is running (current time is between start and end date)
+    let isRunning = false;
+    if (hasYieldSchedule && response.token.yield_?.schedule) {
+      const now = Math.floor(Date.now() / 1000);
+      const startDate = Number(response.token.yield_.schedule.startDate);
+      const endDate = Number(response.token.yield_.schedule.endDate);
+      isRunning = now >= startDate && now <= endDate;
+    }
+
+    // Get coverage percentage from bond stats with proper validation
+    const bondStats = response.token.bond?.stats;
+    const rawCoverage = bondStats?.coveredPercentage;
+
+    // Validate and sanitize coverage percentage
+    let yieldCoverage = from(0);
+    if (rawCoverage && rawCoverage.trim() !== "") {
+      try {
+        const coverageValue = from(rawCoverage);
+        // Ensure non-negative value - negative coverage doesn't make business sense
+        yieldCoverage = coverageValue[0] >= 0n ? coverageValue : from(0);
+      } catch {
+        // Invalid number format - default to 0
+        yieldCoverage = from(0);
+      }
+    }
+
+    return {
+      hasYieldSchedule,
+      isRunning,
+      yieldCoverage,
+    };
+  });

--- a/kit/dapp/src/orpc/routes/token/token.contract.ts
+++ b/kit/dapp/src/orpc/routes/token/token.contract.ts
@@ -33,6 +33,7 @@ import { tokenSearchContract } from "@/orpc/routes/token/routes/token.search.con
 
 // Stats contracts
 import { statsBondStatusContract } from "@/orpc/routes/token/routes/stats/bond-status.contract";
+import { statsBondYieldCoverageContract } from "@/orpc/routes/token/routes/stats/bond-yield-coverage.contract";
 import { statsCollateralRatioContract } from "@/orpc/routes/token/routes/stats/collateral-ratio.contract";
 import { statsSupplyChangesContract } from "@/orpc/routes/token/routes/stats/supply-changes.contract";
 import { statsTotalSupplyContract } from "@/orpc/routes/token/routes/stats/total-supply.contract";
@@ -74,6 +75,7 @@ export const tokenContract = {
 
   // Stats
   statsBondStatus: statsBondStatusContract,
+  statsBondYieldCoverage: statsBondYieldCoverageContract,
   statsCollateralRatio: statsCollateralRatioContract,
   statsTotalSupply: statsTotalSupplyContract,
   statsSupplyChanges: statsSupplyChangesContract,

--- a/kit/dapp/src/orpc/routes/token/token.router.ts
+++ b/kit/dapp/src/orpc/routes/token/token.router.ts
@@ -19,6 +19,7 @@ import { redeem } from "@/orpc/routes/token/routes/mutations/redeem/token.redeem
 import { transfer } from "@/orpc/routes/token/routes/mutations/transfer/token.transfer";
 import { setYieldSchedule } from "@/orpc/routes/token/routes/mutations/yield/token.set-yield-schedule";
 import { statsBondStatus } from "@/orpc/routes/token/routes/stats/bond-status";
+import { statsBondYieldCoverage } from "@/orpc/routes/token/routes/stats/bond-yield-coverage";
 import { statsCollateralRatio } from "@/orpc/routes/token/routes/stats/collateral-ratio";
 import { statsSupplyChanges } from "@/orpc/routes/token/routes/stats/supply-changes";
 import { statsTotalSupply } from "@/orpc/routes/token/routes/stats/total-supply";
@@ -59,6 +60,7 @@ const routes = {
   addComplianceModule,
   removeComplianceModule,
   statsBondStatus,
+  statsBondYieldCoverage,
   statsCollateralRatio,
   statsTotalSupply,
   statsSupplyChanges,

--- a/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx
@@ -3,6 +3,7 @@ import { DetailGrid } from "@/components/detail-grid/detail-grid";
 import { DetailGridItem } from "@/components/detail-grid/detail-grid-item";
 import { DefaultCatchBoundary } from "@/components/error/default-catch-boundary";
 import { AssetBondStatusProgressChart } from "@/components/stats/charts/asset-bond-status-progress-chart";
+import { AssetBondYieldCoverageChart } from "@/components/stats/charts/asset-bond-yield-coverage-chart";
 import { AssetCollateralRatioChart } from "@/components/stats/charts/asset-collateral-ratio-chart";
 import { AssetSupplyChangesAreaChart } from "@/components/stats/charts/asset-supply-changes-area-chart";
 import { AssetTotalSupplyAreaChart } from "@/components/stats/charts/asset-total-supply-area-chart";
@@ -225,6 +226,11 @@ function RouteComponent() {
           {asset.bond && (
             <Suspense fallback={<ChartSkeleton />}>
               <AssetBondStatusProgressChart assetAddress={asset.id} />
+            </Suspense>
+          )}
+          {asset.bond && asset.extensions.includes("YIELD") && (
+            <Suspense fallback={<ChartSkeleton />}>
+              <AssetBondYieldCoverageChart assetAddress={asset.id} />
             </Suspense>
           )}
           {asset.collateral && (

--- a/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx
@@ -9,6 +9,7 @@ import { AssetSupplyChangesAreaChart } from "@/components/stats/charts/asset-sup
 import { AssetTotalSupplyAreaChart } from "@/components/stats/charts/asset-total-supply-area-chart";
 import { AssetTotalVolumeAreaChart } from "@/components/stats/charts/asset-total-volume-area-chart";
 import { AssetWalletDistributionChart } from "@/components/stats/charts/asset-wallet-distribution-chart";
+import { AssetExtensionEnum } from "@/lib/zod/validators/asset-extensions";
 import { createFileRoute, useLoaderData } from "@tanstack/react-router";
 import { Suspense } from "react";
 import { useTranslation } from "react-i18next";
@@ -228,11 +229,12 @@ function RouteComponent() {
               <AssetBondStatusProgressChart assetAddress={asset.id} />
             </Suspense>
           )}
-          {asset.bond && asset.extensions.includes("YIELD") && (
-            <Suspense fallback={<ChartSkeleton />}>
-              <AssetBondYieldCoverageChart assetAddress={asset.id} />
-            </Suspense>
-          )}
+          {asset.bond &&
+            asset.extensions.includes(AssetExtensionEnum.YIELD) && (
+              <Suspense fallback={<ChartSkeleton />}>
+                <AssetBondYieldCoverageChart assetAddress={asset.id} />
+              </Suspense>
+            )}
           {asset.collateral && (
             <Suspense fallback={<ChartSkeleton />}>
               <AssetCollateralRatioChart assetAddress={asset.id} />


### PR DESCRIPTION
## Summary

Adds a bond yield coverage visualization chart to the token details page for bonds with YIELD extension enabled.

## What's Changed

### New Features
- **Bond Yield Coverage Chart**: Visual representation of yield coverage percentage using a donut chart
  - Color-coded thresholds: Red (<100%), Yellow (100-199%), Green (≥200%)
  - Shows covered vs uncovered yield amounts
  - Empty states for non-yield bonds and inactive schedules

### Technical Implementation
- Added ORPC route handler (`statsBondYieldCoverage`) to fetch yield coverage data from TheGraph
- Created reusable data transformation hook (`useBondYieldCoverageData`) for chart data processing
- Implemented chart component following existing patterns (`AssetBondYieldCoverageChart`)
- Added comprehensive error handling and data validation
- Used `AssetExtensionEnum.YIELD` instead of hardcoded strings for better type safety

### Files Added/Modified
- `src/components/stats/charts/asset-bond-yield-coverage-chart.tsx` - Chart component
- `src/hooks/use-bond-yield-coverage-data.ts` - Data transformation hook
- `src/orpc/routes/token/routes/stats/bond-yield-coverage.ts` - ORPC route handler
- `src/orpc/routes/token/routes/stats/bond-yield-coverage.schema.ts` - Schema definitions
- `src/orpc/routes/token/routes/stats/bond-yield-coverage.contract.ts` - Contract definition
- `src/orpc/routes/token/token.contract.ts` - Added route to token contract
- `src/orpc/routes/token/token.router.ts` - Added route to token router
- `src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/$tokenAddress/index.tsx` - Integrated chart
- `locales/en-US/stats.json` - Added translation keys

## Testing
- Chart displays correctly for bonds with YIELD extension
- Empty states show appropriate messages
- Coverage percentage calculations work correctly
- Color thresholds display as expected

## Screenshots
The chart will display in the token details page stats section for yield-enabled bonds.

## Notes
- Removed the bond yield distribution chart implementation as the required data is not yet available in the subgraph
- Future work may include adding yield distribution tracking once the subgraph schema is updated

Closes #3551

## Summary by Sourcery

Add a bond yield coverage visualization feature by introducing a new statsBondYieldCoverage ORPC route, a custom data hook, and a chart component, then integrate it into the token details page with color-coded coverage statuses and empty states.

New Features:
- Add a bond yield coverage donut chart to the token details page for yield-enabled bonds, including color-coded thresholds and empty/inactive states
- Expose a new ORPC GET /token/{tokenAddress}/stats/bond-yield-coverage endpoint to retrieve yield coverage data from TheGraph

Enhancements:
- Introduce useBondYieldCoverageData hook for memoized data transformation with error handling and type safety
- Implement AssetBondYieldCoverageChart component that fetches token and coverage data in parallel and displays a PieChart with a footer showing the coverage percentage
- Replace hardcoded extension strings with the AssetExtensionEnum.YIELD for improved type safety

Documentation:
- Add translation keys for bond yield coverage chart titles, descriptions, and status labels