### PR TITLE
chore(ci): monotonic Docker tags (2.0.0-main.<run>.<sha>) + alias

### DIFF
--- a/kit/contracts/tools/publish-docker.sh
+++ b/kit/contracts/tools/publish-docker.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get version from root package.json
-DOCKER_BUILD_TAG=$(jq -r .version ../../package.json)
+# Base version from root package.json (e.g. 2.0.0)
+BASE_VERSION="$(jq -r .version ../../package.json)"
+PRIMARY_TAG="$BASE_VERSION"
+ALIAS_TAGS=()
 
-# Add dev timestamp if not in CI
-if [ -z "${CI:-}" ]; then
-    DOCKER_BUILD_TAG="$DOCKER_BUILD_TAG-dev.$(date +%s)"
+# In CI on main, publish monotonic semver-like prerelease
+if [[ -n "${CI:-}" && "${GITHUB_REF:-}" == "refs/heads/main" ]]; then
+  RUN_NO="${GITHUB_RUN_NUMBER:-0}"
+  SHORT_SHA="${GITHUB_SHA:-nogit}"
+  SHORT_SHA="${SHORT_SHA:0:8}"
+  PRIMARY_TAG="${BASE_VERSION}-main.${RUN_NO}.${SHORT_SHA}"
+  ALIAS_TAGS+=("${BASE_VERSION}-main")
+elif [[ -z "${CI:-}" ]]; then
+  PRIMARY_TAG="${BASE_VERSION}-dev.$(date +%s)"
 fi
 
 # Build and push Docker image
+TAGS_OPTS=( -t "ghcr.io/settlemint/asset-tokenization-kit-artifacts:${PRIMARY_TAG}" )
+for t in "${ALIAS_TAGS[@]:-}"; do
+  TAGS_OPTS+=( -t "ghcr.io/settlemint/asset-tokenization-kit-artifacts:${t}" )
+done
+
 docker buildx build . \
-    --file=./Dockerfile \
-    --platform=linux/amd64,linux/arm64 \
-    --provenance true \
-    --sbom true \
-    -t "ghcr.io/settlemint/asset-tokenization-kit-artifacts:$DOCKER_BUILD_TAG" \
-    --push
+  --file=./Dockerfile \
+  --platform=linux/amd64,linux/arm64 \
+  --provenance true \
+  --sbom true \
+  "${TAGS_OPTS[@]}" \
+  --push

--- a/kit/dapp/tools/publish-docker.sh
+++ b/kit/dapp/tools/publish-docker.sh
@@ -1,18 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get version from root package.json
-DOCKER_BUILD_TAG=$(jq -r .version ../../package.json)
+# Base version from root package.json (e.g. 2.0.0)
+BASE_VERSION="$(jq -r .version ../../package.json)"
+PRIMARY_TAG="$BASE_VERSION"
+ALIAS_TAGS=()
 
-# Add dev timestamp if not in CI
-if [ -z "${CI:-}" ]; then
-    DOCKER_BUILD_TAG="$DOCKER_BUILD_TAG-dev.$(date +%s)"
+# In CI on main, publish monotonic semver-like prerelease
+if [[ -n "${CI:-}" && "${GITHUB_REF:-}" == "refs/heads/main" ]]; then
+  RUN_NO="${GITHUB_RUN_NUMBER:-0}"
+  SHORT_SHA="${GITHUB_SHA:-nogit}"
+  SHORT_SHA="${SHORT_SHA:0:8}"
+  PRIMARY_TAG="${BASE_VERSION}-main.${RUN_NO}.${SHORT_SHA}"
+  ALIAS_TAGS+=("${BASE_VERSION}-main")
+elif [[ -z "${CI:-}" ]]; then
+  PRIMARY_TAG="${BASE_VERSION}-dev.$(date +%s)"
 fi
 
 # Build and push Docker image
+TAGS_OPTS=( -t "ghcr.io/settlemint/asset-tokenization-kit:${PRIMARY_TAG}" )
+for t in "${ALIAS_TAGS[@]:-}"; do
+  TAGS_OPTS+=( -t "ghcr.io/settlemint/asset-tokenization-kit:${t}" )
+done
+
 docker buildx build . \
-    --platform=linux/amd64,linux/arm64 \
-    --provenance true \
-    --sbom true \
-    -t "ghcr.io/settlemint/asset-tokenization-kit:$DOCKER_BUILD_TAG" \
-    --push
+  --platform=linux/amd64,linux/arm64 \
+  --provenance true \
+  --sbom true \
+  "${TAGS_OPTS[@]}" \
+  --push

--- a/tools/docker-codestudio.sh
+++ b/tools/docker-codestudio.sh
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get version from package.json
-DOCKER_BUILD_TAG=$(jq -r .version package.json)
+# Base version from package.json (e.g. 2.0.0)
+BASE_VERSION="$(jq -r .version package.json)"
+PRIMARY_TAG="$BASE_VERSION"
+ALIAS_TAGS=()
 
-# Add dev timestamp if not in CI
-if [ -z "${CI:-}" ]; then
-    DOCKER_BUILD_TAG="$DOCKER_BUILD_TAG-dev.$(date +%s)"
+# In CI on main, publish monotonic semver-like prerelease:
+# 2.0.0-main.<run_number>.<shortsha> and alias 2.0.0-main for convenience
+if [[ -n "${CI:-}" && "${GITHUB_REF:-}" == "refs/heads/main" ]]; then
+  RUN_NO="${GITHUB_RUN_NUMBER:-0}"
+  SHORT_SHA="${GITHUB_SHA:-nogit}"
+  SHORT_SHA="${SHORT_SHA:0:8}"
+  PRIMARY_TAG="${BASE_VERSION}-main.${RUN_NO}.${SHORT_SHA}"
+  ALIAS_TAGS+=("${BASE_VERSION}-main")
+elif [[ -z "${CI:-}" ]]; then
+  # Local/dev builds: keep uniqueness without polluting main tags
+  PRIMARY_TAG="${BASE_VERSION}-dev.$(date +%s)"
 fi
 
 # Build and push Docker image
+TAGS_OPTS=( -t "ghcr.io/settlemint/codestudio-asset-tokenization-kit:${PRIMARY_TAG}" )
+for t in "${ALIAS_TAGS[@]:-}"; do
+  TAGS_OPTS+=( -t "ghcr.io/settlemint/codestudio-asset-tokenization-kit:${t}" )
+done
+
 docker buildx build . \
-    --platform=linux/amd64,linux/arm64 \
-    --provenance true \
-    --sbom true \
-    -t "ghcr.io/settlemint/codestudio-asset-tokenization-kit:$DOCKER_BUILD_TAG" \
-    --push
+  --platform=linux/amd64,linux/arm64 \
+  --provenance true \
+  --sbom true \
+  "${TAGS_OPTS[@]}" \
+  --push


### PR DESCRIPTION
- Emit CI tags as 2.0.0-main.<run_number>.<shortsha> for deterministic SemVer-ish ordering.
- Publish alias 2.0.0-main for convenience.
- Preserve local `-dev.<timestamp>` behavior for developer builds.

Rationale
- Avoids lexicographic weirdness of `-main<sha>` tags in upstream tooling.
- Plays nicely with BTP Renovate config (semver + versionCompatibility + digest pinning).

No workflow changes required. Scripts consume GITHUB_* env provided by Actions.

## Summary by Sourcery

Consolidate and enhance Docker image publish scripts to generate deterministic semver-like tags in CI, add a main alias tag, and retain timestamped dev tags locally

Enhancements:
- Emit monotonic semver-like prerelease tags (2.0.0-main.<run_number>.<shortsha>) for CI builds on the main branch
- Publish a convenience alias tag (2.0.0-main) alongside the primary CI tag
- Preserve timestamped '-dev.<timestamp>' suffix for local developer builds

Build:
- Refactor all Docker publish scripts to apply multiple tags via buildx with the new tagging scheme