### PR TITLE
fix: sign in/out with onboarded user test

### DIFF
--- a/.github/workflows/e2e-playwright-tests.yml
+++ b/.github/workflows/e2e-playwright-tests.yml
@@ -156,7 +156,7 @@ jobs:
         id: playwright-ui
         # if: success() || steps.playwright-api.conclusion == 'failure'
         run: |
-          bun playwright test --config=playwright.ui.config.ts --project=ui-tests --retries 2 --reporter=html
+          bun playwright test --config=playwright.ui.config.ts --retries 2 --reporter=html
         working-directory: kit/e2e
         env:
           CI: true

--- a/kit/e2e/pages/portfolio-page.ts
+++ b/kit/e2e/pages/portfolio-page.ts
@@ -189,6 +189,46 @@ export class PortfolioPage extends BasePage {
     await expect(addressCell).toBeVisible();
   }
 
+  async signOut(): Promise<void> {
+    try {
+      await this.page.waitForLoadState("networkidle");
+      const userButton = this.page
+        .locator("button")
+        .filter({
+          hasText: /@.*\.com/,
+        })
+        .first();
+
+      if (await userButton.isVisible({ timeout: 5000 })) {
+        await userButton.click();
+
+        const logoutMenuItem = this.page.getByRole("menuitem", {
+          name: "Log out",
+        });
+        await logoutMenuItem.waitFor({ state: "visible", timeout: 3000 });
+        await logoutMenuItem.click();
+
+        return;
+      }
+
+      throw new Error(
+        "Could not find user button for sign out. Please check the UI structure."
+      );
+    } catch (error) {
+      throw new Error(
+        `Sign out failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  async expectSignOutSuccess(): Promise<void> {
+    await this.page.waitForURL(/auth\/sign-in/, { timeout: 10000 });
+
+    await this.page
+      .getByRole("button", { name: "Login" })
+      .waitFor({ state: "visible" });
+  }
+
   private parseAmountString(text: string): number {
     return parseAmountString(text);
   }

--- a/kit/e2e/pages/sign-in-page.ts
+++ b/kit/e2e/pages/sign-in-page.ts
@@ -93,4 +93,58 @@ export class SignInPage {
       );
     }
   }
+
+  async fillEmail(email: string): Promise<void> {
+    const emailField = this.page.getByRole("textbox", { name: "Email" });
+    await emailField.waitFor({ state: "visible", timeout: 10000 });
+    await emailField.fill(email);
+  }
+
+  async fillPassword(password: string): Promise<void> {
+    const passwordField = this.page.getByRole("textbox", { name: "Password" });
+    await passwordField.waitFor({ state: "visible", timeout: 10000 });
+    await passwordField.fill(password);
+  }
+
+  async clickEmailField(): Promise<void> {
+    const emailField = this.page.getByRole("textbox", { name: "Email" });
+    await emailField.waitFor({ state: "visible", timeout: 10000 });
+    await emailField.click();
+  }
+
+  async clickPasswordField(): Promise<void> {
+    const passwordField = this.page.getByRole("textbox", { name: "Password" });
+    await passwordField.waitFor({ state: "visible", timeout: 10000 });
+    await passwordField.click();
+  }
+
+  async clickLoginButton(): Promise<void> {
+    const loginButton = this.page.getByRole("button", { name: "Login" });
+    await expect(loginButton).toBeEnabled({ timeout: 10000 });
+    await loginButton.click();
+  }
+
+  async expectValidationError(errorMessage: string): Promise<void> {
+    await expect(this.page.getByText(errorMessage)).toBeVisible({
+      timeout: 10000,
+    });
+  }
+
+  async expectSuccessfulNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL("/", { timeout: 10000 });
+  }
+
+  async expectSuccessfulLoginWithDashboard(): Promise<void> {
+    await expect(this.page).toHaveURL("/", { timeout: 10000 });
+
+    const assetDesignerButton = this.page.getByRole("button", {
+      name: "Asset designer",
+    });
+    await expect(assetDesignerButton).toBeVisible({ timeout: 15000 });
+
+    const addonDesignerButton = this.page.getByRole("button", {
+      name: "Addon designer",
+    });
+    await expect(addonDesignerButton).toBeVisible({ timeout: 15000 });
+  }
 }

--- a/kit/e2e/playwright.ui.config.ts
+++ b/kit/e2e/playwright.ui.config.ts
@@ -4,7 +4,6 @@ import baseConfig from "./playwright.base.config";
 const uiConfig: PlaywrightTestConfig = {
   ...baseConfig,
   testDir: "./ui-tests",
-  testIgnore: ["**/create-*.spec.ts", "**/xvp-settlement.spec.ts"],
   use: {
     ...baseConfig.use,
     headless: true,
@@ -14,7 +13,27 @@ const uiConfig: PlaywrightTestConfig = {
   },
   projects: [
     {
+      name: "setup",
+      testMatch: "**/complete-onboarding-flow.spec.ts",
+      fullyParallel: false,
+      teardown: "cleanup",
+    },
+    {
       name: "ui-tests",
+      testMatch: "**/*.spec.ts",
+      testIgnore: [
+        "**/complete-onboarding-flow.spec.ts",
+        "**/global-cleanup.spec.ts",
+        "**/create-*.spec.ts",
+        "**/xvp-settlement.spec.ts",
+      ],
+      fullyParallel: true,
+      dependencies: ["setup"],
+    },
+    {
+      name: "cleanup",
+      testMatch: "**/global-cleanup.spec.ts",
+      fullyParallel: false,
     },
   ],
 };

--- a/kit/e2e/test-data/error-messages.ts
+++ b/kit/e2e/test-data/error-messages.ts
@@ -1,0 +1,25 @@
+export const errorMessages = {
+  validation: {
+    emailRequired: "Email is required",
+    passwordRequired: "Password is required",
+    emailInvalid: "Email is invalid",
+  },
+  authentication: {
+    invalidCredentials: "The email or password you entered is invalid.",
+  },
+  signUp: {
+    emailRequired: "Email is required",
+    passwordRequired: "Password is required",
+    confirmPasswordRequired: "Confirm Password is required",
+    passwordsDoNotMatch: "Passwords do not match",
+    emailInvalid: "Email is invalid",
+    passwordTooShort: "Password must be at least 8 characters",
+    emailAlreadyExists: "An account with this email already exists",
+  },
+  general: {
+    networkError: "Network error occurred",
+    unexpectedError: "An unexpected error occurred",
+  },
+} as const;
+
+export type ErrorMessages = typeof errorMessages;

--- a/kit/e2e/test-data/user-data.ts
+++ b/kit/e2e/test-data/user-data.ts
@@ -83,18 +83,9 @@ export const adminApiUser: SignUpData = {
 
 export const signInTestData = {
   wrongPassword: "WrongPassword123!",
-  invalidEmails: [
-    "not-an-email",
-    "invalid-email",
-    "missing@domain",
-    "@missing-local.com",
-    "spaces in@email.com",
-    "double..dots@email.com",
-  ],
 } as const;
 
 export const onboardingTestData = {
-  // Generate unique data for each test run
   email: `admin-onboarding-${Date.now()}-${Math.random().toString(36).substring(7)}@settlemint.com`,
   password: "TestPassword123!",
   pinCode: "987654",

--- a/kit/e2e/test-data/validation-data.ts
+++ b/kit/e2e/test-data/validation-data.ts
@@ -1,0 +1,25 @@
+export const validationTestData = {
+  invalidEmails: [
+    "not-an-email",
+    "invalid-email",
+    "missing@domain",
+    "@missing-local.com",
+    "spaces in@email.com",
+    "double..dots@email.com",
+    "email@",
+    ".email@domain.com",
+    "email@domain.",
+    "email@.domain.com",
+  ],
+  nonExistentEmails: [
+    "nonexistent@settlemint.com",
+    "fake@settlemint.com",
+    "notreal@settlemint.com",
+  ],
+  emptyFields: {
+    email: "",
+    password: "",
+  },
+} as const;
+
+export type ValidationTestData = typeof validationTestData;

--- a/kit/e2e/ui-tests/complete-onboarding-flow.spec.ts
+++ b/kit/e2e/ui-tests/complete-onboarding-flow.spec.ts
@@ -1,4 +1,7 @@
 import { test } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { OnboardingPage } from "../pages/onboarding-page";
 import { onboardingTestData } from "../test-data/user-data";
 
@@ -54,6 +57,23 @@ test.describe.serial("Complete Onboarding Flow", () => {
     await onboardingPage.completeIdentityVerification(testData.pinCode);
     await onboardingPage.verifyOnboardingComplete(
       `${testData.kycData.firstName} ${testData.kycData.lastName}`
+    );
+
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const setupDataPath = path.join(__dirname, "../test-data/setup-user.json");
+    fs.writeFileSync(
+      setupDataPath,
+      JSON.stringify(
+        {
+          email: testData.email,
+          password: testData.password,
+          pinCode: testData.pinCode,
+          fullName: `${testData.kycData.firstName} ${testData.kycData.lastName}`,
+          createdAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
     );
   });
 });

--- a/kit/e2e/ui-tests/complete-onboarding-flow.spec.ts
+++ b/kit/e2e/ui-tests/complete-onboarding-flow.spec.ts
@@ -1,9 +1,8 @@
 import { test } from "@playwright/test";
 import * as fs from "node:fs";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { OnboardingPage } from "../pages/onboarding-page";
 import { onboardingTestData } from "../test-data/user-data";
+import { getSetupUserPath } from "../utils/setup-user";
 
 test.setTimeout(600_000);
 
@@ -59,8 +58,7 @@ test.describe.serial("Complete Onboarding Flow", () => {
       `${testData.kycData.firstName} ${testData.kycData.lastName}`
     );
 
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const setupDataPath = path.join(__dirname, "../test-data/setup-user.json");
+    const setupDataPath = getSetupUserPath();
     fs.writeFileSync(
       setupDataPath,
       JSON.stringify(

--- a/kit/e2e/ui-tests/global-cleanup.spec.ts
+++ b/kit/e2e/ui-tests/global-cleanup.spec.ts
@@ -1,11 +1,9 @@
 import { test } from "@playwright/test";
 import * as fs from "node:fs";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { getSetupUserPath } from "../utils/setup-user";
 
 test("cleanup setup data", async () => {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const setupDataPath = path.join(__dirname, "../test-data/setup-user.json");
+  const setupDataPath = getSetupUserPath();
 
   if (fs.existsSync(setupDataPath)) {
     fs.unlinkSync(setupDataPath);

--- a/kit/e2e/ui-tests/global-cleanup.spec.ts
+++ b/kit/e2e/ui-tests/global-cleanup.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+test("cleanup setup data", async () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const setupDataPath = path.join(__dirname, "../test-data/setup-user.json");
+
+  if (fs.existsSync(setupDataPath)) {
+    fs.unlinkSync(setupDataPath);
+  }
+});

--- a/kit/e2e/ui-tests/sign-in.spec.ts
+++ b/kit/e2e/ui-tests/sign-in.spec.ts
@@ -1,14 +1,20 @@
 import { test } from "@playwright/test";
 import { Pages } from "../pages/pages";
+import { errorMessages } from "../test-data/error-messages";
 import { adminUser, signInTestData } from "../test-data/user-data";
+import { validationTestData } from "../test-data/validation-data";
+import { getSetupUser } from "../utils/setup-user";
 
 test.describe("Sign-in Tests", () => {
   let pages: ReturnType<typeof Pages>;
 
   test.beforeEach(async ({ page }) => {
     pages = Pages(page);
-    await pages.signInPage.goto();
-    await pages.signInPage.clearForm();
+    await page.goto("/auth/sign-in");
+    await page.waitForLoadState("networkidle");
+    await page
+      .getByRole("button", { name: "Login" })
+      .waitFor({ state: "visible" });
   });
 
   test.afterEach(async ({ page }) => {
@@ -19,28 +25,107 @@ test.describe("Sign-in Tests", () => {
     });
   });
 
+  test("should handle empty form submission", async ({ page }) => {
+    await pages.signInPage.clickEmailField();
+    await pages.signInPage.clickPasswordField();
+    await pages.signInPage.clickLoginButton();
+
+    await pages.signInPage.expectValidationError(
+      errorMessages.validation.emailRequired
+    );
+    await pages.signInPage.expectValidationError(
+      errorMessages.validation.passwordRequired
+    );
+  });
+
+  test("should handle empty email field", async ({ page }) => {
+    await pages.signInPage.clickEmailField();
+    await pages.signInPage.fillPassword(adminUser.password);
+    await pages.signInPage.clickLoginButton();
+    await pages.signInPage.expectValidationError(
+      errorMessages.validation.emailRequired
+    );
+  });
+
+  test("should handle empty password field", async ({ page }) => {
+    await pages.signInPage.fillEmail(adminUser.email);
+    await pages.signInPage.clickPasswordField();
+    await pages.signInPage.clickLoginButton();
+    await pages.signInPage.expectValidationError(
+      errorMessages.validation.passwordRequired
+    );
+  });
+
+  test("should sign in successfully with setup user (admin) credentials and sign out", async () => {
+    const setupUser = getSetupUser();
+    await pages.signInPage.fillSignInForm(setupUser.email, setupUser.password);
+    await pages.signInPage.submitSignInForm();
+    await pages.signInPage.expectSuccessfulLoginWithDashboard();
+    await pages.portfolioPage.signOut();
+    await pages.portfolioPage.expectSignOutSuccess();
+  });
+
   test("should stay on sign-in page with wrong password", async ({ page }) => {
+    const setupUser = getSetupUser();
     await pages.signInPage.fillSignInForm(
-      adminUser.email,
+      setupUser.email,
       signInTestData.wrongPassword
     );
     await pages.signInPage.submitSignInForm();
-
-    await page.waitForTimeout(3000);
     await pages.signInPage.expectToStayOnSignInPage();
-    await pages.signInPage.expectAuthenticationError();
+    await pages.signInPage.expectValidationError(
+      errorMessages.authentication.invalidCredentials
+    );
   });
 
-  test("should handle invalid email format", async ({ page }) => {
+  test("should handle non-existent email", async ({ page }) => {
     await pages.signInPage.fillSignInForm(
-      signInTestData.invalidEmails[0],
+      validationTestData.nonExistentEmails[0],
       adminUser.password
     );
-
-    await page.waitForTimeout(1000);
     await pages.signInPage.submitSignInForm();
-    await page.waitForTimeout(2000);
-
     await pages.signInPage.expectToStayOnSignInPage();
+    await pages.signInPage.expectValidationError(
+      errorMessages.authentication.invalidCredentials
+    );
+  });
+
+  validationTestData.invalidEmails.forEach((invalidEmail) => {
+    test(`should handle invalid email format: ${invalidEmail}`, async () => {
+      await pages.signInPage.fillSignInForm(invalidEmail, adminUser.password);
+      await pages.signInPage.submitSignInForm();
+      await pages.signInPage.expectToStayOnSignInPage();
+      await pages.signInPage.expectValidationError(
+        errorMessages.validation.emailInvalid
+      );
+    });
+  });
+
+  test("should handle case insensitive email and sign out", async ({
+    page,
+  }) => {
+    const setupUser = getSetupUser();
+    await pages.signInPage.fillSignInForm(
+      setupUser.email.toUpperCase(),
+      setupUser.password
+    );
+    await pages.signInPage.submitSignInForm();
+    await pages.signInPage.expectSuccessfulLoginWithDashboard();
+    await pages.portfolioPage.signOut();
+    await pages.portfolioPage.expectSignOutSuccess();
+  });
+
+  test("should handle email with extra spaces and sign out", async ({
+    page,
+  }) => {
+    const setupUser = getSetupUser();
+    await pages.signInPage.fillSignInForm(
+      `  ${setupUser.email}  `,
+      setupUser.password
+    );
+    await pages.signInPage.submitSignInForm();
+    await pages.signInPage.expectSuccessfulLoginWithDashboard();
+    await pages.portfolioPage.signOut();
+    await pages.portfolioPage.expectSignOutSuccess();
   });
 });

--- a/kit/e2e/utils/setup-user.ts
+++ b/kit/e2e/utils/setup-user.ts
@@ -1,0 +1,25 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface SetupUser {
+  email: string;
+  password: string;
+  pinCode: string;
+  fullName: string;
+  createdAt: string;
+}
+
+export function getSetupUser(): SetupUser {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const setupDataPath = path.join(__dirname, "../test-data/setup-user.json");
+
+  if (!fs.existsSync(setupDataPath)) {
+    throw new Error(
+      "Setup user data not found. Make sure the onboarding setup test has run successfully."
+    );
+  }
+
+  const data = fs.readFileSync(setupDataPath, "utf8");
+  return JSON.parse(data) as SetupUser;
+}

--- a/kit/e2e/utils/setup-user.ts
+++ b/kit/e2e/utils/setup-user.ts
@@ -10,9 +10,19 @@ export interface SetupUser {
   createdAt: string;
 }
 
-export function getSetupUser(): SetupUser {
+export function getSetupUserPath(): string {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const setupDataPath = path.join(__dirname, "../test-data/setup-user.json");
+  return path.join(__dirname, "../test-data/setup-user.json");
+}
+
+let cachedSetupUser: SetupUser | null = null;
+
+export function getSetupUser(): SetupUser {
+  if (cachedSetupUser) {
+    return cachedSetupUser;
+  }
+
+  const setupDataPath = getSetupUserPath();
 
   if (!fs.existsSync(setupDataPath)) {
     throw new Error(
@@ -21,5 +31,8 @@ export function getSetupUser(): SetupUser {
   }
 
   const data = fs.readFileSync(setupDataPath, "utf8");
-  return JSON.parse(data) as SetupUser;
+  const user = JSON.parse(data) as SetupUser;
+
+  cachedSetupUser = user;
+  return user;
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:integration": "turbo test:integration ",
     "publish": "turbo publish ",
     "test:e2e:ui": "bun run --cwd kit/e2e playwright test --config=playwright.ui.config.ts --project=ui-tests",
-    "test:e2e:ui:debug": "bun run --cwd kit/e2e playwright test --config=playwright.ui.config.ts --project=ui-tests --ui",
+    "test:e2e:ui:debug": "bun run --cwd kit/e2e playwright test --config=playwright.ui.config.ts --ui",
     "test:e2e:api": "bun run --cwd kit/e2e playwright test --config=playwright.api.config.ts --project=api-tests",
     "test:e2e:api:debug": "bun run --cwd kit/e2e playwright test --config=playwright.api.config.ts --project=api-tests --ui",
     "helm": "turbo run helm ",


### PR DESCRIPTION
## Summary by Sourcery

Expand and enhance sign-in end-to-end tests and supporting infrastructure

New Features:
- Add UI tests for empty form submission, empty email, and empty password validations
- Add tests for wrong credentials, non-existent emails, invalid email formats, case-insensitive emails, and emails with extra spaces
- Add sign-in and sign-out flow test using onboarded user credentials

Enhancements:
- Implement SignInPage and PortfolioPage helper methods for field interactions, validation checks, and sign-out flow
- Introduce a setup-user utility to persist and retrieve onboarded user data between tests
- Add centralized error messages and validation test data modules

Build:
- Update Playwright config to introduce setup, ui-tests, and cleanup projects with dependencies and test matching adjustments
- Simplify package.json scripts to invoke Playwright without explicit project flags

CI:
- Modify GitHub Actions workflow to run the full Playwright suite without restricting to a specific project and adjust retry/reporting flags

Tests:
- Enhance complete-onboarding-flow test to write onboarded user credentials to a JSON file for downstream tests