### PR TITLE
chore: skip slack notifier when credentials are missing

### DIFF
--- a/.github/actions/slack-pr-notifier/slack-notifier.js
+++ b/.github/actions/slack-pr-notifier/slack-notifier.js
@@ -67,6 +67,14 @@ module.exports = async ({ github, context, core }) => {
     SLACK_BOT_TOKEN: SLACK_BOT_TOKEN ? "Set" : "Not set",
   });
 
+  // If Slack credentials are missing, skip notification but don't fail the run
+  if (!SLACK_BOT_TOKEN || !SLACK_CHANNEL_ID) {
+    console.warn(
+      "Missing Slack credentials; skipping PR notification and continuing."
+    );
+    return;
+  }
+
   // Avoid unconditional waits; only backoff when API indicates instability
   const waitTime = parseInt(WAIT_TIME, 10);
   if (waitTime > 0) {
@@ -701,6 +709,12 @@ module.exports = async ({ github, context, core }) => {
       );
     }
   } catch (error) {
+    if (String(error.message).includes("not_authed")) {
+      console.warn(
+        "Slack authentication failed; skipping notification without failing run."
+      );
+      return;
+    }
     console.error("❌ CRITICAL ERROR in Slack notifier:", error.message);
     console.error("Stack trace:", error.stack);
     console.error("\n=== EXECUTION CONTEXT ===");


### PR DESCRIPTION
## Summary
- avoid failing workflow if Slack token or channel ID are missing
- ignore `not_authed` Slack errors so PR builds aren't blocked

## Testing
- `npx prettier@3.6.2 --write .github/actions/slack-pr-notifier/slack-notifier.js`
- `npx turbo@2.5.6 lint` *(fails: command exited with code 1)*
- `npx turbo@2.5.6 test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a193a6699c8332b396e53d7595da77