### PR TITLE
fix: log orpc server errors

### DIFF
--- a/kit/dapp/src/orpc/helpers/error.ts
+++ b/kit/dapp/src/orpc/helpers/error.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared Error Logging Helper for ORPC
+ *
+ * This helper provides comprehensive error logging for all ORPC error handling interceptors,
+
+ *
+ * Features:
+ * - Logs all errors in test/development environments (not just 500+)
+ * - Provides structured error output for debugging
+ */
+
+import { createLogger } from "@settlemint/sdk-utils/logging";
+
+const logger = createLogger();
+
+/**
+ * Creates a shared error interceptor for ORPC handlers
+ *
+ * @param context - Optional context about where the interceptor is being used
+ * @returns ORPC error interceptor
+ */
+export function handleError(error: unknown) {
+  const e = error as {
+    code?: string;
+    status?: number;
+    message?: string;
+    data?: unknown;
+    cause?: unknown;
+    stack?: string;
+    response?: unknown;
+  };
+
+  const status = typeof e?.status === "number" ? e.status : undefined;
+  const code = typeof e?.code === "string" ? e.code : undefined;
+
+  // Skip common/expected client-side errors
+  if (
+    (status && status < 500) /* 4xx */ ||
+    code === "NOT_FOUND" ||
+    code === "UNAUTHORIZED"
+  ) {
+    return;
+  }
+
+  logger.error(`ORPC error details:`, {
+    message: e?.message,
+    code: e?.code,
+    status: e?.status,
+    data: e?.data,
+    cause: e?.cause,
+    stack: e?.stack,
+    response: e?.response,
+  });
+}

--- a/kit/dapp/src/orpc/server.ts
+++ b/kit/dapp/src/orpc/server.ts
@@ -1,14 +1,17 @@
 import { auth } from "@/lib/auth";
+import { handleError } from "@/orpc/helpers/error";
 import { router } from "@/orpc/routes/router";
 import { bigDecimalSerializer } from "@atk/zod/bigdecimal";
 import { bigIntSerializer } from "@atk/zod/bigint";
 import { timestampSerializer } from "@atk/zod/timestamp";
+import { onError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/node";
 import { BatchHandlerPlugin } from "@orpc/server/plugins";
 import { toNodeHandler } from "better-auth/node";
 import { createServer } from "node:http";
 
 const handler = new RPCHandler(router, {
+  interceptors: [onError(handleError)],
   plugins: [new BatchHandlerPlugin()],
   customJsonSerializers: [
     bigDecimalSerializer,

--- a/kit/dapp/src/routes/api/$.ts
+++ b/kit/dapp/src/routes/api/$.ts
@@ -17,6 +17,7 @@
  * @see {@link https://spec.openapis.org/oas/latest.html} - OpenAPI specification
  */
 
+import { handleError } from "@/orpc/helpers/error";
 import { router } from "@/orpc/routes/router";
 import { metadata } from "@atk/config/metadata";
 import { bigDecimalSerializer } from "@atk/zod/bigdecimal";
@@ -26,14 +27,11 @@ import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { CORSPlugin } from "@orpc/server/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
-import { createLogger } from "@settlemint/sdk-utils/logging";
 import {
   createServerFileRoute,
   getHeaders,
 } from "@tanstack/react-start/server";
 import pkgjson from "../../../package.json";
-
-const logger = createLogger();
 
 /**
  * OpenAPI handler configuration.
@@ -45,25 +43,7 @@ const logger = createLogger();
  * - Smart coercion for flexible parameter handling
  */
 const handler = new OpenAPIHandler(router, {
-  // Log only unexpected server errors (skip 4xx like NOT_FOUND/UNAUTHORIZED)
-  interceptors: [
-    onError((error) => {
-      const e = error as { code?: string; status?: number; message?: string };
-      const status = typeof e?.status === "number" ? e.status : undefined;
-      const code = typeof e?.code === "string" ? e.code : undefined;
-
-      // Skip common/expected client-side errors
-      if (
-        (status && status < 500) /* 4xx */ ||
-        code === "NOT_FOUND" ||
-        code === "UNAUTHORIZED"
-      ) {
-        return;
-      }
-
-      logger.error(e?.message ?? "OpenAPI handler error", error);
-    }),
-  ],
+  interceptors: [onError(handleError)],
   customJsonSerializers: [bigDecimalSerializer],
   plugins: [
     /**

--- a/kit/dapp/src/routes/api/rpc.$.ts
+++ b/kit/dapp/src/routes/api/rpc.$.ts
@@ -17,6 +17,7 @@
  * @see {@link https://spec.openapis.org/oas/latest.html} - OpenAPI specification
  */
 
+import { handleError } from "@/orpc/helpers/error";
 import { router } from "@/orpc/routes/router";
 import { bigDecimalSerializer } from "@atk/zod/bigdecimal";
 import { bigIntSerializer } from "@atk/zod/bigint";
@@ -24,13 +25,10 @@ import { timestampSerializer } from "@atk/zod/timestamp";
 import { onError } from "@orpc/client";
 import { RPCHandler } from "@orpc/server/fetch";
 import { BatchHandlerPlugin } from "@orpc/server/plugins";
-import { createLogger } from "@settlemint/sdk-utils/logging";
 import {
   createServerFileRoute,
   getHeaders,
 } from "@tanstack/react-start/server";
-
-const logger = createLogger();
 
 /**
  * OpenAPI handler configuration.
@@ -42,25 +40,7 @@ const logger = createLogger();
  * - Smart coercion for flexible parameter handling
  */
 const handler = new RPCHandler(router, {
-  // Log only unexpected server errors (skip 4xx like NOT_FOUND/UNAUTHORIZED)
-  interceptors: [
-    onError((error) => {
-      const e = error as { code?: string; status?: number; message?: string };
-      const status = typeof e?.status === "number" ? e.status : undefined;
-      const code = typeof e?.code === "string" ? e.code : undefined;
-
-      // Skip common/expected client-side errors
-      if (
-        (status && status < 500) /* 4xx */ ||
-        code === "NOT_FOUND" ||
-        code === "UNAUTHORIZED"
-      ) {
-        return;
-      }
-
-      logger.error(e?.message ?? "ORPC handler error", error);
-    }),
-  ],
+  interceptors: [onError(handleError)],
   plugins: [new BatchHandlerPlugin()],
   customJsonSerializers: [
     bigDecimalSerializer,

--- a/kit/dapp/tsconfig.json
+++ b/kit/dapp/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": [
     "**/*.ts",
-    "**/*.tsx",
+    "**/*.tsx"
   ],
   "compilerOptions": {
     "lib": [


### PR DESCRIPTION
- Shared util for all onError handlers
- Adds error logs for the orpc server, now when there is an error thrown in the tests we can see the actual error message:

Before: 

```
[ERROR] Failed to setup test environment, args:
Error: Internal server error
    at createORPCErrorFromJson (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/shared/client.txdq_i5V.mjs:138:10)
    at StandardRPCLinkCodec.decode (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/shared/client.DKmRtVO2.mjs:298:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/shared/client.DKmRtVO2.mjs:61:26
    at async Proxy.procedureClient (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/index.mjs:39:12)
    at async bootstrapSystem (/Users/snigdhasingh/Development/asset-tokenization-kit/kit/dapp/test/fixtures/system-bootstrap.ts:26:21)
    at async Object.setup (/Users/snigdhasingh/Development/asset-tokenization-kit/kit/dapp/test/setup/integration-global.ts:23:20)
    at async TestProject._initializeGlobalSetup (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:7074:21)
    at async Vitest.initializeGlobalSetup (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9724:35)
    at async file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9636:5


```

now:

```
[ERROR] ORPC error details:, args:
{
  "message": "Type `AccessControl` has no field `organisationIdentityManager`: {\"response\":{\"errors\":[{\"locations\":[{\"line\":135,\"column\":3}],\"message\":\"Type `AccessControl` has no field `organisationIdentityManager`\"}],\"status\":200,\"headers\":{}},\"request\":{\"query\":\"query GetSystem($systemAddress: ID!) {\\n  system(id: $systemAddress) {\\n    id\\n    deployedInTransaction\\n    systemAccessManager {\\n      id\\n      accessControl {\\n        ...AccessControlFragment\\n      }\\n    }\\n    tokenFactoryRegistry {\\n      id\\n      tokenFactories {\\n        id\\n        name\\n        typeId\\n      }\\n    }\\n    complianceModuleRegistry {\\n      id\\n      complianceModules {\\n        id\\n        typeId\\n        name\\n      }\\n    }\\n    identityFactory {\\n      id\\n    }\\n    identityRegistryStorage {\\n      id\\n    }\\n    identityRegistry {\\n      id\\n    }\\n    trustedIssuersRegistry {\\n      id\\n    }\\n    topicSchemeRegistry {\\n      id\\n    }\\n    systemAddonRegistry {\\n      id\\n      systemAddons {\\n        id\\n        name\\n        typeId\\n      }\\n    }\\n  }\\n}\\n\\nfragment AccessControlFragment on AccessControl {\\n  id\\n  addonManager {\\n    id\\n    isContract\\n  }\\n  addonModule {\\n    id\\n    isContract\\n  }\\n  addonRegistryModule {\\n    id\\n    isContract\\n  }\\n  admin {\\n    id\\n    isContract\\n  }\\n  auditor {\\n    id\\n    isContract\\n  }\\n  burner {\\n    id\\n    isContract\\n  }\\n  capManagement {\\n    id\\n    isContract\\n  }\\n  claimPolicyManager {\\n    id\\n    isContract\\n  }\\n  complianceAdmin {\\n    id\\n    isContract\\n  }\\n  complianceManager {\\n    id\\n    isContract\\n  }\\n  custodian {\\n    id\\n    isContract\\n  }\\n  emergency {\\n    id\\n    isContract\\n  }\\n  forcedTransfer {\\n    id\\n    isContract\\n  }\\n  freezer {\\n    id\\n    isContract\\n  }\\n  fundsManager {\\n    id\\n    isContract\\n  }\\n  globalListManager {\\n    id\\n    isContract\\n  }\\n  governance {\\n    id\\n    isContract\\n  }\\n  identityManager {\\n    id\\n    isContract\\n  }\\n  identityRegistryModule {\\n    id\\n    isContract\\n  }\\n  minter {\\n    id\\n    isContract\\n  }\\n  organisationIdentityManager {\\n    id\\n    isContract\\n  }\\n  pauser {\\n    id\\n    isContract\\n  }\\n  recovery {\\n    id\\n    isContract\\n  }\\n  saleAdmin {\\n    id\\n    isContract\\n  }\\n  signer {\\n    id\\n    isContract\\n  }\\n  supplyManagement {\\n    id\\n    isContract\\n  }\\n  systemManager {\\n    id\\n    isContract\\n  }\\n  systemModule {\\n    id\\n    isContract\\n  }\\n  tokenAdmin {\\n    id\\n    isContract\\n  }\\n  tokenFactoryModule {\\n    id\\n    isContract\\n  }\\n  tokenFactoryRegistryModule {\\n    id\\n    isContract\\n  }\\n  tokenManager {\\n    id\\n    isContract\\n  }\\n  verificationAdmin {\\n    id\\n    isContract\\n  }\\n}\",\"variables\":{\"systemAddress\":\"0xA5Fb99A01Cda1A28a2a36CD1EcD2e6fE2FdCe27b\"}}}",
  "stack": "Error: Type `AccessControl` has no field `organisationIdentityManager`: {\"response\":{\"errors\":[{\"locations\":[{\"line\":135,\"column\":3}],\"message\":\"Type `AccessControl` has no field `organisationIdentityManager`\"}],\"status\":200,\"headers\":{}},\"request\":{\"query\":\"query GetSystem($systemAddress: ID!) {\\n  system(id: $systemAddress) {\\n    id\\n    deployedInTransaction\\n    systemAccessManager {\\n      id\\n      accessControl {\\n        ...AccessControlFragment\\n      }\\n    }\\n    tokenFactoryRegistry {\\n      id\\n      tokenFactories {\\n        id\\n        name\\n        typeId\\n      }\\n    }\\n    complianceModuleRegistry {\\n      id\\n      complianceModules {\\n        id\\n        typeId\\n        name\\n      }\\n    }\\n    identityFactory {\\n      id\\n    }\\n    identityRegistryStorage {\\n      id\\n    }\\n    identityRegistry {\\n      id\\n    }\\n    trustedIssuersRegistry {\\n      id\\n    }\\n    topicSchemeRegistry {\\n      id\\n    }\\n    systemAddonRegistry {\\n      id\\n      systemAddons {\\n        id\\n        name\\n        typeId\\n      }\\n    }\\n  }\\n}\\n\\nfragment AccessControlFragment on AccessControl {\\n  id\\n  addonManager {\\n    id\\n    isContract\\n  }\\n  addonModule {\\n    id\\n    isContract\\n  }\\n  addonRegistryModule {\\n    id\\n    isContract\\n  }\\n  admin {\\n    id\\n    isContract\\n  }\\n  auditor {\\n    id\\n    isContract\\n  }\\n  burner {\\n    id\\n    isContract\\n  }\\n  capManagement {\\n    id\\n    isContract\\n  }\\n  claimPolicyManager {\\n    id\\n    isContract\\n  }\\n  complianceAdmin {\\n    id\\n    isContract\\n  }\\n  complianceManager {\\n    id\\n    isContract\\n  }\\n  custodian {\\n    id\\n    isContract\\n  }\\n  emergency {\\n    id\\n    isContract\\n  }\\n  forcedTransfer {\\n    id\\n    isContract\\n  }\\n  freezer {\\n    id\\n    isContract\\n  }\\n  fundsManager {\\n    id\\n    isContract\\n  }\\n  globalListManager {\\n    id\\n    isContract\\n  }\\n  governance {\\n    id\\n    isContract\\n  }\\n  identityManager {\\n    id\\n    isContract\\n  }\\n  identityRegistryModule {\\n    id\\n    isContract\\n  }\\n  minter {\\n    id\\n    isContract\\n  }\\n  organisationIdentityManager {\\n    id\\n    isContract\\n  }\\n  pauser {\\n    id\\n    isContract\\n  }\\n  recovery {\\n    id\\n    isContract\\n  }\\n  saleAdmin {\\n    id\\n    isContract\\n  }\\n  signer {\\n    id\\n    isContract\\n  }\\n  supplyManagement {\\n    id\\n    isContract\\n  }\\n  systemManager {\\n    id\\n    isContract\\n  }\\n  systemModule {\\n    id\\n    isContract\\n  }\\n  tokenAdmin {\\n    id\\n    isContract\\n  }\\n  tokenFactoryModule {\\n    id\\n    isContract\\n  }\\n  tokenFactoryRegistryModule {\\n    id\\n    isContract\\n  }\\n  tokenManager {\\n    id\\n    isContract\\n  }\\n  verificationAdmin {\\n    id\\n    isContract\\n  }\\n}\",\"variables\":{\"systemAddress\":\"0xA5Fb99A01Cda1A28a2a36CD1EcD2e6fE2FdCe27b\"}}}\n    at runRequest (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/graphql-request/build/legacy/helpers/runRequest.js:47:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async GraphQLClient.request (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/graphql-request/build/legacy/classes/GraphQLClient.js:66:26)\n    at async getSystemContext (/Users/snigdhasingh/Development/asset-tokenization-kit/kit/dapp/src/orpc/middlewares/system/system.middleware.ts:105:22)\n    at async Object.handler (/Users/snigdhasingh/Development/asset-tokenization-kit/kit/dapp/src/orpc/routes/system/routes/system.read.ts:30:25)\n    at async next (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/server/dist/shared/server.7jWaIryJ.mjs:236:9)\n    at async next (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/server/dist/shared/server.7jWaIryJ.mjs:229:23)\n    at async file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/server/dist/shared/server.7jWaIryJ.mjs:223:24\n    at async next (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/server/dist/shared/server.7jWaIryJ.mjs:218:26)\n    at async next (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/server/dist/shared/server.7jWaIryJ.mjs:229:23)",
  "response": {
    "errors": [
      {
        "locations": [
          {
            "line": 135,
            "column": 3
          }
        ],
        "message": "Type `AccessControl` has no field `organisationIdentityManager`"
      }
    ],
    "status": 200,
    "headers": {}
  }
}
[ERROR] Failed to setup test environment, args:
Error: Internal server error
    at createORPCErrorFromJson (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/shared/client.txdq_i5V.mjs:138:10)
    at StandardRPCLinkCodec.decode (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/shared/client.DKmRtVO2.mjs:298:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/shared/client.DKmRtVO2.mjs:61:26
    at async Proxy.procedureClient (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/@orpc/client/dist/index.mjs:39:12)
    at async bootstrapSystem (/Users/snigdhasingh/Development/asset-tokenization-kit/kit/dapp/test/fixtures/system-bootstrap.ts:26:21)
    at async Object.setup (/Users/snigdhasingh/Development/asset-tokenization-kit/kit/dapp/test/setup/integration-global.ts:23:20)
    at async TestProject._initializeGlobalSetup (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:7074:21)
    at async Vitest.initializeGlobalSetup (file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9724:35)
    at async file:///Users/snigdhasingh/Development/asset-tokenization-kit/node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9636:5
```