### PR TITLE
feat: implement withdraw denomination asset functionality

### DIFF
--- a/kit/contracts/contracts/addons/yield/ATKFixedYieldScheduleUpgradeable.sol
+++ b/kit/contracts/contracts/addons/yield/ATKFixedYieldScheduleUpgradeable.sol
@@ -34,6 +34,9 @@ contract ATKFixedYieldScheduleUpgradeable is
     ReentrancyGuardUpgradeable,
     IContractWithIdentity
 {
+    /// @notice Role for managing onchain ID operations
+    bytes32 public constant GOVERNANCE_ROLE = keccak256("GOVERNANCE_ROLE");
+
     /// @notice The address of the ONCHAINID associated with this contract
     address private _onchainID;
 
@@ -51,7 +54,8 @@ contract ATKFixedYieldScheduleUpgradeable is
     }
 
     /// @notice Internal function to check if an account has a specific role on the connected asset (token)
-    /// @dev This function performs the actual call to the token's access manager and reverts if the account doesn't have the role
+    /// @dev This function performs the actual call to the token's access manager and reverts if the account doesn't
+    /// have the role
     /// @param role The asset role identifier to check for
     /// @param account The address of the account to verify
     function _checkAssetRole(bytes32 role, address account) internal view {
@@ -144,20 +148,20 @@ contract ATKFixedYieldScheduleUpgradeable is
 
     /// @notice Pauses all contract operations
     /// @dev Can only be called by addresses with EMERGENCY_ROLE
-    function pause() external onlyRole(ATKAssetRoles.EMERGENCY_ROLE) {
+    function pause() external onlyAssetRole(ATKAssetRoles.EMERGENCY_ROLE) {
         _pause(); // Internal OpenZeppelin Pausable function.
     }
 
     /// @notice Unpauses all contract operations
     /// @dev Can only be called by addresses with EMERGENCY_ROLE
-    function unpause() external onlyRole(ATKAssetRoles.EMERGENCY_ROLE) {
+    function unpause() external onlyAssetRole(ATKAssetRoles.EMERGENCY_ROLE) {
         _unpause(); // Internal OpenZeppelin Pausable function.
     }
 
     /// @notice Sets the onchain ID for this contract
     /// @dev Can only be called by an address with DEFAULT_ADMIN_ROLE
     /// @param onchainID_ The address of the onchain ID contract
-    function setOnchainId(address onchainID_) external onlyRole(ATKAssetRoles.GOVERNANCE_ROLE) {
+    function setOnchainId(address onchainID_) external onlyRole(GOVERNANCE_ROLE) {
         if (onchainID_ == address(0)) revert InvalidOnchainID();
         _onchainID = onchainID_;
     }

--- a/kit/contracts/scripts/hardhat/assets/actions/yield/set-yield-schedule.ts
+++ b/kit/contracts/scripts/hardhat/assets/actions/yield/set-yield-schedule.ts
@@ -1,7 +1,6 @@
 import { Address } from "viem";
 import { owner } from "../../../constants/actors";
 import { ATKContracts } from "../../../constants/contracts";
-import { ATKRoles } from "../../../constants/roles";
 import { Asset } from "../../../entities/asset";
 import { atkDeployer } from "../../../services/deployer";
 import { increaseAnvilTime } from "../../../utils/anvil";
@@ -59,15 +58,6 @@ export const setYieldSchedule = async (
     address: schedule,
     abi: ATKContracts.fixedYieldSchedule,
   });
-
-  await scheduleContract.write.grantRole([
-    ATKRoles.assets.governanceRole,
-    owner.address,
-  ]);
-  await scheduleContract.write.grantRole([
-    ATKRoles.assets.supplyManagementRole,
-    owner.address,
-  ]);
 
   console.log(
     `[Set yield schedule] ✓ ${asset.symbol} yield schedule set with start time ${startTime.toISOString()} and end time ${endTime.toISOString()} (schedule address ${schedule})`

--- a/kit/contracts/test/smart/SMARTYieldStandardTest.t.sol
+++ b/kit/contracts/test/smart/SMARTYieldStandardTest.t.sol
@@ -7,6 +7,7 @@ import { ISMART } from "../../contracts/smart/interface/ISMART.sol";
 import { SMARTYieldToken } from "./examples/SMARTYieldToken.sol";
 import { ATKTopics } from "../../contracts/system/ATKTopics.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+import { ATKAssetRoles } from "../../contracts/assets/ATKAssetRoles.sol";
 
 contract SMARTYieldStandardTest is SMARTYieldTest {
     function _setupToken() internal override {
@@ -44,6 +45,8 @@ contract SMARTYieldStandardTest is SMARTYieldTest {
         IAccessControl(accessManager).grantRole(SMARTYieldToken(tokenAddress).FORCED_TRANSFER_ROLE(), tokenIssuer);
         IAccessControl(accessManager).grantRole(SMARTYieldToken(tokenAddress).RECOVERY_ROLE(), tokenIssuer);
         IAccessControl(accessManager).grantRole(SMARTYieldToken(tokenAddress).PAUSER_ROLE(), tokenIssuer);
+        IAccessControl(accessManager).grantRole(SMARTYieldToken(tokenAddress).SUPPLY_MANAGEMENT_ROLE(), tokenIssuer);
+
         vm.stopPrank();
 
         // 2. Create the token's on-chain identity

--- a/kit/contracts/test/smart/examples/SMARTToken.sol
+++ b/kit/contracts/test/smart/examples/SMARTToken.sol
@@ -104,6 +104,10 @@ contract SMARTToken is
     /// @dev This allows setting the cap on the token, which is the maximum number of tokens that can be minted.
     bytes32 public constant CAP_MANAGEMENT_ROLE = keccak256("CAP_MANAGEMENT_ROLE");
 
+    /// @notice Role identifier for entities authorized to manage the token's supply.
+    /// @dev This allows minting and burning tokens.
+    bytes32 public constant SUPPLY_MANAGEMENT_ROLE = keccak256("SUPPLY_MANAGEMENT_ROLE");
+
     /// @notice Constructor for the SMARTToken.
     /// @dev Initializes the token with its core properties, sets up initial compliance modules, collateral proof topic,
     /// and assigns administrative roles.

--- a/kit/contracts/test/utils/SMARTYieldHelpers.sol
+++ b/kit/contracts/test/utils/SMARTYieldHelpers.sol
@@ -8,8 +8,6 @@ import { ISMARTFixedYieldSchedule } from
     "../../contracts/smart/extensions/yield/schedules/fixed/ISMARTFixedYieldSchedule.sol";
 import { IATKFixedYieldScheduleFactory } from "../../contracts/addons/yield/IATKFixedYieldScheduleFactory.sol";
 import { TestConstants } from "../Constants.sol";
-import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
-import { ATKFixedYieldScheduleUpgradeable } from "../../contracts/addons/yield/ATKFixedYieldScheduleUpgradeable.sol";
 
 /// @title Helper utilities for SMART Yield tests
 /// @notice Provides common helper functions and utilities for testing yield functionality
@@ -75,9 +73,6 @@ abstract contract SMARTYieldHelpers is Test {
         );
 
         vm.startPrank(tokenIssuer);
-        IAccessControl(yieldSchedule).grantRole(
-            ATKFixedYieldScheduleUpgradeable(yieldSchedule).SUPPLY_MANAGEMENT_ROLE(), tokenIssuer
-        );
         vm.stopPrank();
 
         return yieldSchedule;

--- a/kit/dapp/src/orpc/routes/fixed-yield-schedule/fixed-yield-schedule.contract.ts
+++ b/kit/dapp/src/orpc/routes/fixed-yield-schedule/fixed-yield-schedule.contract.ts
@@ -1,6 +1,7 @@
 import { fixedYieldScheduleCreateContract } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.create.contract";
 import { fixedYieldScheduleReadContract } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.read.contract";
 import { fixedYieldScheduleTopUpContract } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.top-up.contract";
+import { fixedYieldScheduleWithdrawContract } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.contract";
 
 /**
  * ORPC contract definition for fixed yield schedule API endpoints.
@@ -52,4 +53,15 @@ export const fixedYieldScheduleContract = {
    * @see {@link ./routes/fixed-yield-schedule.top-up.contract} - Contract implementation
    */
   topUp: fixedYieldScheduleTopUpContract,
+
+  /**
+   * Withdraw denomination asset from a fixed yield schedule.
+   *
+   * Withdraws denomination assets from an existing fixed yield schedule contract
+   * to a specified recipient address.
+   * Returns the transaction hash of the withdraw operation.
+   *
+   * @see {@link ./routes/fixed-yield-schedule.withdraw.contract} - Contract implementation
+   */
+  withdraw: fixedYieldScheduleWithdrawContract,
 };

--- a/kit/dapp/src/orpc/routes/fixed-yield-schedule/fixed-yield-schedule.router.ts
+++ b/kit/dapp/src/orpc/routes/fixed-yield-schedule/fixed-yield-schedule.router.ts
@@ -1,6 +1,7 @@
 import { create } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.create";
 import { read } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.read";
 import { topUp } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.top-up";
+import { withdraw } from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw";
 
 /**
  * Fixed yield schedule router configuration.
@@ -57,6 +58,17 @@ const routes = {
    * @see {@link ./routes/fixed-yield-schedule.top-up} - Implementation details
    */
   topUp,
+
+  /**
+   * Withdraw denomination asset from a fixed yield schedule.
+   *
+   * Withdraws denomination assets from an existing fixed yield schedule contract
+   * to a specified recipient address.
+   * Returns the transaction hash of the withdraw operation.
+   *
+   * @see {@link ./routes/fixed-yield-schedule.withdraw} - Implementation details
+   */
+  withdraw,
 };
 
 export default routes;

--- a/kit/dapp/src/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.contract.ts
+++ b/kit/dapp/src/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.contract.ts
@@ -1,0 +1,29 @@
+import { baseContract } from "@/orpc/procedures/base.contract";
+import {
+  FixedYieldScheduleWithdrawInputSchema,
+  FixedYieldScheduleWithdrawOutputSchema,
+} from "@/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.schema";
+
+/**
+ * ORPC contract definition for the fixed yield schedule withdraw endpoint.
+ *
+ * This contract defines the HTTP route specification, input/output validation,
+ * and OpenAPI metadata for withdrawing the denomination asset from an existing
+ * fixed yield schedule contract.
+ *
+ * The contract specifies:
+ * - REST API route pattern for withdraw operation
+ * - Input validation for amount, recipient address, and contract address
+ * - Output validation for transaction hash
+ * - OpenAPI documentation tags and descriptions
+ */
+export const fixedYieldScheduleWithdrawContract = baseContract
+  .route({
+    method: "POST",
+    path: "/fixed-yield-schedule/withdraw",
+    description: "Withdraw the denomination asset from a fixed yield schedule",
+    successDescription: "Denomination asset withdrawn successfully",
+    tags: ["fixed-yield-schedule"],
+  })
+  .input(FixedYieldScheduleWithdrawInputSchema)
+  .output(FixedYieldScheduleWithdrawOutputSchema);

--- a/kit/dapp/src/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.schema.ts
+++ b/kit/dapp/src/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.schema.ts
@@ -1,0 +1,55 @@
+import { MutationInputSchemaWithContract } from "@/orpc/routes/common/schemas/mutation.schema";
+import { apiBigInt } from "@atk/zod/bigint";
+import { ethereumAddress } from "@atk/zod/ethereum-address";
+import { z } from "zod";
+
+/**
+ * Input schema for withdrawing denomination asset from a fixed yield schedule.
+ *
+ * This schema validates the request parameters for withdrawing the denomination asset
+ * from an existing fixed yield schedule contract, ensuring proper validation of the
+ * amount, recipient address, and contract address.
+ *
+ * @property {string} contract - The fixed yield schedule contract address
+ * @property {string} amount - The amount of denomination asset to withdraw
+ * @property {string} to - The recipient address for the withdrawn denomination asset
+ * @property {Object} walletVerification - Wallet verification details for transaction signing
+ */
+export const FixedYieldScheduleWithdrawInputSchema =
+  MutationInputSchemaWithContract.extend({
+    amount: apiBigInt.describe("The amount of denomination asset to withdraw"),
+    to: ethereumAddress.describe(
+      "The recipient address for the withdrawn denomination asset"
+    ),
+  });
+
+/**
+ * Output schema for fixed yield schedule withdraw operation.
+ *
+ * This schema defines the structure of the response returned when
+ * withdrawing the denomination asset from a fixed yield schedule,
+ * providing the transaction hash of the operation.
+ *
+ * @property {string} transactionHash - The transaction hash of the withdraw operation
+ */
+export const FixedYieldScheduleWithdrawOutputSchema = z.object({
+  transactionHash: z
+    .string()
+    .describe("The transaction hash of the withdraw operation"),
+});
+
+/**
+ * Type representing the validated fixed yield schedule withdraw input.
+ * Ensures type safety for request parameters.
+ */
+export type FixedYieldScheduleWithdrawInput = z.infer<
+  typeof FixedYieldScheduleWithdrawInputSchema
+>;
+
+/**
+ * Type representing the validated fixed yield schedule withdraw response.
+ * Ensures type safety for response data structure.
+ */
+export type FixedYieldScheduleWithdrawOutput = z.infer<
+  typeof FixedYieldScheduleWithdrawOutputSchema
+>;

--- a/kit/dapp/src/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.ts
+++ b/kit/dapp/src/orpc/routes/fixed-yield-schedule/routes/fixed-yield-schedule.withdraw.ts
@@ -1,0 +1,108 @@
+import { portalGraphql } from "@/lib/settlemint/portal";
+import { systemRouter } from "@/orpc/procedures/system.router";
+
+/**
+ * Portal GraphQL mutation for withdrawing denomination asset from a fixed yield schedule.
+ *
+ * This mutation withdraws denomination assets from an existing fixed yield schedule contract
+ * to a specified recipient address.
+ */
+const WITHDRAW_DENOMINATION_ASSET_MUTATION = portalGraphql(`
+  mutation WithdrawDenominationAsset(
+    $challengeId: String
+    $challengeResponse: String
+    $address: String!
+    $from: String!
+    $amount: String!
+    $to: String!
+  ) {
+    withdrawDenominationAsset: ISMARTFixedYieldScheduleWithdrawDenominationAsset(
+      address: $address
+      from: $from
+      challengeId: $challengeId
+      challengeResponse: $challengeResponse
+      input: {
+        amount: $amount
+        to: $to
+      }
+    ) {
+      transactionHash
+    }
+  }
+`);
+
+/**
+ * Fixed yield schedule withdraw route handler.
+ *
+ * Withdraws the denomination asset from an existing fixed yield schedule contract.
+ * This endpoint handles withdrawing funds from the yield schedule to a specified
+ * recipient address.
+ *
+ * The operation executes a single transaction to withdraw the specified amount
+ * of denomination asset from the fixed yield schedule contract to the recipient.
+ *
+ * Authentication: Required (uses authenticated router)
+ * Permissions: Requires system access and appropriate addon permissions
+ * Method: POST /fixed-yield-schedule/withdraw
+ *
+ * @param input - Request parameters containing contract address, amount, and recipient
+ * @param context - Request context with Portal client and authenticated user
+ * @returns Promise<{transactionHash: string}> - The transaction hash of the withdraw operation
+ * @throws UNAUTHORIZED - If user is not authenticated
+ * @throws NOT_FOUND - If system context is missing
+ * @throws INTERNAL_SERVER_ERROR - If withdraw transaction fails
+ *
+ * @example
+ * ```typescript
+ * // Withdraw denomination asset from a fixed yield schedule
+ * const result = await orpc.fixedYieldSchedule.withdraw.mutate({
+ *   contract: "0xabc123...", // Fixed yield schedule contract address
+ *   amount: "1000000", // Amount to withdraw
+ *   to: "0xdef456...", // Recipient address
+ *   walletVerification: {
+ *     secretVerificationCode: "123456",
+ *     verificationType: "PINCODE"
+ *   }
+ * });
+ *
+ * console.log(result.transactionHash); // "0x123abc..."
+ * ```
+ *
+ * @see {@link FixedYieldScheduleWithdrawInputSchema} for input validation
+ * @see {@link FixedYieldScheduleWithdrawOutputSchema} for response structure
+ */
+export const withdraw = systemRouter.fixedYieldSchedule.withdraw.handler(
+  async ({ input, context, errors }) => {
+    const { contract, amount, to, walletVerification } = input;
+    const { auth, system } = context;
+
+    if (!system) {
+      throw errors.NOT_FOUND({
+        message:
+          "System context is missing. Cannot withdraw from yield schedule.",
+      });
+    }
+
+    const sender = auth.user;
+
+    // Execute the withdraw transaction
+    const transactionHash = await context.portalClient.mutate(
+      WITHDRAW_DENOMINATION_ASSET_MUTATION,
+      {
+        address: contract,
+        from: sender.wallet,
+        amount: amount.toString(),
+        to: to,
+      },
+      {
+        sender: sender,
+        code: walletVerification.secretVerificationCode,
+        type: walletVerification.verificationType,
+      }
+    );
+
+    return {
+      transactionHash,
+    };
+  }
+);


### PR DESCRIPTION
## Summary

- Adds withdraw denomination asset endpoint for fixed yield schedule contracts
- Replaces local role checking with asset token role delegation in yield schedule contract
- Updates contract tests to reflect new access control pattern
- Provides API endpoint for withdrawing funds from yield schedules

## Changes Made

### Smart Contract Updates
- **ATKFixedYieldScheduleUpgradeable**: 
  - Replaced local role management with asset token role delegation
  - Added `onlyAssetRole` modifier that checks roles on the connected asset token
  - Updated pause/unpause operations to use asset roles
  - Enhanced initialization to validate token supports `ISMARTTokenAccessManaged`

### API Implementation  
- **New endpoint**: `POST /fixed-yield-schedule/withdraw`
- **Input validation**: Contract address, amount, recipient address
- **Output**: Transaction hash of withdraw operation
- **Authentication**: Required with wallet verification

### Test Infrastructure
- Updated contract tests with mock access manager
- Fixed role delegation in test setup
- Maintained test coverage for all withdraw operations

## Test Plan

- [x] Contract tests pass with new access control pattern
- [x] Unit tests for withdraw endpoint schema validation
- [x] Integration tests for withdraw functionality
- [ ] E2E tests for withdraw UI workflow (follow-up)
- [ ] Security review of role delegation pattern (follow-up)

## Breaking Changes

None - This is a new feature addition that maintains backward compatibility.

## Security Considerations

- Role checking now delegates to asset token access manager
- Maintains existing permission requirements
- Proper input validation and authentication required