### PR TITLE
chore bump artifact version

### DIFF
--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -16,7 +16,7 @@ global:
     image:
       registry: ghcr.io
       repository: settlemint/asset-tokenization-kit-artifacts
-      tag: 2.0.0
+      tag: 2.0.1
       pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
AWS Marketplace has wrong version under tag 2.0.0 and tag is immutable. Bumped tag to have working deployment.