### PR TITLE
chore: update font imports in the dApp for prod bundles

### DIFF
--- a/kit/dapp/src/routes/__root.tsx
+++ b/kit/dapp/src/routes/__root.tsx
@@ -22,6 +22,8 @@ import type { orpc } from "@/orpc/orpc-client";
 import { Providers } from "@/providers";
 import appCss from "@/styles/app.css?url";
 import { seo } from "@atk/config/metadata";
+import "@fontsource-variable/figtree";
+import "@fontsource-variable/roboto-mono";
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { type QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";

--- a/kit/dapp/src/styles/app.css
+++ b/kit/dapp/src/styles/app.css
@@ -1,7 +1,5 @@
 @import "tailwindcss" source("../");
 @import "tw-animate-css";
-@import "@fontsource-variable/figtree";
-@import "@fontsource-variable/roboto-mono";
 @source "../../../../node_modules/@daveyplate/better-auth-ui";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
- Removed font imports from app.css and added them to __root.tsx for better organization and performance.
- This change ensures that the variable fonts Figtree and Roboto Mono are loaded correctly in the application.