### PR TITLE
fix: provide right network id

### DIFF
--- a/kit/charts/atk/README.md
+++ b/kit/charts/atk/README.md
@@ -80,7 +80,7 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | blockscout.blockscout-stack.blockscout.env.WEBAPP_URL | string | `"https://explorer.k8s.orb.local"` |  |
 | blockscout.blockscout-stack.blockscout.image.pullPolicy | string | `"IfNotPresent"` |  |
 | blockscout.blockscout-stack.blockscout.image.repository | string | `"ghcr.io/blockscout/blockscout"` |  |
-| blockscout.blockscout-stack.blockscout.image.tag | string | `"9.0.2"` |  |
+| blockscout.blockscout-stack.blockscout.image.tag | string | `"9.0.1"` |  |
 | blockscout.blockscout-stack.blockscout.ingress.hostname | string | `"explorer.k8s.orb.local"` |  |
 | blockscout.blockscout-stack.blockscout.init.args[0] | string | `"-c"` |  |
 | blockscout.blockscout-stack.blockscout.init.args[1] | string | `"echo \"Waiting for postgresql:5432...\"\nwhile ! nc -z postgresql 5432; do\n  sleep 2;\ndone;\necho \"PostgreSQL is ready!\"\n# Original command:\nbin/blockscout eval \"Elixir.Explorer.ReleaseTasks.create_and_migrate()\"\n"` |  |
@@ -98,7 +98,7 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | dapp.enabled | bool | `true` |  |
 | dapp.image.pullPolicy | string | `"IfNotPresent"` |  |
 | dapp.image.repository | string | `"ghcr.io/settlemint/asset-tokenization-kit"` |  |
-| dapp.image.tag | string | `"2.0.0-main71f0929ab"` |  |
+| dapp.image.tag | string | `"2.0.0-main1e32acb7f"` |  |
 | dapp.ingress.enabled | bool | `true` |  |
 | dapp.ingress.hosts[0].host | string | `"dapp.k8s.orb.local"` |  |
 | dapp.ingress.hosts[0].paths[0].path | string | `"/"` |  |
@@ -160,11 +160,11 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | erpc.config.logLevel | string | `"info"` |  |
 | erpc.config.projects[0].id | string | `"settlemint"` |  |
 | erpc.config.projects[0].upstreams[0].endpoint | string | `"http://besu-node-rpc-1:8545"` |  |
-| erpc.config.projects[0].upstreams[0].evm.chainId | int | `1337` |  |
+| erpc.config.projects[0].upstreams[0].evm.chainId | int | `53771311147` |  |
 | erpc.config.projects[0].upstreams[0].failsafe.timeout.duration | string | `"30s"` |  |
 | erpc.config.projects[0].upstreams[0].id | string | `"besu-node-rpc-1"` |  |
 | erpc.config.projects[0].upstreams[1].endpoint | string | `"http://besu-node-validator-1:8545"` |  |
-| erpc.config.projects[0].upstreams[1].evm.chainId | int | `1337` |  |
+| erpc.config.projects[0].upstreams[1].evm.chainId | int | `53771311147` |  |
 | erpc.config.projects[0].upstreams[1].failsafe.timeout.duration | string | `"30s"` |  |
 | erpc.config.projects[0].upstreams[1].id | string | `"besu-node-validator-1"` |  |
 | erpc.config.server.httpHostV4 | string | `"0.0.0.0"` |  |
@@ -252,7 +252,7 @@ A Helm chart for the SettleMint Asset Tokenization Kit
 | observability.loki.gateway.image.tag | string | `"1.29-alpine"` |  |
 | observability.loki.loki.image.registry | string | `"docker.io"` | The Docker registry |
 | observability.loki.loki.image.repository | string | `"grafana/loki"` | Docker image repository |
-| observability.loki.loki.image.tag | string | `"3.5.3"` | Overrides the image tag whose default is the chart's appVersion |
+| observability.loki.loki.image.tag | string | `"3.5.4"` | Overrides the image tag whose default is the chart's appVersion |
 | observability.loki.memcached.enabled | bool | `true` | Enable the built in memcached server provided by the chart |
 | observability.loki.memcached.image.repository | string | `"docker.io/memcached"` | Memcached Docker image repository |
 | observability.loki.memcached.image.tag | string | `"1.6.39-alpine"` | Memcached Docker image tag |

--- a/kit/charts/atk/charts/blockscout/README.md
+++ b/kit/charts/atk/charts/blockscout/README.md
@@ -24,10 +24,13 @@ A Helm chart for the blockscout components
 | blockscout-stack.blockscout.env.API_GRAPHQL_MAX_COMPLEXITY | string | `"1000"` |  |
 | blockscout-stack.blockscout.env.API_URL | string | `"https://explorer.k8s.orb.local"` |  |
 | blockscout-stack.blockscout.env.DATABASE_TIMEOUT | string | `"60000"` |  |
+| blockscout-stack.blockscout.env.DATABASE_URL | string | `"postgresql://blockscout:atk@postgresql:5432/blockscout?sslmode=disable"` |  |
 | blockscout-stack.blockscout.env.DISABLE_EXCHANGE_RATES | string | `"true"` |  |
 | blockscout-stack.blockscout.env.ECTO_ADAPTER_TIMEOUT | string | `"60000"` |  |
 | blockscout-stack.blockscout.env.ECTO_USE_SSL | string | `"false"` |  |
 | blockscout-stack.blockscout.env.EMISSION_FORMAT | string | `"DEFAULT"` |  |
+| blockscout-stack.blockscout.env.ETHEREUM_JSONRPC_HTTP_URL | string | `"http://erpc:4000/settlemint/evm/53771311147"` |  |
+| blockscout-stack.blockscout.env.ETHEREUM_JSONRPC_TRACE_URL | string | `"http://erpc:4000/settlemint/evm/53771311147"` |  |
 | blockscout-stack.blockscout.env.ETHEREUM_JSONRPC_VARIANT | string | `"besu"` |  |
 | blockscout-stack.blockscout.env.FETCH_REWARDS_WAY | string | `"trace_block"` |  |
 | blockscout-stack.blockscout.env.IPFS_GATEWAY_URL | string | `"https://ipfs.io/ipfs"` |  |
@@ -37,17 +40,14 @@ A Helm chart for the blockscout components
 | blockscout-stack.blockscout.env.OTHER_EXPLORERS | string | `"{}"` |  |
 | blockscout-stack.blockscout.env.POOL_SIZE | string | `"10"` |  |
 | blockscout-stack.blockscout.env.POOL_SIZE_API | string | `"10"` |  |
+| blockscout-stack.blockscout.env.SECRET_KEY_BASE | string | `"atk"` |  |
 | blockscout-stack.blockscout.env.SHOW_TXS_CHART | string | `"true"` |  |
 | blockscout-stack.blockscout.env.SUBNETWORK | string | `"ATK"` |  |
 | blockscout-stack.blockscout.env.SUPPORTED_CHAINS | string | `"{}"` |  |
 | blockscout-stack.blockscout.env.TXS_STATS_ENABLED | string | `"true"` |  |
 | blockscout-stack.blockscout.env.WEBAPP_URL | string | `"https://explorer.k8s.orb.local"` |  |
-| blockscout-stack.blockscout.envFromSecret.DATABASE_URL | string | `"postgresql://blockscout:atk@postgresql:5432/blockscout?sslmode=disable"` |  |
-| blockscout-stack.blockscout.envFromSecret.ETHEREUM_JSONRPC_HTTP_URL | string | `"http://erpc:4000/settlemint/evm/1337"` |  |
-| blockscout-stack.blockscout.envFromSecret.ETHEREUM_JSONRPC_TRACE_URL | string | `"http://erpc:4000/settlemint/evm/1337"` |  |
-| blockscout-stack.blockscout.envFromSecret.SECRET_KEY_BASE | string | `"atk"` |  |
 | blockscout-stack.blockscout.image.repository | string | `"ghcr.io/blockscout/blockscout"` |  |
-| blockscout-stack.blockscout.image.tag | string | `"9.0.2"` |  |
+| blockscout-stack.blockscout.image.tag | string | `"9.0.1"` |  |
 | blockscout-stack.blockscout.ingress.className | string | `"atk-nginx"` |  |
 | blockscout-stack.blockscout.ingress.enabled | bool | `true` |  |
 | blockscout-stack.blockscout.ingress.hostname | string | `"explorer.k8s.orb.local"` |  |
@@ -59,7 +59,7 @@ A Helm chart for the blockscout components
 | blockscout-stack.config.network.currency.decimals | int | `18` |  |
 | blockscout-stack.config.network.currency.name | string | `"Native Token"` |  |
 | blockscout-stack.config.network.currency.symbol | string | `"NT"` |  |
-| blockscout-stack.config.network.id | int | `1337` |  |
+| blockscout-stack.config.network.id | int | `53771311147` |  |
 | blockscout-stack.config.network.name | string | `"Asset Tokenization Kit"` |  |
 | blockscout-stack.config.network.shortname | string | `"ATK"` |  |
 | blockscout-stack.config.prometheus.blackbox.enabled | bool | `false` |  |

--- a/kit/charts/atk/charts/blockscout/values.yaml
+++ b/kit/charts/atk/charts/blockscout/values.yaml
@@ -8,7 +8,7 @@ blockscout-stack:
       blackbox:
         enabled: false
     network:
-      id: 1337
+      id: 53771311147
       name: Asset Tokenization Kit
       shortname: ATK
       currency:
@@ -23,7 +23,7 @@ blockscout-stack:
       prometheus.io/path: "/metrics"
     image:
       repository: ghcr.io/blockscout/blockscout
-      tag: "9.0.2"
+      tag: "9.0.1"
     ingress:
       enabled: true
       className: "atk-nginx"
@@ -52,10 +52,9 @@ blockscout-stack:
       IPFS_PUBLIC_GATEWAY_URL: 'https://ipfs.io/ipfs'
       API_URL: https://explorer.k8s.orb.local
       WEBAPP_URL: https://explorer.k8s.orb.local
-    envFromSecret:
       DATABASE_URL: postgresql://blockscout:atk@postgresql:5432/blockscout?sslmode=disable
-      ETHEREUM_JSONRPC_HTTP_URL: http://erpc:4000/settlemint/evm/1337
-      ETHEREUM_JSONRPC_TRACE_URL: http://erpc:4000/settlemint/evm/1337
+      ETHEREUM_JSONRPC_HTTP_URL: http://erpc:4000/settlemint/evm/53771311147
+      ETHEREUM_JSONRPC_TRACE_URL: http://erpc:4000/settlemint/evm/53771311147
       SECRET_KEY_BASE: atk
   frontend:
     image:

--- a/kit/charts/atk/charts/dapp/README.md
+++ b/kit/charts/atk/charts/dapp/README.md
@@ -18,7 +18,7 @@ A Helm chart for the ATK DApp frontend
 | fullnameOverride | string | `"dapp"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/settlemint/asset-tokenization-kit"` |  |
-| image.tag | string | `"2.0.0-main0d06815fc"` |  |
+| image.tag | string | `"2.0.0-main1e32acb7f"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `"atk-nginx"` |  |
 | ingress.enabled | bool | `false` |  |

--- a/kit/charts/atk/charts/dapp/values.yaml
+++ b/kit/charts/atk/charts/dapp/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/settlemint/asset-tokenization-kit
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.0-main0d06815fc"
+  tag: "2.0.0-main1e32acb7f"
 
 nameOverride: "dapp"
 fullnameOverride: "dapp"

--- a/kit/charts/atk/charts/graph-node/README.md
+++ b/kit/charts/atk/charts/graph-node/README.md
@@ -18,12 +18,12 @@ A Helm chart for Graph Node
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| chains | object | `{"settlemint":{"enabled":true,"provider":[{"details":{"features":["archive","traces"],"type":"web3","url":"http://erpc:4000/settlemint/evm/1337"},"label":"erpc"}],"shard":"primary"}}` | Blockchain configuration for Graph Node |
-| chains.settlemint | object | `{"enabled":true,"provider":[{"details":{"features":["archive","traces"],"type":"web3","url":"http://erpc:4000/settlemint/evm/1337"},"label":"erpc"}],"shard":"primary"}` | Ethereum Mainnet |
+| chains | object | `{"settlemint":{"enabled":true,"provider":[{"details":{"features":["archive","traces"],"type":"web3","url":"http://erpc:4000/settlemint/evm/53771311147"},"label":"erpc"}],"shard":"primary"}}` | Blockchain configuration for Graph Node |
+| chains.settlemint | object | `{"enabled":true,"provider":[{"details":{"features":["archive","traces"],"type":"web3","url":"http://erpc:4000/settlemint/evm/53771311147"},"label":"erpc"}],"shard":"primary"}` | Ethereum Mainnet |
 | chains.settlemint.enabled | bool | `true` | Enable this configuring graph-node with this chain |
 | chains.settlemint.provider[0].details.features | list | `["archive","traces"]` | Data capabilities this node has |
 | chains.settlemint.provider[0].details.type | string | `"web3"` | Type of Provider: web3 |
-| chains.settlemint.provider[0].details.url | string | `"http://erpc:4000/settlemint/evm/1337"` | URL for JSON-RPC endpoint |
+| chains.settlemint.provider[0].details.url | string | `"http://erpc:4000/settlemint/evm/53771311147"` | URL for JSON-RPC endpoint |
 | chains.settlemint.provider[0].label | string | `"erpc"` | Label for a JSON-RPC endpoint |
 | chains.settlemint.shard | string | `"primary"` | The database shard to use for this chain |
 | configTemplate | string | See default template in [values.yaml](values.yaml) | [Configuration for graph-node](https://github.com/graphprotocol/graph-node/blob/master/docs/config.md) |

--- a/kit/charts/atk/charts/graph-node/values.yaml
+++ b/kit/charts/atk/charts/graph-node/values.yaml
@@ -198,7 +198,7 @@ chains:
           # -- Type of Provider: web3
           type: web3
           # -- URL for JSON-RPC endpoint
-          url: http://erpc:4000/settlemint/evm/1337
+          url: http://erpc:4000/settlemint/evm/53771311147
           # -- Data capabilities this node has
           features: [archive, traces]
 

--- a/kit/charts/atk/charts/observability/README.md
+++ b/kit/charts/atk/charts/observability/README.md
@@ -16,7 +16,7 @@ A Helm chart for the observability components
 |------------|------|---------|
 | https://grafana.github.io/helm-charts | alloy | 1.2.1 |
 | https://grafana.github.io/helm-charts | grafana | 9.4.4 |
-| https://grafana.github.io/helm-charts | loki | 6.38.0 |
+| https://grafana.github.io/helm-charts | loki | 6.39.0 |
 | https://grafana.github.io/helm-charts | tempo | 1.23.3 |
 | https://kubernetes-sigs.github.io/metrics-server/ | metrics-server | 3.13.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 6.3.0 |

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -141,14 +141,14 @@ erpc:
           - id: besu-node-rpc-1
             endpoint: http://besu-node-rpc-1:8545
             evm:
-              chainId: 1337
+              chainId: 53771311147
             failsafe:
               timeout:
                 duration: 30s
           - id: besu-node-validator-1
             endpoint: http://besu-node-validator-1:8545
             evm:
-              chainId: 1337
+              chainId: 53771311147
             failsafe:
               timeout:
                 duration: 30s
@@ -185,7 +185,7 @@ blockscout:
     blockscout:
       image:
         repository: ghcr.io/blockscout/blockscout
-        tag: "9.0.2"
+        tag: "9.0.1"
         pullPolicy: IfNotPresent
       # Add an extra init container to wait for PostgreSQL
       init:
@@ -593,7 +593,7 @@ dapp:
   enabled: true
   image:
     repository: ghcr.io/settlemint/asset-tokenization-kit
-    tag: "2.0.0-main71f0929ab"
+    tag: "2.0.0-main1e32acb7f"
     pullPolicy: IfNotPresent
   replicaCount: 1
   ingress:


### PR DESCRIPTION
## Summary by Sourcery

Update network identifiers in Helm charts and enhance AWS Marketplace automation to correctly handle ECR-formatted images.

Bug Fixes:
- Correct network.id and evm.chainId from 1337 to 53771311147 across blockscout, erpc, graph-node, and values configurations.

Enhancements:
- Improve AWSMarketplaceAutomation to skip already ECR-prefixed images, consolidate conversion logic, and enhance error handling without interrupting the loop.

Documentation:
- Refresh Helm chart README defaults and values.yaml to include updated environment variables, remove deprecated envFromSecret entries, and align image repository settings.

Chores:
- Bump blockscout image tag to 9.0.1, dapp tag to 2.0.0-main1e32acb7f, Loki image tag to 3.5.4, and update loki chart version to 6.39.0.