### PR TITLE
fix: kyc form submit button

### DIFF
--- a/kit/contracts/foundry.toml
+++ b/kit/contracts/foundry.toml
@@ -51,5 +51,5 @@
 [soldeer]
   remappings_version = false
 
-[profile.lint]
+[lint]
   exclude_lints = ["mixed-case-function", "mixed-case-variable", "screaming-snake-case-const", "screaming-snake-case-immutable", "pascal-case-struct", "asm-keccak256"]

--- a/kit/contracts/foundry.toml
+++ b/kit/contracts/foundry.toml
@@ -51,5 +51,5 @@
 [soldeer]
   remappings_version = false
 
-[lint]
+[profile.lint]
   exclude_lints = ["mixed-case-function", "mixed-case-variable", "screaming-snake-case-const", "screaming-snake-case-immutable", "pascal-case-struct", "asm-keccak256"]

--- a/kit/dapp/src/components/form/verification-button.tsx
+++ b/kit/dapp/src/components/form/verification-button.tsx
@@ -27,9 +27,11 @@ export function VerificationButton({
       selector={(state) => ({
         isSubmitting: state.isSubmitting,
         isValid: state.isValid,
+        isDirty: state.isDirty,
+        errors: state.errors,
       })}
     >
-      {({ isSubmitting, isValid }) => {
+      {({ isSubmitting, isValid, isDirty, errors }) => {
         return (
           <VerificationButtonComponent
             verification={verification}
@@ -43,12 +45,14 @@ export function VerificationButton({
               }
             }}
             disabled={
-              typeof disabled === "function"
+              (typeof disabled === "function"
                 ? disabled({
-                    isDirty: form.state.isDirty,
-                    errors: form.state.errors,
+                    isDirty,
+                    errors,
                   })
-                : disabled || isSubmitting || !isValid
+                : disabled) ||
+              isSubmitting ||
+              !isValid
             }
           >
             {children}

--- a/kit/dapp/src/components/kyc/kyc-form.tsx
+++ b/kit/dapp/src/components/kyc/kyc-form.tsx
@@ -70,6 +70,7 @@ export function KycForm({ onComplete }: KycFormProps) {
   const form = useAppForm({
     defaultValues: {
       ...kyc,
+      userId: session?.user.id ?? "",
     } as KycFormValues,
     validators: {
       onChange: KycUpsertInputSchema,


### PR DESCRIPTION
## Summary by Sourcery

Expose form dirty status and errors in the VerificationButton component to refine its disabled logic, and initialize the KycForm with the session user’s ID.

Bug Fixes:
- Fix submit button disable logic by incorporating form isDirty and errors into ValidationButton’s disabled condition.

Enhancements:
- Select and forward isDirty and errors from form state in VerificationButton.
- Pass isDirty and errors into the custom disabled callback in VerificationButton.
- Initialize KycForm’s default values with the current user’s ID.