### PR TITLE
feat(dapp): unify role management with single-transaction operations

### DIFF
--- a/kit/dapp/src/components/data-table/data-table-export.test.tsx
+++ b/kit/dapp/src/components/data-table/data-table-export.test.tsx
@@ -298,7 +298,7 @@ describe("DataTableExport", () => {
       const text = await blobCall.text();
 
       // BOM character should be at the start
-      expect(text.codePointAt(0)).toBe(0xfe_ff);
+      expect(text.codePointAt(0)).toBe(0xFE_FF);
     });
   });
 

--- a/kit/dapp/src/orpc/routes/system/access-manager/routes/grant-role.schema.ts
+++ b/kit/dapp/src/orpc/routes/system/access-manager/routes/grant-role.schema.ts
@@ -4,25 +4,30 @@ import { UserVerificationSchema } from "@/orpc/routes/common/schemas/user-verifi
 import { z } from "zod";
 
 /**
- * Input schema for granting a role to multiple accounts
+ * Input schema for granting roles to accounts
+ * Supports:
+ * - Single address, single role
+ * - Multiple addresses, single role
+ * - Single address, multiple roles
  */
 export const GrantRoleInputSchema = z.object({
   verification: UserVerificationSchema,
   /**
-   * The accounts to grant the roles to
+   * The account(s) to grant the role(s) to
    */
-  accounts: z.array(ethereumAddress),
+  address: z.union([ethereumAddress, z.array(ethereumAddress)]),
   /**
-   * The role to grant to the accounts
+   * The role(s) to grant
    */
-  role: accessControlRole,
+  role: z.union([accessControlRole, z.array(accessControlRole)]),
 });
 
 /**
- * Response schema for granting a role to multiple accounts
+ * Response schema for granting roles
  */
 export const GrantRoleOutputSchema = z.object({
-  accounts: z.array(ethereumAddress),
+  addresses: z.array(ethereumAddress),
+  roles: z.array(accessControlRole),
 });
 
 /**

--- a/kit/dapp/src/orpc/routes/system/access-manager/routes/grant-role.ts
+++ b/kit/dapp/src/orpc/routes/system/access-manager/routes/grant-role.ts
@@ -5,8 +5,31 @@ import { blockchainPermissionsMiddleware } from "@/orpc/middlewares/auth/blockch
 import { portalRouter } from "@/orpc/procedures/portal.router";
 import { SYSTEM_PERMISSIONS } from "@/orpc/routes/system/system.permissions";
 
+// Single address, single role
 const GRANT_ROLE_MUTATION = portalGraphql(`
   mutation GrantRoleMutation(
+    $verificationId: String
+    $challengeResponse: String!
+    $address: String!
+    $account: String!
+    $role: String!
+    $from: String!
+  ) {
+    IATKSystemAccessManagerGrantRole(
+      verificationId: $verificationId
+      challengeResponse: $challengeResponse
+      address: $address
+      from: $from
+      input: { role: $role, account: $account }
+    ) {
+      transactionHash
+    }
+  }
+`);
+
+// Multiple addresses, single role
+const BATCH_GRANT_ROLE_MUTATION = portalGraphql(`
+  mutation BatchGrantRoleMutation(
     $verificationId: String
     $challengeResponse: String!
     $address: String!
@@ -26,6 +49,28 @@ const GRANT_ROLE_MUTATION = portalGraphql(`
   }
 `);
 
+// Single address, multiple roles
+const GRANT_MULTIPLE_ROLES_MUTATION = portalGraphql(`
+  mutation GrantMultipleRolesMutation(
+    $verificationId: String
+    $challengeResponse: String!
+    $address: String!
+    $account: String!
+    $roles: [String!]!
+    $from: String!
+  ) {
+    IATKSystemAccessManagerGrantMultipleRoles(
+      verificationId: $verificationId
+      challengeResponse: $challengeResponse
+      address: $address
+      from: $from
+      input: { account: $account, roles: $roles }
+    ) {
+      transactionHash
+    }
+  }
+`);
+
 export const grantRole = portalRouter.system.grantRole
   .use(
     blockchainPermissionsMiddleware({
@@ -36,7 +81,7 @@ export const grantRole = portalRouter.system.grantRole
     })
   )
   .handler(async ({ input, context, errors }) => {
-    const { verification, accounts, role } = input;
+    const { verification, address, role } = input;
     const { auth, system } = context;
     const sender = auth.user;
 
@@ -48,35 +93,100 @@ export const grantRole = portalRouter.system.grantRole
       });
     }
 
-    if (accounts.length === 0) {
+    // Normalize inputs to arrays
+    const addresses = Array.isArray(address) ? address : [address];
+    const roles = Array.isArray(role) ? role : [role];
+
+    // Remove duplicates
+    const uniqueAddresses = [...new Set(addresses)];
+    const uniqueRoles = [...new Set(roles)];
+
+    if (uniqueAddresses.length === 0 || uniqueRoles.length === 0) {
       return {
-        accounts: [],
+        addresses: [],
+        roles: [],
       };
     }
 
-    const roleInfo = getRoleByFieldName(role);
-    if (!roleInfo) {
-      throw errors.NOT_FOUND({
-        message: `Role '${role}' not found`,
-      });
-    }
+    // Validate all roles exist
+    const roleInfos = uniqueRoles.map((r) => {
+      const roleInfo = getRoleByFieldName(r);
+      if (!roleInfo) {
+        throw errors.NOT_FOUND({
+          message: `Role '${r}' not found`,
+        });
+      }
+      return roleInfo;
+    });
 
     const challengeResponse = await handleChallenge(sender, {
       code: verification.verificationCode,
       type: verification.verificationType,
     });
 
-    const accountsWithoutDuplicates = [...new Set(accounts)];
-
-    await context.portalClient.mutate(GRANT_ROLE_MUTATION, {
-      address: system.systemAccessManager.id,
-      from: sender.wallet,
-      accounts: accountsWithoutDuplicates,
-      role: roleInfo.bytes,
-      ...challengeResponse,
-    });
+    // Execute the appropriate mutation based on the use case
+    if (uniqueAddresses.length === 1 && uniqueRoles.length === 1) {
+      // Single address, single role - use grantRole
+      const account = uniqueAddresses[0];
+      const roleInfo = roleInfos[0];
+      if (!account || !roleInfo) {
+        throw errors.INTERNAL_SERVER_ERROR({
+          message: "Invalid address or role configuration",
+        });
+      }
+      await context.portalClient.mutate(GRANT_ROLE_MUTATION, {
+        address: system.systemAccessManager.id,
+        from: sender.wallet,
+        account,
+        role: roleInfo.bytes,
+        ...challengeResponse,
+      });
+    } else if (uniqueAddresses.length > 1 && uniqueRoles.length === 1) {
+      // Multiple addresses, single role - use batchGrantRole
+      const roleInfo = roleInfos[0];
+      if (!roleInfo) {
+        throw errors.INTERNAL_SERVER_ERROR({
+          message: "Invalid role configuration",
+        });
+      }
+      await context.portalClient.mutate(BATCH_GRANT_ROLE_MUTATION, {
+        address: system.systemAccessManager.id,
+        from: sender.wallet,
+        accounts: uniqueAddresses,
+        role: roleInfo.bytes,
+        ...challengeResponse,
+      });
+    } else if (uniqueAddresses.length === 1 && uniqueRoles.length > 1) {
+      // Single address, multiple roles - use grantMultipleRoles
+      const account = uniqueAddresses[0];
+      if (!account) {
+        throw errors.INTERNAL_SERVER_ERROR({
+          message: "Invalid address configuration",
+        });
+      }
+      const roleBytes = roleInfos.map((r) => r.bytes);
+      await context.portalClient.mutate(GRANT_MULTIPLE_ROLES_MUTATION, {
+        address: system.systemAccessManager.id,
+        from: sender.wallet,
+        account,
+        roles: roleBytes,
+        ...challengeResponse,
+      });
+    } else {
+      // Multiple addresses, multiple roles - not supported in a single transaction
+      throw errors.INPUT_VALIDATION_FAILED({
+        message:
+          "Cannot grant multiple roles to multiple addresses in a single transaction. Please use separate requests.",
+        data: {
+          errors: [
+            "Cannot grant multiple roles to multiple addresses in a single transaction. Please use separate requests.",
+          ],
+        },
+      });
+    }
 
     return {
-      accounts: accountsWithoutDuplicates,
+      addresses: uniqueAddresses,
+      roles: uniqueRoles,
     };
   });

--- a/kit/dapp/src/orpc/routes/system/access-manager/routes/revoke-role.schema.ts
+++ b/kit/dapp/src/orpc/routes/system/access-manager/routes/revoke-role.schema.ts
@@ -4,25 +4,30 @@ import { UserVerificationSchema } from "@/orpc/routes/common/schemas/user-verifi
 import { z } from "zod";
 
 /**
- * Input schema for revoking a role from multiple accounts
+ * Input schema for revoking roles from accounts
+ * Supports:
+ * - Single address, single role
+ * - Multiple addresses, single role
+ * - Single address, multiple roles
  */
 export const RevokeRoleInputSchema = z.object({
   verification: UserVerificationSchema,
   /**
-   * The accounts to revoke the roles from
+   * The account(s) to revoke the role(s) from
    */
-  accounts: z.array(ethereumAddress),
+  address: z.union([ethereumAddress, z.array(ethereumAddress)]),
   /**
-   * The role to revoke from the accounts
+   * The role(s) to revoke
    */
-  role: accessControlRole,
+  role: z.union([accessControlRole, z.array(accessControlRole)]),
 });
 
 /**
- * Response schema for revoking a role from multiple accounts
+ * Response schema for revoking roles
  */
 export const RevokeRoleOutputSchema = z.object({
-  accounts: z.array(ethereumAddress),
+  addresses: z.array(ethereumAddress),
+  roles: z.array(accessControlRole),
 });
 
 /**

--- a/kit/dapp/src/orpc/routes/system/access-manager/routes/revoke-role.spec.ts
+++ b/kit/dapp/src/orpc/routes/system/access-manager/routes/revoke-role.spec.ts
@@ -40,7 +40,7 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
           verificationCode: DEFAULT_PINCODE,
           verificationType: "pincode",
         },
-        accounts: [
+        address: [
           testAddresses.valid1,
           testAddresses.valid2,
           testAddresses.valid3,
@@ -57,12 +57,13 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
           verificationCode: DEFAULT_PINCODE,
           verificationType: "pincode",
         },
-        accounts: [testAddresses.valid1],
+        address: testAddresses.valid1,
         role: "tokenManager",
       });
 
       expect(result).toEqual({
-        accounts: [testAddresses.valid1],
+        addresses: [testAddresses.valid1],
+        roles: ["tokenManager"],
       });
 
       const systemRoles = await adminClient.system.rolesList({
@@ -75,13 +76,13 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
       expect(updatedSystemRoles?.roles).not.toContain("tokenManager");
     });
 
-    it("should revoke a role from multiple accounts", async () => {
+    it("should revoke a single role from multiple accounts", async () => {
       const result = await adminClient.system.revokeRole({
         verification: {
           verificationCode: DEFAULT_PINCODE,
           verificationType: "pincode",
         },
-        accounts: [
+        address: [
           testAddresses.valid1,
           testAddresses.valid2,
           testAddresses.valid3,
@@ -90,11 +91,12 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
       });
 
       expect(result).toEqual({
-        accounts: [
+        addresses: [
           testAddresses.valid1,
           testAddresses.valid2,
           testAddresses.valid3,
         ],
+        roles: ["complianceManager"],
       });
 
       const systemRoles = await adminClient.system.rolesList({
@@ -107,18 +109,45 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
       expect(updatedSystemRoles?.roles).not.toContain("complianceManager");
     });
 
-    it("should handle empty accounts array", async () => {
+    it("should revoke multiple roles from a single account", async () => {
       const result = await adminClient.system.revokeRole({
         verification: {
           verificationCode: DEFAULT_PINCODE,
           verificationType: "pincode",
         },
-        accounts: [],
+        address: testAddresses.valid1,
+        role: ["systemManager", "tokenManager"],
+      });
+
+      expect(result).toEqual({
+        addresses: [testAddresses.valid1],
+        roles: ["systemManager", "tokenManager"],
+      });
+
+      const systemRoles = await adminClient.system.rolesList({
+        excludeContracts: true,
+      });
+      const updatedSystemRoles = systemRoles.find(
+        (role) => role.account === testAddresses.valid1
+      );
+      expect(updatedSystemRoles).toBeDefined();
+      expect(updatedSystemRoles?.roles).not.toContain("systemManager");
+      expect(updatedSystemRoles?.roles).not.toContain("tokenManager");
+    });
+
+    it("should handle empty arrays", async () => {
+      const result = await adminClient.system.revokeRole({
+        verification: {
+          verificationCode: DEFAULT_PINCODE,
+          verificationType: "pincode",
+        },
+        address: [],
         role: "tokenManager",
       });
 
       expect(result).toEqual({
-        accounts: [],
+        addresses: [],
+        roles: [],
       });
     });
   });
@@ -130,12 +159,13 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
           verificationCode: DEFAULT_PINCODE,
           verificationType: "pincode",
         },
-        accounts: [testAddresses.valid1],
+        address: testAddresses.valid1,
         role: "tokenManager",
       });
 
       expect(result).toEqual({
-        accounts: [testAddresses.valid1],
+        addresses: [testAddresses.valid1],
+        roles: ["tokenManager"],
       });
     });
 
@@ -146,7 +176,7 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
             verificationCode: DEFAULT_PINCODE,
             verificationType: "pincode",
           },
-          accounts: [testAddresses.valid1],
+          address: testAddresses.valid1,
           role: "tokenManager",
         })
       ).rejects.toThrow(
@@ -163,7 +193,7 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
             verificationCode: DEFAULT_PINCODE,
             verificationType: "pincode",
           },
-          accounts: [testAddresses.valid1],
+          address: testAddresses.valid1,
           role: "invalidRole" as never,
         })
       ).rejects.toThrow("INPUT_VALIDATION_FAILED");
@@ -176,7 +206,7 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
             verificationCode: DEFAULT_PINCODE,
             verificationType: "pincode",
           },
-          accounts: [testAddresses.invalid],
+          address: testAddresses.invalid,
           role: "tokenManager",
         })
       ).rejects.toThrow("INPUT_VALIDATION_FAILED");
@@ -189,7 +219,7 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
             verificationCode: DEFAULT_PINCODE,
             verificationType: "pincode",
           },
-          accounts: [
+          address: [
             testAddresses.valid1,
             testAddresses.invalid,
             testAddresses.valid2,
@@ -206,7 +236,7 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
             verificationCode: "000000",
             verificationType: "pincode",
           },
-          accounts: [testAddresses.valid1],
+          address: testAddresses.valid1,
           role: "tokenManager",
         })
       ).rejects.toThrow("Invalid authentication challenge");
@@ -220,17 +250,31 @@ describe("Access Manager - Revoke Role ORPC routes", () => {
           verificationCode: DEFAULT_PINCODE,
           verificationType: "pincode",
         },
-        accounts: [
+        address: [
           testAddresses.valid1,
           testAddresses.valid1,
           testAddresses.valid2,
         ],
         role: "tokenManager",
       });
-      expect(result.accounts).toEqual([
+      expect(result.addresses).toEqual([
         testAddresses.valid1,
         testAddresses.valid2,
       ]);
+      expect(result.roles).toEqual(["tokenManager"]);
+    });
+
+    it("should handle duplicate roles in the array", async () => {
+      const result = await adminClient.system.revokeRole({
+        verification: {
+          verificationCode: DEFAULT_PINCODE,
+          verificationType: "pincode",
+        },
+        address: testAddresses.valid1,
+        role: ["tokenManager", "tokenManager", "complianceManager"],
+      });
+      expect(result.addresses).toEqual([testAddresses.valid1]);
+      expect(result.roles).toEqual(["tokenManager", "complianceManager"]);
     });
   });
 });

--- a/kit/dapp/src/orpc/routes/system/routes/system.create.ts
+++ b/kit/dapp/src/orpc/routes/system/routes/system.create.ts
@@ -259,17 +259,16 @@ export const create = onboardedRouter.system.create
       "complianceManager",
       "addonManager",
     ];
-    for (const role of operationalRoles) {
-      await call(
-        grantRole,
-        {
-          role: role,
-          accounts: [sender.wallet],
-          verification,
-        },
-        { context }
-      );
-    }
+    // Grant all operational roles in a single transaction
+    await call(
+      grantRole,
+      {
+        address: sender.wallet,
+        role: operationalRoles,
+        verification,
+      },
+      { context }
+    );
 
     const systemDetails = await call(
       read,


### PR DESCRIPTION
## Summary

This PR refactors the grant-role and revoke-role endpoints to support multiple use cases with a unified schema, ensuring each operation executes in a single blockchain transaction.

## Changes

### 🎯 Core Functionality
- **Unified Schema**: Single input/output schema with union types for `address` and `role` fields
- **Smart Mutation Selection**: Handler automatically selects the correct GraphQL mutation based on input
- **Three Use Cases Supported**:
  - Single address, single role → `grantRole` / `revokeRole`
  - Multiple addresses, single role → `batchGrantRole` / `batchRevokeRole`
  - Single address, multiple roles → `grantMultipleRoles` / `revokeMultipleRoles`

### ⚡ Performance Improvements
- Each use case now executes in a single blockchain transaction
- `system.create.ts` optimized to grant all operational roles in one call
- Test fixtures updated to grant multiple roles efficiently

### 🧪 Testing
- Updated test suites for both grant-role and revoke-role
- Added test cases for multiple roles scenario
- Fixed TypeScript type errors

## Technical Details

The implementation uses dedicated GraphQL mutations for each use case:
- `IATKSystemAccessManagerGrantRole` - single address, single role
- `IATKSystemAccessManagerBatchGrantRole` - multiple addresses, single role  
- `IATKSystemAccessManagerGrantMultipleRoles` - single address, multiple roles

This ensures optimal blockchain transaction efficiency while maintaining a clean, unified API.

## Breaking Changes
- API field renamed: `accounts` → `address` (now supports single or array)
- Response structure changed: `accounts` → `addresses` and added `roles` field

## Testing
- [x] Unit tests pass
- [x] TypeScript compilation succeeds
- [x] Linting passes