### PR TITLE
fix: trusted issuer stores the identity address, not the wallet

### DIFF
--- a/kit/dapp/src/components/platform-settings/trusted-issuers/add-trusted-issuer-sheet.tsx
+++ b/kit/dapp/src/components/platform-settings/trusted-issuers/add-trusted-issuer-sheet.tsx
@@ -101,17 +101,27 @@ export function AddTrustedIssuerSheet({
       } as UserVerification,
     },
     onSubmit: async ({ value }) => {
-      const trustedIssuerAccount = await client.account.read({
-        wallet: value.issuerAddress,
-      });
-      if (!trustedIssuerAccount.identity) {
-        throw new Error("Trusted issuer account not found");
+      try {
+        const trustedIssuerAccount = await client.account.read({
+          wallet: value.issuerAddress,
+        });
+        if (!trustedIssuerAccount.identity) {
+          throw new Error("Trusted issuer account not found");
+        }
+        createMutation.mutate({
+          issuerAddress: trustedIssuerAccount.identity,
+          claimTopicIds: value.claimTopicIds,
+          walletVerification: value.walletVerification,
+        });
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : "unknown error";
+        toast.error(
+          t("trustedIssuers.toast.addError", {
+            error: errorMessage,
+          })
+        );
       }
-      createMutation.mutate({
-        issuerAddress: trustedIssuerAccount.identity,
-        claimTopicIds: value.claimTopicIds,
-        walletVerification: value.walletVerification,
-      });
     },
   });
 

--- a/kit/dapp/src/components/platform-settings/trusted-issuers/add-trusted-issuer-sheet.tsx
+++ b/kit/dapp/src/components/platform-settings/trusted-issuers/add-trusted-issuer-sheet.tsx
@@ -100,8 +100,18 @@ export function AddTrustedIssuerSheet({
         verificationType: "PINCODE" as const,
       } as UserVerification,
     },
-    onSubmit: ({ value }) => {
-      createMutation.mutate(value as TrustedIssuerCreateInput);
+    onSubmit: async ({ value }) => {
+      const trustedIssuerAccount = await client.account.read({
+        wallet: value.issuerAddress,
+      });
+      if (!trustedIssuerAccount.identity) {
+        throw new Error("Trusted issuer account not found");
+      }
+      createMutation.mutate({
+        issuerAddress: trustedIssuerAccount.identity,
+        claimTopicIds: value.claimTopicIds,
+        walletVerification: value.walletVerification,
+      });
     },
   });
 

--- a/kit/dapp/src/components/platform-settings/trusted-issuers/trusted-issuers-table.tsx
+++ b/kit/dapp/src/components/platform-settings/trusted-issuers/trusted-issuers-table.tsx
@@ -8,6 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatValue } from "@/lib/utils/format-value";
 import { orpc } from "@/orpc/orpc-client";
 import type { TrustedIssuer } from "@/orpc/routes/system/trusted-issuers/routes/trusted-issuer.list.schema";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -44,12 +45,22 @@ export function TrustedIssuersTable() {
   const columns = useMemo(
     () =>
       withAutoFeatures([
-        columnHelper.accessor("id", {
+        columnHelper.display({
           header: t("trustedIssuers.table.columns.issuerIdentity"),
           meta: {
             displayName: t("trustedIssuers.table.columns.issuerIdentity"),
             type: "address",
             icon: Hash,
+          },
+          cell: ({ row }) => {
+            const formatted = formatValue(
+              row.original.account?.id ?? row.original.id,
+              {
+                type: "address",
+                displayName: t("trustedIssuers.table.columns.issuerIdentity"),
+              }
+            );
+            return formatted;
           },
         }),
         columnHelper.display({

--- a/kit/dapp/src/components/platform-settings/trusted-issuers/trusted-issuers-table.tsx
+++ b/kit/dapp/src/components/platform-settings/trusted-issuers/trusted-issuers-table.tsx
@@ -8,7 +8,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatValue } from "@/lib/utils/format-value";
 import { orpc } from "@/orpc/orpc-client";
 import type { TrustedIssuer } from "@/orpc/routes/system/trusted-issuers/routes/trusted-issuer.list.schema";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -45,22 +44,12 @@ export function TrustedIssuersTable() {
   const columns = useMemo(
     () =>
       withAutoFeatures([
-        columnHelper.display({
+        columnHelper.accessor((row) => row.account?.id ?? row.id, {
           header: t("trustedIssuers.table.columns.issuerIdentity"),
           meta: {
             displayName: t("trustedIssuers.table.columns.issuerIdentity"),
             type: "address",
             icon: Hash,
-          },
-          cell: ({ row }) => {
-            const formatted = formatValue(
-              row.original.account?.id ?? row.original.id,
-              {
-                type: "address",
-                displayName: t("trustedIssuers.table.columns.issuerIdentity"),
-              }
-            );
-            return formatted;
           },
         }),
         columnHelper.display({

--- a/kit/dapp/src/orpc/routes/system/trusted-issuers/routes/trusted-issuer.list.schema.ts
+++ b/kit/dapp/src/orpc/routes/system/trusted-issuers/routes/trusted-issuer.list.schema.ts
@@ -16,6 +16,11 @@ export const TrustedIssuerTopicSchema = z.object({
  */
 export const TrustedIssuerSchema = z.object({
   id: ethereumAddress.describe("Issuer identity address"),
+  account: z
+    .object({
+      id: ethereumAddress.describe("Issuer wallet address"),
+    })
+    .optional(),
   claimTopics: z
     .array(TrustedIssuerTopicSchema)
     .describe("Topics this issuer can verify"),

--- a/kit/dapp/src/orpc/routes/system/trusted-issuers/routes/trusted-issuer.list.ts
+++ b/kit/dapp/src/orpc/routes/system/trusted-issuers/routes/trusted-issuer.list.ts
@@ -28,6 +28,9 @@ const TRUSTED_ISSUERS_QUERY = theGraphGraphql(
         name
         signature
       }
+      account {
+        id
+      }
     }
   }
 `,

--- a/kit/subgraph/schema.graphql
+++ b/kit/subgraph/schema.graphql
@@ -484,7 +484,7 @@ type TrustedIssuersRegistry @entity(immutable: false) {
 }
 
 type TrustedIssuer @entity(immutable: false) {
-  # Unique identifier - issuer address
+  # Unique identifier - issuer identity address
   id: Bytes!
   # Transaction hash where this was added
   deployedInTransaction: Bytes!
@@ -492,6 +492,8 @@ type TrustedIssuer @entity(immutable: false) {
   registry: TrustedIssuersRegistry!
   # Topics this issuer can verify
   claimTopics: [TopicScheme!]!
+  # Account associated with this trusted issuer identity
+  account: Account
 }
 
 type ComplianceModuleRegistry @entity(immutable: false) {

--- a/kit/subgraph/src/trusted-issuers-registry/fetch/trusted-issuer.ts
+++ b/kit/subgraph/src/trusted-issuers-registry/fetch/trusted-issuer.ts
@@ -1,14 +1,17 @@
 import { Address, Bytes } from "@graphprotocol/graph-ts";
 import { TrustedIssuer } from "../../../generated/schema";
+import { fetchIdentity } from "../../identity/fetch/identity";
 
 export function fetchTrustedIssuer(address: Address): TrustedIssuer {
   let trustedIssuer = TrustedIssuer.load(address);
 
   if (!trustedIssuer) {
+    const identity = fetchIdentity(address);
     trustedIssuer = new TrustedIssuer(address);
     trustedIssuer.deployedInTransaction = Bytes.empty();
     trustedIssuer.registry = Address.zero();
     trustedIssuer.claimTopics = [];
+    trustedIssuer.account = identity.account;
     trustedIssuer.save();
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Fix storage and usage of trusted issuer identity by separating the identity address from the wallet address and updating schemas, subgraph, ORPC routes, and UI accordingly.

Bug Fixes:
- Query trusted issuers by their wallet account ID and filter on account.id instead of storing the wallet in the primary ID field
- Resolve and use the issuer’s identity address in the UI form submission instead of the raw wallet address
- Correct the issuer table column to display the identity address, falling back to account.wallet when needed

Enhancements:
- Add an optional account field to the TrustedIssuer entity in subgraph, GraphQL schema, and ORPC types to map the wallet address
- Update GraphQL query, ORPC schemas, and UI components to include and handle the new account relation
- Populate the account relation in subgraph.fetchTrustedIssuer by fetching the identity entity