### PR TITLE
fix: foundry config

### DIFF
--- a/kit/contracts/foundry.toml
+++ b/kit/contracts/foundry.toml
@@ -51,5 +51,5 @@
 [soldeer]
   remappings_version = false
 
-[lint]
+[profile.default.lint]
   exclude_lints = ["mixed-case-function", "mixed-case-variable", "screaming-snake-case-const", "screaming-snake-case-immutable", "pascal-case-struct", "asm-keccak256"]


### PR DESCRIPTION
Fixes the following warning in forge compile: 

```
Warning: Found unknown config section in foundry.toml: [lint]
This notation for profiles has been deprecated and may result in the profile not being registered in future versions.
Please use [profile.lint] instead or run `forge config --fix`.
Compiling 378 files with Solc 0.8.30
```

and this comment from gemini: https://github.com/settlemint/asset-tokenization-kit/pull/3145#discussion_r2262673062

```
This change defines the linting configuration under a new profile named lint. However, the postlint script in package.json executes forge lint without specifying a profile, which defaults to using the default profile. Consequently, these linting exclusions will not be applied. To fix this, the linting configuration should be nested under the default profile.
```