### PR TITLE
fix: rename underlying asset to denomination asset

### DIFF
--- a/kit/contracts/contracts/addons/yield/ATKFixedYieldScheduleUpgradeable.sol
+++ b/kit/contracts/contracts/addons/yield/ATKFixedYieldScheduleUpgradeable.sol
@@ -92,12 +92,12 @@ contract ATKFixedYieldScheduleUpgradeable is
     }
 
     /// @inheritdoc ISMARTFixedYieldSchedule
-    function topUpUnderlyingAsset(uint256 amount) external override nonReentrant whenNotPaused {
-        _topUpUnderlyingAsset(amount);
+    function topUpDenominationAsset(uint256 amount) external override nonReentrant whenNotPaused {
+        _topUpDenominationAsset(amount);
     }
 
     /// @inheritdoc ISMARTFixedYieldSchedule
-    function withdrawUnderlyingAsset(
+    function withdrawDenominationAsset(
         address to,
         uint256 amount
     )
@@ -107,18 +107,18 @@ contract ATKFixedYieldScheduleUpgradeable is
         onlyRole(SUPPLY_MANAGEMENT_ROLE)
         whenNotPaused
     {
-        _withdrawUnderlyingAsset(to, amount);
+        _withdrawDenominationAsset(to, amount);
     }
 
     /// @inheritdoc ISMARTFixedYieldSchedule
-    function withdrawAllUnderlyingAsset(address to)
+    function withdrawAllDenominationAsset(address to)
         external
         override
         nonReentrant
         onlyRole(SUPPLY_MANAGEMENT_ROLE)
         whenNotPaused
     {
-        _withdrawAllUnderlyingAsset(to);
+        _withdrawAllDenominationAsset(to);
     }
 
     /// @notice Pauses all contract operations

--- a/kit/contracts/contracts/assets/README.md
+++ b/kit/contracts/contracts/assets/README.md
@@ -22,7 +22,7 @@ Fixed-term debt instruments with maturity dates and redemption features
 **Key Features:**
 
 - Fixed maturity date and face value
-- Underlying asset backing (collateral)
+- Denomination asset backing (collateral)
 - Yield distribution capabilities
 - Redemption at maturity
 - Historical balance tracking
@@ -56,8 +56,7 @@ Fixed-term debt instruments with maturity dates and redemption features
 #### Redemption Mechanics
 
 - **Maturity Requirement**: Only redeemable after maturation
-- **Collateral Check**: Ensures sufficient underlying assets
-- **Proportional Redemption**: Tokens redeemed for proportional underlying
+- **Proportional Redemption**: Tokens redeemed for proportional denomination
   assets
 
 **Use Cases:**

--- a/kit/contracts/contracts/assets/bond/IATKBondFactory.sol
+++ b/kit/contracts/contracts/assets/bond/IATKBondFactory.sol
@@ -18,8 +18,8 @@ interface IATKBondFactory is IATKTokenFactory {
     /// @param decimals The number of decimals for the bond tokens.
     /// @param cap The maximum total supply of the bond tokens.
     /// @param maturityDate The Unix timestamp representing the bond's maturity date.
-    /// @param faceValue The face value of each bond token in the underlying asset's base units.
-    /// @param denominationAsset The address of the ERC20 token used as the underlying asset for the bond.
+    /// @param faceValue The face value of each bond token in the denomination asset's base units.
+    /// @param denominationAsset The address of the ERC20 token used as the denomination asset for the bond.
     /// @param countryCode The ISO 3166-1 numeric country code for jurisdiction
     event BondCreated(
         address indexed sender,

--- a/kit/contracts/contracts/assets/deposit/ATKDepositImplementation.sol
+++ b/kit/contracts/contracts/assets/deposit/ATKDepositImplementation.sol
@@ -33,10 +33,9 @@ import { SMARTTokenAccessManagedUpgradeable } from
 
 /// @title ATKDeposit Implementation
 /// @author SettleMint
-/// @notice An implementation of a deposit token using the SMART extension framework,
-///         backed by collateral and using custom roles.
+/// @notice An implementation of a deposit token using the SMART extension framework using custom roles.
 /// @dev Combines core SMART features (compliance, verification) with extensions for pausing,
-///      burning, custodian actions, and collateral tracking. Access control uses custom roles.
+///      burning, and custodian actions. Access control uses custom roles.
 contract ATKDepositImplementation is
     Initializable,
     IATKDeposit,
@@ -451,8 +450,8 @@ contract ATKDepositImplementation is
 
     /// @notice Hook that is called before tokens are minted
     /// @dev This hook chains validation logic from multiple extensions:
-    ///      1. SMARTCustodianUpgradeable: Checks if recipient is frozen
-    ///      2. SMARTUpgradeable: Performs compliance and identity checks
+    ///      2. SMARTCustodianUpgradeable: Checks if recipient is frozen
+    ///      3. SMARTUpgradeable: Performs compliance and identity checks
     /// @param to The address that will receive the minted tokens
     /// @param amount The amount of tokens to be minted
     /// @inheritdoc SMARTHooks

--- a/kit/contracts/contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol
+++ b/kit/contracts/contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol
@@ -46,7 +46,7 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// @param requiredBalance The required balance of the denomination asset for the operation.
     error InsufficientDenominationAssetBalance(uint256 currentBalance, uint256 requiredBalance); // Could also be used if a
         // transferFrom fails.
-    /// @dev Reverted if the `_DenominationAsset` (derived from `_token.yieldToken()`) is the zero address, or if `to`
+    /// @dev Reverted if the `_denominationAsset` (derived from `_token.yieldToken()`) is the zero address, or if `to`
     /// address in withdrawal is zero.
     error InvalidDenominationAsset();
     /// @dev Reverted by `withdrawDenominationAsset` if the withdrawal `amount` is zero.
@@ -70,7 +70,7 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// @param rate The rate of the yield schedule.
     /// @param interval The interval of the yield schedule.
     /// @param periodEndTimestamps The timestamps of the end of each period.
-    /// @param DenominationAsset The denomination asset of the yield schedule.
+    /// @param denominationAsset The denomination asset of the yield schedule.
     /// @param yieldForNextPeriod The yield for the next period.
     event FixedYieldScheduleSet(
         uint256 startDate,
@@ -78,20 +78,20 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
         uint256 rate,
         uint256 interval,
         uint256[] periodEndTimestamps,
-        IERC20 DenominationAsset,
+        IERC20 denominationAsset,
         uint256 yieldForNextPeriod
     );
 
-    /// @notice Emitted when an administrator or funder successfully deposits `_DenominationAsset` into the contract to
+    /// @notice Emitted when an administrator or funder successfully deposits `_denominationAsset` into the contract to
     /// fund yield payments.
-    /// @param from The address that sent the `_DenominationAsset` tokens (the funder).
-    /// @param amount The quantity of `_DenominationAsset` tokens deposited.
-    event DenominationAssetTopUp(address indexed from, uint256 indexed amount);
+    /// @param from The address that sent the `_denominationAsset` tokens (the funder).
+    /// @param amount The quantity of `_denominationAsset` tokens deposited.
+    event denominationAssetTopUp(address indexed from, uint256 indexed amount);
 
-    /// @notice Emitted when an administrator successfully withdraws `_DenominationAsset` from the contract.
-    /// @param to The address that received the withdrawn `_DenominationAsset` tokens.
-    /// @param amount The quantity of `_DenominationAsset` tokens withdrawn.
-    event DenominationAssetWithdrawn(address indexed to, uint256 indexed amount);
+    /// @notice Emitted when an administrator successfully withdraws `_denominationAsset` from the contract.
+    /// @param to The address that received the withdrawn `_denominationAsset` tokens.
+    /// @param amount The quantity of `_denominationAsset` tokens withdrawn.
+    event denominationAssetWithdrawn(address indexed to, uint256 indexed amount);
 
     /// @notice Emitted when a token holder successfully claims their accrued yield.
     /// @param holder The address of the token holder who claimed the yield.

--- a/kit/contracts/contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol
+++ b/kit/contracts/contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol
@@ -86,12 +86,12 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// fund yield payments.
     /// @param from The address that sent the `_denominationAsset` tokens (the funder).
     /// @param amount The quantity of `_denominationAsset` tokens deposited.
-    event denominationAssetTopUp(address indexed from, uint256 indexed amount);
+    event DenominationAssetTopUp(address indexed from, uint256 indexed amount);
 
     /// @notice Emitted when an administrator successfully withdraws `_denominationAsset` from the contract.
     /// @param to The address that received the withdrawn `_denominationAsset` tokens.
     /// @param amount The quantity of `_denominationAsset` tokens withdrawn.
-    event denominationAssetWithdrawn(address indexed to, uint256 indexed amount);
+    event DenominationAssetWithdrawn(address indexed to, uint256 indexed amount);
 
     /// @notice Emitted when a token holder successfully claims their accrued yield.
     /// @param holder The address of the token holder who claimed the yield.

--- a/kit/contracts/contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol
+++ b/kit/contracts/contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol
@@ -16,7 +16,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol
 /// functions for managing and querying the fixed yield mechanism.
 /// @dev Implementing contracts will manage the lifecycle of yield distribution, including calculating yield based on
 /// historical balances,
-/// allowing users to claim their yield, and administrative functions like topping up the underlying asset used for
+/// allowing users to claim their yield, and administrative functions like topping up the denomination asset used for
 /// payments.
 /// Functions are `external`, meaning they are designed to be called from other contracts or off-chain applications.
 /// Many are `view` functions, which read state but don't modify it.
@@ -40,19 +40,19 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// @dev Reverted by `calculateAccruedYield` if the schedule has not yet started (i.e., `block.timestamp <
     /// _startDate`).
     error ScheduleNotActive();
-    /// @dev Reverted by `topUpUnderlyingAsset` or `withdrawUnderlyingAsset` if the underlying asset transfer fails or
+    /// @dev Reverted by `topUpDenominationAsset` or `withdrawDenominationAsset` if the denomination asset transfer fails or
     /// if there's not enough balance.
-    /// @param currentBalance The current balance of the underlying asset in the contract.
-    /// @param requiredBalance The required balance of the underlying asset for the operation.
-    error InsufficientUnderlyingBalance(uint256 currentBalance, uint256 requiredBalance); // Could also be used if a
+    /// @param currentBalance The current balance of the denomination asset in the contract.
+    /// @param requiredBalance The required balance of the denomination asset for the operation.
+    error InsufficientDenominationAssetBalance(uint256 currentBalance, uint256 requiredBalance); // Could also be used if a
         // transferFrom fails.
-    /// @dev Reverted if the `_underlyingAsset` (derived from `_token.yieldToken()`) is the zero address, or if `to`
+    /// @dev Reverted if the `_DenominationAsset` (derived from `_token.yieldToken()`) is the zero address, or if `to`
     /// address in withdrawal is zero.
-    error InvalidUnderlyingAsset();
-    /// @dev Reverted by `withdrawUnderlyingAsset` if the withdrawal `amount` is zero.
+    error InvalidDenominationAsset();
+    /// @dev Reverted by `withdrawDenominationAsset` if the withdrawal `amount` is zero.
     error InvalidAmount();
-    /// @dev Reverted by `withdrawUnderlyingAsset` if the underlying asset balance is zero.
-    error NoUnderlyingBalance();
+    /// @dev Reverted by `withdrawDenominationAsset` if the denomination asset balance is zero.
+    error NoDenominationAssetBalance();
     /// @dev Reverted by `periodEnd` if an invalid period number (0 or out of bounds) is requested.
     error InvalidPeriod();
 
@@ -70,7 +70,7 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// @param rate The rate of the yield schedule.
     /// @param interval The interval of the yield schedule.
     /// @param periodEndTimestamps The timestamps of the end of each period.
-    /// @param underlyingAsset The underlying asset of the yield schedule.
+    /// @param DenominationAsset The denomination asset of the yield schedule.
     /// @param yieldForNextPeriod The yield for the next period.
     event FixedYieldScheduleSet(
         uint256 startDate,
@@ -78,24 +78,24 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
         uint256 rate,
         uint256 interval,
         uint256[] periodEndTimestamps,
-        IERC20 underlyingAsset,
+        IERC20 DenominationAsset,
         uint256 yieldForNextPeriod
     );
 
-    /// @notice Emitted when an administrator or funder successfully deposits `_underlyingAsset` into the contract to
+    /// @notice Emitted when an administrator or funder successfully deposits `_DenominationAsset` into the contract to
     /// fund yield payments.
-    /// @param from The address that sent the `_underlyingAsset` tokens (the funder).
-    /// @param amount The quantity of `_underlyingAsset` tokens deposited.
-    event UnderlyingAssetTopUp(address indexed from, uint256 indexed amount);
+    /// @param from The address that sent the `_DenominationAsset` tokens (the funder).
+    /// @param amount The quantity of `_DenominationAsset` tokens deposited.
+    event DenominationAssetTopUp(address indexed from, uint256 indexed amount);
 
-    /// @notice Emitted when an administrator successfully withdraws `_underlyingAsset` from the contract.
-    /// @param to The address that received the withdrawn `_underlyingAsset` tokens.
-    /// @param amount The quantity of `_underlyingAsset` tokens withdrawn.
-    event UnderlyingAssetWithdrawn(address indexed to, uint256 indexed amount);
+    /// @notice Emitted when an administrator successfully withdraws `_DenominationAsset` from the contract.
+    /// @param to The address that received the withdrawn `_DenominationAsset` tokens.
+    /// @param amount The quantity of `_DenominationAsset` tokens withdrawn.
+    event DenominationAssetWithdrawn(address indexed to, uint256 indexed amount);
 
     /// @notice Emitted when a token holder successfully claims their accrued yield.
     /// @param holder The address of the token holder who claimed the yield.
-    /// @param claimedAmount The total quantity of `_underlyingAsset` transferred to the holder in this claim.
+    /// @param claimedAmount The total quantity of `_denominationAsset` transferred to the holder in this claim.
     /// @param fromPeriod The first period number (1-indexed) included in this claim.
     /// @param toPeriod The last period number (1-indexed) included in this claim.
     /// @param periodAmounts An array containing the amount of yield claimed for each specific period within the
@@ -171,7 +171,7 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// upcoming distribution period.
     /// @dev This is a projection based on current total supply (or relevant historical supply measure) and the yield
     /// rate.
-    /// Useful for administrators to ensure sufficient underlying assets are available in the contract for future
+    /// Useful for administrators to ensure sufficient denomination assets are available in the contract for future
     /// payouts.
     /// @return totalAmount The estimated total yield tokens needed for the next period's distribution.
     function totalYieldForNextPeriod() external view returns (uint256 totalAmount);
@@ -192,35 +192,35 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// 1. Determine the periods for which the caller has not yet claimed yield.
     /// 2. Calculate the yield owed for those periods based on their historical token balance at the end of each
     /// respective period.
-    /// 3. Transfer the total calculated yield (in `underlyingAsset()`) to the caller.
+    /// 3. Transfer the total calculated yield (in `denominationAsset()`) to the caller.
     /// 4. Update the caller's `lastClaimedPeriod`.
     /// This is a state-changing function and will emit events (e.g., `YieldClaimed`).
     function claimYield() external; // Consider adding `returns (uint256 claimedAmount)`
 
-    /// @notice Allows anyone to deposit (top-up) the underlying asset into the schedule contract to fund yield
+    /// @notice Allows anyone to deposit (top-up) the denomination asset into the schedule contract to fund yield
     /// payments.
-    /// @dev This function is used to ensure the contract has sufficient reserves of the `underlyingAsset()` to pay out
+    /// @dev This function is used to ensure the contract has sufficient reserves of the `denominationAsset()` to pay out
     /// accrued yield.
-    /// It typically involves the caller first approving the schedule contract to spend their `underlyingAsset` tokens,
+    /// It typically involves the caller first approving the schedule contract to spend their `denominationAsset` tokens,
     /// then this function calls `transferFrom`.
-    /// @param amount The quantity of the `underlyingAsset` to deposit into the schedule contract.
-    function topUpUnderlyingAsset(uint256 amount) external;
+    /// @param amount The quantity of the `denominationAsset` to deposit into the schedule contract.
+    function topUpDenominationAsset(uint256 amount) external;
 
-    /// @notice Allows an authorized administrator to withdraw a specific `amount` of the `underlyingAsset` from the
+    /// @notice Allows an authorized administrator to withdraw a specific `amount` of the `denominationAsset` from the
     /// schedule contract.
     /// @dev This is an administrative function and should be strictly access-controlled (e.g., `onlyRole(ADMIN_ROLE)`).
     /// Useful for managing excess funds or in emergency situations.
-    /// @param to The address to which the withdrawn `underlyingAsset` tokens will be sent.
-    /// @param amount The quantity of `underlyingAsset` tokens to withdraw.
-    function withdrawUnderlyingAsset(address to, uint256 amount) external;
+    /// @param to The address to which the withdrawn `denominationAsset` tokens will be sent.
+    /// @param amount The quantity of `denominationAsset` tokens to withdraw.
+    function withdrawDenominationAsset(address to, uint256 amount) external;
 
-    /// @notice Allows an authorized administrator to withdraw all available `underlyingAsset` tokens from the schedule
+    /// @notice Allows an authorized administrator to withdraw all available `denominationAsset` tokens from the schedule
     /// contract.
-    /// @dev Similar to `withdrawUnderlyingAsset`, but withdraws the entire balance of `underlyingAsset` held by the
+    /// @dev Similar to `withdrawDenominationAsset`, but withdraws the entire balance of `denominationAsset` held by the
     /// contract.
     /// Should also be strictly access-controlled.
-    /// @param to The address to which all `underlyingAsset` tokens will be sent.
-    function withdrawAllUnderlyingAsset(address to) external;
+    /// @param to The address to which all `denominationAsset` tokens will be sent.
+    function withdrawAllDenominationAsset(address to) external;
 
     /// @notice Returns the address of the SMART token contract for which this yield schedule is defined.
     /// @dev The schedule contract needs to interact with this token contract to query historical balances (e.g.,
@@ -233,7 +233,7 @@ interface ISMARTFixedYieldSchedule is ISMARTYieldSchedule, IERC165 {
     /// @dev This is the actual token that holders will receive when they claim their yield.
     /// It can be the same as `token()` or a different token (e.g., a stablecoin).
     /// @return assetToken The `IERC20` compliant token contract address used for payments.
-    function underlyingAsset() external view returns (IERC20 assetToken);
+    function denominationAsset() external view returns (IERC20 assetToken);
 
     /// @notice Returns the timestamp representing the end date and time of the entire yield schedule.
     /// @dev After this timestamp, no more yield will typically accrue or be distributed by this schedule.

--- a/kit/contracts/scripts/hardhat/assets/actions/yield/claim-yield.ts
+++ b/kit/contracts/scripts/hardhat/assets/actions/yield/claim-yield.ts
@@ -7,7 +7,7 @@ import { waitForEvent } from "../../../utils/wait-for-event";
 
 export const claimYield = async (
   asset: Asset<any>,
-  underlyingAsset: Asset<any>,
+  denominationAsset: Asset<any>,
   actor: Actor
 ) => {
   console.log(`[Claim yield] → Starting yield claim...`);
@@ -41,6 +41,6 @@ export const claimYield = async (
   };
 
   console.log(
-    `[Claim yield] ✓ ${formatBaseUnits(claimedAmount, underlyingAsset.decimals)} ${underlyingAsset.symbol} yield claimed from period ${fromPeriod} to ${toPeriod}`
+    `[Claim yield] ✓ ${formatBaseUnits(claimedAmount, denominationAsset.decimals)} ${denominationAsset.symbol} yield claimed from period ${fromPeriod} to ${toPeriod}`
   );
 };

--- a/kit/contracts/scripts/hardhat/assets/actions/yield/topup-denomination-asset.ts
+++ b/kit/contracts/scripts/hardhat/assets/actions/yield/topup-denomination-asset.ts
@@ -8,12 +8,14 @@ import { waitForEvent } from "../../../utils/wait-for-event";
 import { approve } from "../core/approve";
 import { mint } from "../core/mint";
 
-export const topupUnderlyingAsset = async (
+export const topupDenominationAsset = async (
   asset: Asset<any>,
-  underlyingAsset: Asset<any>,
+  denominationAsset: Asset<any>,
   amount: bigint
 ) => {
-  console.log(`[Topup underlying asset] → Starting underlying asset topup...`);
+  console.log(
+    `[Topup denomination asset] → Starting denomination asset topup...`
+  );
 
   const tokenContract = owner.getContractInstance({
     address: asset.address,
@@ -21,26 +23,26 @@ export const topupUnderlyingAsset = async (
   });
 
   const scheduleAddress = await tokenContract.read.yieldSchedule();
-  await mint(underlyingAsset, owner, amount);
-  await approve(underlyingAsset, scheduleAddress, amount);
+  await mint(denominationAsset, owner, amount);
+  await approve(denominationAsset, scheduleAddress, amount);
 
   const scheduleContract = owner.getContractInstance({
     address: scheduleAddress,
     abi: ATKContracts.ismartFixedYieldSchedule,
   });
 
-  const topUpAmount = toBaseUnits(amount, underlyingAsset.decimals);
+  const topUpAmount = toBaseUnits(amount, denominationAsset.decimals);
 
   const topUpTransactionHash = await withDecodedRevertReason(() =>
-    scheduleContract.write.topUpUnderlyingAsset([topUpAmount])
+    scheduleContract.write.topUpDenominationAsset([topUpAmount])
   );
   await waitForEvent({
     transactionHash: topUpTransactionHash,
     contract: scheduleContract,
-    eventName: "UnderlyingAssetTopUp",
+    eventName: "DenominationAssetTopUp",
   });
 
   console.log(
-    `[Topup underlying asset] ✓ ${asset.symbol} underlying asset topped up with ${formatBaseUnits(topUpAmount, underlyingAsset.decimals)} ${underlyingAsset.symbol}`
+    `[Topup denomination asset] ✓ ${asset.symbol} denomination asset topped up with ${formatBaseUnits(topUpAmount, denominationAsset.decimals)} ${denominationAsset.symbol}`
   );
 };

--- a/kit/contracts/scripts/hardhat/assets/actions/yield/withdrawn-denomination-asset.ts
+++ b/kit/contracts/scripts/hardhat/assets/actions/yield/withdrawn-denomination-asset.ts
@@ -6,14 +6,14 @@ import { withDecodedRevertReason } from "../../../utils/decode-revert-reason";
 import { toBaseUnits } from "../../../utils/to-base-units";
 import { waitForEvent } from "../../../utils/wait-for-event";
 
-export const withdrawnUnderlyingAsset = async (
+export const withdrawnDenominationAsset = async (
   asset: Asset<any>,
-  underlyingAsset: Asset<any>,
+  denominationAsset: Asset<any>,
   to: Address,
   amount: bigint
 ) => {
   console.log(
-    `[Withdrawn underlying asset] → Starting underlying asset withdrawal...`
+    `[Withdrawn denomination asset] → Starting denomination asset withdrawal...`
   );
 
   const tokenContract = owner.getContractInstance({
@@ -27,17 +27,17 @@ export const withdrawnUnderlyingAsset = async (
     abi: ATKContracts.ismartFixedYieldSchedule,
   });
 
-  const withdrawnAmount = toBaseUnits(amount, underlyingAsset.decimals);
+  const withdrawnAmount = toBaseUnits(amount, denominationAsset.decimals);
   const transactionHash = await withDecodedRevertReason(() =>
-    scheduleContract.write.withdrawUnderlyingAsset([to, withdrawnAmount])
+    scheduleContract.write.withdrawDenominationAsset([to, withdrawnAmount])
   );
   await waitForEvent({
     transactionHash,
     contract: scheduleContract,
-    eventName: "UnderlyingAssetWithdrawn",
+    eventName: "DenominationAssetWithdrawn",
   });
 
   console.log(
-    `[Withdrawn underlying asset] ✓ ${asset.symbol} underlying asset withdrawn to ${to} with amount ${amount} ${underlyingAsset.symbol}`
+    `[Withdrawn denomination asset] ✓ ${asset.symbol} denomination asset withdrawn to ${to} with amount ${amount} ${denominationAsset.symbol}`
   );
 };

--- a/kit/contracts/scripts/hardhat/assets/bond.ts
+++ b/kit/contracts/scripts/hardhat/assets/bond.ts
@@ -25,8 +25,8 @@ import { redeem } from "./actions/redeemable/redeem";
 import { setupAsset } from "./actions/setup-asset";
 import { claimYield } from "./actions/yield/claim-yield";
 import { setYieldSchedule } from "./actions/yield/set-yield-schedule";
-import { topupUnderlyingAsset } from "./actions/yield/topup-underlying-asset";
-import { withdrawnUnderlyingAsset } from "./actions/yield/withdrawn-underlying-asset";
+import { topupDenominationAsset } from "./actions/yield/topup-underlying-asset";
+import { withdrawnDenominationAsset } from "./actions/yield/withdrawn-underlying-asset";
 import { getDefaultComplianceModules } from "./utils/default-compliance-modules";
 
 export const createBond = async (depositToken: Asset<any>) => {
@@ -111,7 +111,7 @@ export const createBond = async (depositToken: Asset<any>) => {
   const allowedIdentities = await Promise.all([
     investorA.getIdentity(),
     investorB.getIdentity(),
-    // owner also needs to be able to hold deposit token ... topUpUnderlyingAsset will mint to owner
+    // owner also needs to be able to hold deposit token ... topUpDenominationAsset will mint to owner
     owner.getIdentity(),
     bond.address,
     scheduleContract.address,
@@ -126,7 +126,7 @@ export const createBond = async (depositToken: Asset<any>) => {
   // do some mint/burns to change the yield
   await mint(bond, owner, 10n);
   await burn(bond, owner, 1n);
-  await topupUnderlyingAsset(bond, depositToken, 10000n);
+  await topupDenominationAsset(bond, depositToken, 10000n);
   // claim yield for 3 periods
   for (let i = 0; i < 3; i++) {
     const didAdvance = await advanceToNextPeriod();
@@ -141,7 +141,7 @@ export const createBond = async (depositToken: Asset<any>) => {
     await transfer(bond, owner, investorA, 6n);
     await transfer(bond, owner, investorB, 3n);
   }
-  await withdrawnUnderlyingAsset(bond, depositToken, investorA.address, 5n);
+  await withdrawnDenominationAsset(bond, depositToken, investorA.address, 5n);
 
   // mature bond
   await mint(depositToken, bond.address, 150n);

--- a/kit/contracts/scripts/hardhat/assets/bond.ts
+++ b/kit/contracts/scripts/hardhat/assets/bond.ts
@@ -25,8 +25,8 @@ import { redeem } from "./actions/redeemable/redeem";
 import { setupAsset } from "./actions/setup-asset";
 import { claimYield } from "./actions/yield/claim-yield";
 import { setYieldSchedule } from "./actions/yield/set-yield-schedule";
-import { topupDenominationAsset } from "./actions/yield/topup-underlying-asset";
-import { withdrawnDenominationAsset } from "./actions/yield/withdrawn-underlying-asset";
+import { topupDenominationAsset } from "./actions/yield/topup-denomination-asset";
+import { withdrawnDenominationAsset } from "./actions/yield/withdrawn-denomination-asset";
 import { getDefaultComplianceModules } from "./utils/default-compliance-modules";
 
 export const createBond = async (depositToken: Asset<any>) => {

--- a/kit/contracts/test/assets/ATKBondReentrancyTest.t.sol
+++ b/kit/contracts/test/assets/ATKBondReentrancyTest.t.sol
@@ -192,12 +192,12 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
         // Setup: Prepare bond for redemption
         uint256 redeemAmount = 10 * 10 ** DECIMALS; // 10 bonds
         uint256 denominationAmountNeeded = redeemAmount * faceValue / (10 ** DECIMALS);
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS); // For all bonds
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS); // For all bonds
 
         vm.startPrank(owner);
 
         // Mint denomination tokens and transfer to bond contract
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
 
         // Transfer some bonds to user1
         assertTrue(bond.transfer(user1, redeemAmount), "Transfer failed");
@@ -233,12 +233,12 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
      */
     function test_MultipleRedemptionCallsProtected() public {
         uint256 redeemAmount = 5 * 10 ** DECIMALS; // 5 bonds
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS); // For all bonds
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS); // For all bonds
 
         vm.startPrank(owner);
 
         // Mint enough denomination tokens for multiple redemptions
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
 
         // Transfer bonds to user1
         assertTrue(bond.transfer(user1, redeemAmount * 2), "Transfer failed");
@@ -269,11 +269,11 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
     function test_RedeemMoreThanAvailable() public {
         uint256 redeemAmount = 10 * 10 ** DECIMALS;
         uint256 excessAmount = 15 * 10 ** DECIMALS;
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
         assertTrue(bond.transfer(user1, redeemAmount), "Transfer failed");
 
         vm.warp(maturityDate + 1);
@@ -310,12 +310,12 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
      */
     function test_RedeemInsufficientDenominationAssetBalance() public {
         uint256 redeemAmount = 10 * 10 ** DECIMALS;
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
         // First provide enough tokens to mature the bond
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
         assertTrue(bond.transfer(user1, redeemAmount), "Transfer failed");
 
         vm.warp(maturityDate + 1);
@@ -346,11 +346,11 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
     function test_StateChangesAppliedBeforeExternalCall() public {
         uint256 redeemAmount = 10 * 10 ** DECIMALS;
         uint256 denominationAmountNeeded = redeemAmount * faceValue / (10 ** DECIMALS);
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
         assertTrue(bond.transfer(user1, redeemAmount), "Transfer failed");
 
         vm.warp(maturityDate + 1);
@@ -376,7 +376,7 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
             "Redeemed amount not tracked correctly"
         );
         assertEq(
-            maliciousToken.balanceOf(user1), denominationAmountNeeded, "Underlying tokens not transferred correctly"
+            maliciousToken.balanceOf(user1), denominationAmountNeeded, "Denomination tokens not transferred correctly"
         );
     }
 
@@ -386,11 +386,11 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
     function test_RedeemAllReentrancyProtection() public {
         uint256 userBonds = 20 * 10 ** DECIMALS;
         uint256 denominationAmountNeeded = userBonds * faceValue / (10 ** DECIMALS);
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
         assertTrue(bond.transfer(user1, userBonds), "Transfer failed");
 
         vm.warp(maturityDate + 1);
@@ -424,12 +424,12 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
      */
     function test_FailedTransferHandling() public {
         uint256 redeemAmount = 10 * 10 ** DECIMALS;
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
         // Mint enough to mature the bond
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
         assertTrue(bond.transfer(user1, redeemAmount), "Transfer failed");
 
         vm.warp(maturityDate + 1);
@@ -456,11 +456,11 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
      */
     function test_GasConsumptionWithReentrancyProtection() public {
         uint256 redeemAmount = 1 * 10 ** DECIMALS;
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
-        maliciousToken.mint(address(bond), totalUnderlyingNeeded);
+        maliciousToken.mint(address(bond), totalDenominationNeeded);
         assertTrue(bond.transfer(user1, redeemAmount), "Transfer failed");
 
         vm.warp(maturityDate + 1);
@@ -513,12 +513,12 @@ contract ATKBondReentrancyTest is AbstractATKAssetTest {
 
         uint256 redeemAmount = 10 * 10 ** DECIMALS;
         uint256 denominationAmountNeeded = redeemAmount * faceValue / (10 ** DECIMALS);
-        uint256 totalUnderlyingNeeded = initialSupply * faceValue / (10 ** DECIMALS);
+        uint256 totalDenominationNeeded = initialSupply * faceValue / (10 ** DECIMALS);
 
         vm.startPrank(owner);
 
         normalBond.mint(owner, initialSupply);
-        normalToken.mint(address(normalBond), totalUnderlyingNeeded);
+        normalToken.mint(address(normalBond), totalDenominationNeeded);
         assertTrue(normalBond.transfer(user1, redeemAmount), "Transfer failed");
 
         vm.warp(maturityDate + 1);

--- a/kit/contracts/test/smart/extensions/SMARTYieldIntegrationTest.sol
+++ b/kit/contracts/test/smart/extensions/SMARTYieldIntegrationTest.sol
@@ -29,7 +29,7 @@ abstract contract SMARTYieldIntegrationTest is SMARTYieldBaseTest {
         assertEq(schedule.startDate(), futureStartDate, "Schedule start date should match");
         assertEq(address(schedule.token()), address(token), "Schedule token should reference our token");
         assertEq(
-            address(schedule.underlyingAsset()), yieldPaymentToken, "Schedule underlying asset should match yield token"
+            address(schedule.denominationAsset()), yieldPaymentToken, "Schedule denomination asset should match yield token"
         );
         assertEq(schedule.rate(), YIELD_RATE, "Schedule rate should match configured rate");
         assertEq(schedule.interval(), PERIOD_INTERVAL, "Schedule interval should match configured interval");
@@ -260,7 +260,7 @@ abstract contract SMARTYieldIntegrationTest is SMARTYieldBaseTest {
 
         // Withdraw
         vm.prank(tokenIssuer);
-        ISMARTFixedYieldSchedule(scheduleAddress).withdrawUnderlyingAsset(tokenIssuer, withdrawAmount);
+        ISMARTFixedYieldSchedule(scheduleAddress).withdrawDenominationAsset(tokenIssuer, withdrawAmount);
 
         uint256 finalTokenIssuerBalance = IERC20(yieldPaymentToken).balanceOf(tokenIssuer);
 

--- a/kit/contracts/test/utils/SMARTYieldHelpers.sol
+++ b/kit/contracts/test/utils/SMARTYieldHelpers.sol
@@ -102,7 +102,7 @@ abstract contract SMARTYieldHelpers is Test {
         // Approve and fund the schedule
         vm.startPrank(funder);
         IERC20(yieldPaymentToken).approve(scheduleAddress, amount);
-        ISMARTFixedYieldSchedule(scheduleAddress).topUpUnderlyingAsset(amount);
+        ISMARTFixedYieldSchedule(scheduleAddress).topUpDenominationAsset(amount);
         vm.stopPrank();
     }
 }

--- a/kit/dapp/locales/ar-SA/tokens.json
+++ b/kit/dapp/locales/ar-SA/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "الأذونات",
     "tokenInformation": "تفاصيل الأصل",
-    "underlyingAssets": "الأصول الأساسية",
+    "denominationAssets": "الأصول الأساسية",
     "yield": "العائد"
   },
   "api": {

--- a/kit/dapp/locales/ar-SA/tokens.json
+++ b/kit/dapp/locales/ar-SA/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "الأذونات",
     "tokenInformation": "تفاصيل الأصل",
-    "denominationAssets": "الأصول الأساسية",
+    "underlyingAssets": "الأصول الأساسية",
     "yield": "العائد"
   },
   "api": {

--- a/kit/dapp/locales/de-DE/tokens.json
+++ b/kit/dapp/locales/de-DE/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "Berechtigungen",
     "tokenInformation": "Vermögensdetails",
-    "denominationAssets": "Unterliegende Vermögenswerte",
+    "underlyingAssets": "Unterliegende Vermögenswerte",
     "yield": "Ertrag"
   },
   "api": {

--- a/kit/dapp/locales/de-DE/tokens.json
+++ b/kit/dapp/locales/de-DE/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "Berechtigungen",
     "tokenInformation": "Vermögensdetails",
-    "underlyingAssets": "Unterliegende Vermögenswerte",
+    "denominationAssets": "Unterliegende Vermögenswerte",
     "yield": "Ertrag"
   },
   "api": {

--- a/kit/dapp/locales/en-US/stats.json
+++ b/kit/dapp/locales/en-US/stats.json
@@ -57,7 +57,7 @@
       },
       "active": {
         "title": "Redemption Coverage",
-        "description": "{{percentage}}% of underlying assets available",
+        "description": "{{percentage}}% of denomination assets available",
         "label": "Active"
       },
       "matured": {

--- a/kit/dapp/locales/en-US/tokens.json
+++ b/kit/dapp/locales/en-US/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "Permissions",
     "tokenInformation": "Asset Details",
-    "underlyingAssets": "Underlying Assets",
+    "denominationAssets": "Denomination Assets",
     "yield": "Yield"
   },
   "api": {

--- a/kit/dapp/locales/en-US/tokens.json
+++ b/kit/dapp/locales/en-US/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "Permissions",
     "tokenInformation": "Asset Details",
-    "denominationAssets": "Denomination Assets",
+    "underlyingAssets": "Denomination Assets",
     "yield": "Yield"
   },
   "api": {

--- a/kit/dapp/locales/ja-JP/tokens.json
+++ b/kit/dapp/locales/ja-JP/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "権限",
     "tokenInformation": "資産の詳細",
-    "denominationAssets": "基礎資産",
+    "underlyingAssets": "基礎資産",
     "yield": "利回り"
   },
   "api": {

--- a/kit/dapp/locales/ja-JP/tokens.json
+++ b/kit/dapp/locales/ja-JP/tokens.json
@@ -554,7 +554,7 @@
     "mica": "MICA",
     "permissions": "権限",
     "tokenInformation": "資産の詳細",
-    "underlyingAssets": "基礎資産",
+    "denominationAssets": "基礎資産",
     "yield": "利回り"
   },
   "api": {

--- a/kit/dapp/src/components/stats/charts/asset-bond-status-progress-chart.tsx
+++ b/kit/dapp/src/components/stats/charts/asset-bond-status-progress-chart.tsx
@@ -14,7 +14,7 @@ export interface AssetBondStatusProgressChartProps {
  *
  * Displays bond status progress as a donut chart showing different states:
  * - Issuing: Progress of bond issuance against cap
- * - Active: Progress of underlying asset accumulation for redemption
+ * - Active: Progress of denomination asset accumulation for redemption
  * - Matured: Progress of bond redemption
  *
  * This component follows the Strategy Pattern with Custom Hooks:

--- a/kit/dapp/src/lib/utils/features-enabled.test.ts
+++ b/kit/dapp/src/lib/utils/features-enabled.test.ts
@@ -1,13 +1,13 @@
+import type { AssetType } from "@/lib/zod/validators/asset-types";
 import { describe, expect, test } from "vitest";
 import {
-  hasBlocklist,
   hasAllowlist,
+  hasBlocklist,
+  hasFreeze,
   hasUnderlyingAssets,
   hasYield,
-  hasFreeze,
   isMicaEnabledForAsset,
 } from "./features-enabled";
-import type { AssetType } from "@/lib/zod/validators/asset-types";
 
 describe("hasBlocklist", () => {
   test("returns true for all asset types except deposit", () => {
@@ -37,7 +37,6 @@ describe("hasAllowlist", () => {
 
 describe("hasUnderlyingAssets", () => {
   test("returns true for bond and fund", () => {
-    expect(hasUnderlyingAssets("bond")).toBe(true);
     expect(hasUnderlyingAssets("fund")).toBe(true);
   });
 
@@ -45,6 +44,7 @@ describe("hasUnderlyingAssets", () => {
     expect(hasUnderlyingAssets("equity")).toBe(false);
     expect(hasUnderlyingAssets("stablecoin")).toBe(false);
     expect(hasUnderlyingAssets("deposit")).toBe(false);
+    expect(hasUnderlyingAssets("bond")).toBe(false);
   });
 });
 

--- a/kit/dapp/src/lib/utils/features-enabled.ts
+++ b/kit/dapp/src/lib/utils/features-enabled.ts
@@ -17,7 +17,7 @@ export const hasAllowlist = (assetType: AssetType): boolean =>
  * Checks if an asset type supports underlying assets
  */
 export const hasUnderlyingAssets = (assetType: AssetType): boolean =>
-  assetType === "bond" || assetType === "fund";
+  assetType === "fund";
 
 /**
  * Checks if an asset type supports yield functionality

--- a/kit/dapp/src/lib/utils/features-enabled.ts
+++ b/kit/dapp/src/lib/utils/features-enabled.ts
@@ -19,6 +19,9 @@ export const hasAllowlist = (assetType: AssetType): boolean =>
 export const hasUnderlyingAssets = (assetType: AssetType): boolean =>
   assetType === "fund";
 
+export const hasDenominationAsset = (assetType: AssetType): boolean =>
+  assetType === "bond";
+
 /**
  * Checks if an asset type supports yield functionality
  */

--- a/kit/dapp/src/orpc/routes/token/routes/stats/bond-status.contract.ts
+++ b/kit/dapp/src/orpc/routes/token/routes/stats/bond-status.contract.ts
@@ -10,7 +10,7 @@ export const statsBondStatusContract = baseContract
     path: "/token/{tokenAddress}/stats/bond-status",
     description: "Get bond status statistics for a specific token",
     successDescription:
-      "Bond status statistics including underlying asset information",
+      "Bond status statistics including denomination asset information",
     tags: ["token", "stats", "bond"],
   })
   .input(StatsBondStatusInputSchema)

--- a/kit/e2e/pages/admin-page.ts
+++ b/kit/e2e/pages/admin-page.ts
@@ -20,7 +20,7 @@ export class AdminPage extends BasePage {
     decimals: string;
     maximumSupply: string;
     faceValue: string;
-    underlyingAsset: string;
+    denominationAsset: string;
     pincode: string;
   }) {
     const nextButton = this.page.getByRole("button", {
@@ -38,17 +38,17 @@ export class AdminPage extends BasePage {
     const formattedDateTime = tomorrow.toISOString().slice(0, 16);
     await this.page.getByLabel("Maturity date").fill(formattedDateTime);
     await this.page
-      .locator('[id="underlyingAsset"]')
+      .locator('[id="denominationAsset"]')
       .waitFor({ state: "visible" });
     await this.page
-      .locator('button[id="underlyingAsset"][data-slot="popover-trigger"]')
+      .locator('button[id="denominationAsset"][data-slot="popover-trigger"]')
       .click();
     await this.page.getByPlaceholder("Search for an asset...").click();
     await this.page
       .getByPlaceholder("Search for an asset...")
-      .fill(options.underlyingAsset);
+      .fill(options.denominationAsset);
     await this.page
-      .getByRole("option", { name: `Avatar ${options.underlyingAsset}` })
+      .getByRole("option", { name: `Avatar ${options.denominationAsset}` })
       .click();
     await nextButton.click();
     await nextButton.click();

--- a/kit/e2e/pages/create-asset-form.ts
+++ b/kit/e2e/pages/create-asset-form.ts
@@ -52,19 +52,19 @@ export class CreateAssetForm extends BasePage {
     maximumSupply: string;
     faceValue: string;
     maturityDate: string;
-    underlyingAsset?: string;
+    denominationAsset?: string;
   }) {
     await this.page.getByLabel("Decimals").fill(options.decimals);
     await this.page.getByLabel("Maximum supply").fill(options.maximumSupply);
     await this.page.getByLabel("Face value").fill(options.faceValue);
     await this.page.getByLabel("Maturity date").fill(options.maturityDate);
-    if (options.underlyingAsset !== undefined) {
-      await this.page.getByLabel("Underlying asset").click();
+    if (options.denominationAsset !== undefined) {
+      await this.page.getByLabel("Denomination asset").click();
       await this.page
         .getByPlaceholder("Search for an asset...")
-        .fill(options.underlyingAsset);
+        .fill(options.denominationAsset);
       await this.page
-        .getByRole("option", { name: options.underlyingAsset })
+        .getByRole("option", { name: options.denominationAsset })
         .click();
     }
   }

--- a/kit/e2e/test-data/message-data.ts
+++ b/kit/e2e/test-data/message-data.ts
@@ -28,6 +28,6 @@ export const errorMessageData = {
     "Please enter a number no greater than 9007199254740991",
   errorMessageMaturityDate:
     "Maturity date must be at least 1 hour in the future",
-  errorMessageUnderlyingAsset: "Please provide all required information",
+  errorMessageDenominationAsset: "Please provide all required information",
   errorMessageManagementFee: "Please enter a value between 0 and 10000",
 };

--- a/kit/e2e/ui-tests/create-bond-validation.spec.ts
+++ b/kit/e2e/ui-tests/create-bond-validation.spec.ts
@@ -273,7 +273,7 @@ test.describe.serial("Bond Creation Validation", () => {
         errorMessageData.errorMessageMaturityDate
       );
     });
-    test("validates underlying asset is required", async () => {
+    test("validates denomination asset is required", async () => {
       await createAssetForm.fillBondDetails({
         decimals: "18",
         maximumSupply: "1000",
@@ -282,7 +282,7 @@ test.describe.serial("Bond Creation Validation", () => {
       });
       await createAssetForm.clickOnNextButton();
       await createAssetForm.expectErrorMessage(
-        errorMessageData.errorMessageUnderlyingAsset
+        errorMessageData.errorMessageDenominationAsset
       );
     });
   });
@@ -310,7 +310,7 @@ test.describe.serial("Bond Creation Validation", () => {
     test("Create Bond asset", async () => {
       const bondDataWithStablecoin = {
         ...bondData,
-        underlyingAsset: testData.stablecoinName,
+        denominationAsset: testData.stablecoinName,
       };
       await adminPages.adminPage.createBond(bondDataWithStablecoin);
       await adminPages.adminPage.verifySuccessMessage(

--- a/kit/e2e/ui-tests/create-top-up-mint-burn-transfer-bond.spec.ts
+++ b/kit/e2e/ui-tests/create-top-up-mint-burn-transfer-bond.spec.ts
@@ -1,6 +1,7 @@
 import { type BrowserContext, test } from "@playwright/test";
 import { Pages } from "../pages/pages";
 import {
+  bondBurnData,
   bondData,
   bondMintData,
   bondTransferData,
@@ -8,7 +9,6 @@ import {
   stableCoinUpdateCollateralData,
   stablecoinData,
   topUpData,
-  bondBurnData,
 } from "../test-data/asset-data";
 import { successMessageData } from "../test-data/message-data";
 import { adminUser, signUpTransferUserData } from "../test-data/user-data";
@@ -83,7 +83,7 @@ test.describe("Create, top up, mint and transfer bonds", () => {
   test("Admin user creates bond", async () => {
     const bondDataWithStablecoin = {
       ...bondData,
-      underlyingAsset: testData.stablecoinName,
+      denominationAsset: testData.stablecoinName,
     };
     await adminPages.adminPage.createBond(bondDataWithStablecoin);
     testData.bondName = bondDataWithStablecoin.name;

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -679,7 +679,7 @@ type TokenFixedYieldSchedule @entity(immutable: false) {
   totalUnclaimedYieldExact: BigInt!
   totalYield: BigDecimal!
   totalYieldExact: BigInt!
-  underlyingAsset: Token!
+  denominationAsset: Token!
   currentPeriod: TokenFixedYieldSchedulePeriod
   nextPeriod: TokenFixedYieldSchedulePeriod
   periods: [TokenFixedYieldSchedulePeriod!]! @derivedFrom(field: "schedule")
@@ -946,13 +946,13 @@ type TokenBondStatsState @entity(immutable: false) {
   id: Bytes!
   # Reference to the associated bond
   bond: TokenBond!
-  # Available balance of the underlying asset (human-readable)
+  # Available balance of the denomination asset (human-readable)
   denominationAssetBalanceAvailable: BigDecimal!
-  # Available balance of the underlying asset (exact, raw units)
+  # Available balance of the denomination asset (exact, raw units)
   denominationAssetBalanceAvailableExact: BigInt!
-  # Required balance of the underlying asset to fully collateralize the bond (human-readable)
+  # Required balance of the denomination asset to fully collateralize the bond (human-readable)
   denominationAssetBalanceRequired: BigDecimal!
-  # Required balance of the underlying asset (exact, raw units)
+  # Required balance of the denomination asset (exact, raw units)
   denominationAssetBalanceRequiredExact: BigInt!
   # Percentage of required collateral that is currently covered (available / required * 100)
   coveredPercentage: BigDecimal!
@@ -963,13 +963,13 @@ type TokenBondStatsData @entity(timeseries: true) {
   timestamp: Timestamp!
   # Reference to the associated bond
   bond: TokenBond!
-  # Available balance of the underlying asset (human-readable)
+  # Available balance of the denomination asset (human-readable)
   denominationAssetBalanceAvailable: BigDecimal!
-  # Available balance of the underlying asset (exact, raw units)
+  # Available balance of the denomination asset (exact, raw units)
   denominationAssetBalanceAvailableExact: BigInt!
-  # Required balance of the underlying asset to fully collateralize the bond (human-readable)
+  # Required balance of the denomination asset to fully collateralize the bond (human-readable)
   denominationAssetBalanceRequired: BigDecimal!
-  # Required balance of the underlying asset (exact, raw units)
+  # Required balance of the denomination asset (exact, raw units)
   denominationAssetBalanceRequiredExact: BigInt!
   # Percentage of required collateral that is currently covered (available / required * 100)
   coveredPercentage: BigDecimal!

--- a/kit/subgraph/src/stats/utils/bond-stats-utils.ts
+++ b/kit/subgraph/src/stats/utils/bond-stats-utils.ts
@@ -4,17 +4,17 @@ import { fetchToken } from "../../token/fetch/token";
 import { updateTokenBondStats } from "../token-bond-stats";
 
 /**
- * Update stats for bond when underlying asset balance changes.
+ * Update stats for bond when denomination asset balance changes.
  */
-export function updateBondStatsForUnderlyingAssetBalanceChange(
-  underlyingAsset: Token,
+export function updateBondStatsForDenominationAssetBalanceChange(
+  denominationAsset: Token,
   bond: Address
 ): void {
   // Check if the bond whose balance changed is a bond contract
   const potentialBondToken = TokenBond.load(bond);
   if (potentialBondToken != null) {
-    // Check if this bond uses the transferred token as underlying asset
-    if (potentialBondToken.denominationAsset == underlyingAsset.id) {
+    // Check if this bond uses the transferred token as denomination asset
+    if (potentialBondToken.denominationAsset == denominationAsset.id) {
       const token = fetchToken(Address.fromBytes(potentialBondToken.id));
       updateTokenBondStats(token);
     }

--- a/kit/subgraph/src/token-balance/utils/token-balance-utils.ts
+++ b/kit/subgraph/src/token-balance/utils/token-balance-utils.ts
@@ -4,7 +4,7 @@ import { fetchAccount } from "../../account/fetch/account";
 import { decreaseAccountStatsBalanceCount } from "../../stats/account-stats";
 import { updateTokenDistributionStats } from "../../stats/token-distribution-stats";
 import { decreaseTokenStatsBalanceCount } from "../../stats/token-stats";
-import { updateBondStatsForUnderlyingAssetBalanceChange } from "../../stats/utils/bond-stats-utils";
+import { updateBondStatsForDenominationAssetBalanceChange } from "../../stats/utils/bond-stats-utils";
 import { setBigNumber } from "../../utils/bignumber";
 import { fetchTokenBalance } from "../fetch/token-balance";
 
@@ -38,8 +38,8 @@ export function increaseTokenBalanceValue(
     newValue
   );
 
-  // Check if this balance change affects any bond token's underlying asset balance
-  updateBondStatsForUnderlyingAssetBalanceChange(token, account);
+  // Check if this balance change affects any bond token's denomination asset balance
+  updateBondStatsForDenominationAssetBalanceChange(token, account);
 }
 
 export function decreaseTokenBalanceValue(
@@ -72,8 +72,8 @@ export function decreaseTokenBalanceValue(
     newValue
   );
 
-  // Check if this balance change affects any bond token's underlying asset balance
-  updateBondStatsForUnderlyingAssetBalanceChange(token, account);
+  // Check if this balance change affects any bond token's denomination asset balance
+  updateBondStatsForDenominationAssetBalanceChange(token, account);
 }
 
 export function increaseTokenBalanceFrozen(

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fetch/fixed-yield-schedule.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fetch/fixed-yield-schedule.ts
@@ -38,7 +38,7 @@ export function fetchFixedYieldSchedule(
       BigInt.zero(),
       DEFAULT_TOKEN_DECIMALS
     );
-    fixedYieldSchedule.underlyingAsset = Address.zero();
+    fixedYieldSchedule.denominationAsset = Address.zero();
     fixedYieldSchedule.deployedInTransaction = Bytes.empty();
     fixedYieldSchedule.save();
     FixedYieldScheduleTemplate.create(address);

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
@@ -48,7 +48,7 @@ export function handleFixedYieldScheduleSet(
     event.params.yieldForNextPeriod,
     tokenDecimals
   );
-  fixedYieldSchedule.DenominationAsset = event.params.DenominationAsset;
+  fixedYieldSchedule.denominationAsset = event.params.denominationAsset;
   for (let i = 1; i <= event.params.periodEndTimestamps.length; i++) {
     const period = fetchFixedYieldSchedulePeriod(getPeriodId(event.address, i));
     if (period.deployedInTransaction.equals(Bytes.empty())) {

--- a/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
+++ b/kit/subgraph/src/token-extensions/fixed-yield-schedule/fixed-yield-schedule.ts
@@ -1,9 +1,9 @@
 import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { TokenFixedYieldSchedulePeriod } from "../../../generated/schema";
 import {
+  DenominationAssetTopUp,
+  DenominationAssetWithdrawn,
   FixedYieldScheduleSet,
-  UnderlyingAssetTopUp,
-  UnderlyingAssetWithdrawn,
   YieldClaimed,
 } from "../../../generated/templates/FixedYieldSchedule/FixedYieldSchedule";
 import { fetchEvent } from "../../event/fetch/event";
@@ -48,7 +48,7 @@ export function handleFixedYieldScheduleSet(
     event.params.yieldForNextPeriod,
     tokenDecimals
   );
-  fixedYieldSchedule.underlyingAsset = event.params.underlyingAsset;
+  fixedYieldSchedule.DenominationAsset = event.params.DenominationAsset;
   for (let i = 1; i <= event.params.periodEndTimestamps.length; i++) {
     const period = fetchFixedYieldSchedulePeriod(getPeriodId(event.address, i));
     if (period.deployedInTransaction.equals(Bytes.empty())) {
@@ -76,14 +76,16 @@ export function handleFixedYieldScheduleSet(
   fixedYieldSchedule.save();
 }
 
-export function handleUnderlyingAssetTopUp(event: UnderlyingAssetTopUp): void {
-  fetchEvent(event, "UnderlyingAssetTopUp");
+export function handleDenominationAssetTopUp(
+  event: DenominationAssetTopUp
+): void {
+  fetchEvent(event, "DenominationAssetTopUp");
 }
 
-export function handleUnderlyingAssetWithdrawn(
-  event: UnderlyingAssetWithdrawn
+export function handleDenominationAssetWithdrawn(
+  event: DenominationAssetWithdrawn
 ): void {
-  fetchEvent(event, "UnderlyingAssetWithdrawn");
+  fetchEvent(event, "DenominationAssetWithdrawn");
 }
 
 export function handleYieldClaimed(event: YieldClaimed): void {

--- a/kit/subgraph/subgraph.yaml
+++ b/kit/subgraph/subgraph.yaml
@@ -400,8 +400,8 @@ templates:
       language: wasm/assemblyscript
       entities:
         - FixedYieldScheduleSet
-        - UnderlyingAssetTopUp
-        - UnderlyingAssetWithdrawn
+        - DenominationAssetTopUp
+        - DenominationAssetWithdrawn
         - YieldClaimed
       abis:
         - name: FixedYieldSchedule
@@ -409,10 +409,10 @@ templates:
       eventHandlers:
         - event: FixedYieldScheduleSet(uint256,uint256,uint256,uint256,uint256[],address,uint256)
           handler: handleFixedYieldScheduleSet
-        - event: UnderlyingAssetTopUp(indexed address,indexed uint256)
-          handler: handleUnderlyingAssetTopUp
-        - event: UnderlyingAssetWithdrawn(indexed address,indexed uint256)
-          handler: handleUnderlyingAssetWithdrawn
+        - event: DenominationAssetTopUp(indexed address,indexed uint256)
+          handler: handleDenominationAssetTopUp
+        - event: DenominationAssetWithdrawn(indexed address,indexed uint256)
+          handler: handleDenominationAssetWithdrawn
         - event: YieldClaimed(indexed
             address,uint256,uint256,uint256,uint256[],uint256[],uint256,uint256)
           handler: handleYieldClaimed

--- a/kit/subgraph/test/extensions/fixed-yield.spec.ts
+++ b/kit/subgraph/test/extensions/fixed-yield.spec.ts
@@ -34,7 +34,7 @@ describe("Fixed yield", () => {
                 totalClaimed
                 totalUnclaimedYield
               }
-              underlyingAsset {
+              denominationAsset {
                 name
               }
             }
@@ -120,7 +120,7 @@ describe("Fixed yield", () => {
                 totalUnclaimedYield: "0",
               },
             ],
-            underlyingAsset: {
+            denominationAsset: {
               name: "Euro Deposits",
             },
           },

--- a/kit/subgraph/test/stats/account-stats.spec.ts
+++ b/kit/subgraph/test/stats/account-stats.spec.ts
@@ -121,8 +121,8 @@ describe("AccountStats", () => {
     // - Owner
     // - Investor A New
     // - Investor B
-    // - Bond contract (underlying deposit asset)
-    // - Fixed yield schedule contract (underlying deposit asset)
+    // - Bond contract (denomination deposit asset)
+    // - Fixed yield schedule contract (denomination deposit asset)
     expect(accountsResponse.accounts.length).toBe(5);
 
     const account = accountsResponse.accounts[0];

--- a/kit/subgraph/test/stats/token-bond-stats.spec.ts
+++ b/kit/subgraph/test/stats/token-bond-stats.spec.ts
@@ -36,7 +36,7 @@ describe("TokenBondStats", () => {
     bondToken = bondResponse.tokens[0];
   });
 
-  it("should track bond statistics with underlying asset balance", async () => {
+  it("should track bond statistics with denomination asset balance", async () => {
     const query = theGraphGraphql(
       `query($tokenId: String!) {
         tokenBondStatsState(id: $tokenId) {

--- a/kit/subgraph/test/token-balance.spec.ts
+++ b/kit/subgraph/test/token-balance.spec.ts
@@ -46,8 +46,8 @@ describe("TokenBalances", () => {
     // - Investor A New
     // - Investor B
     // - Frozen investor
-    // - Bond contract (underlying deposit asset)
-    // - Fixed yield schedule contract (underlying deposit asset)
+    // - Bond contract (denomination deposit asset)
+    // - Fixed yield schedule contract (denomination deposit asset)
     expect(Object.keys(balancesByAccount).length).toBe(6);
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Rename the underlying asset concept to denomination asset across the entire codebase to align terminology consistently.

Enhancements:
- Replace all occurrences of underlyingAsset identifiers with denominationAsset in contracts, tests, interfaces, and scripts
- Update events, errors, functions, schema, subgraph mappings, UI labels, and documentation to use denomination asset
- Adjust file names, function names, GraphQL schema fields, and E2E tests to reflect the new naming

Documentation:
- Update user-facing documentation and README to reference denomination asset instead of underlying asset