### PR TITLE
feat: add yield schedule modifier functionality

### DIFF
--- a/kit/contracts/test/addons/yield/ATKFixedYieldSchedule.t.sol
+++ b/kit/contracts/test/addons/yield/ATKFixedYieldSchedule.t.sol
@@ -674,9 +674,9 @@ contract ATKFixedYieldScheduleTest is Test {
         yieldSchedule.setOnchainId(address(0));
     }
 
-    function test_CanAddClaim_FactoryReturnsTrue() public view {
-        // Factory (address(this)) should be able to add claims
-        assertTrue(yieldSchedule.canAddClaim(address(this)));
+    function test_CanAddClaim_FactoryReturnsFalse() public view {
+        // Factory (address(this)) should not be able to add claims
+        assertFalse(yieldSchedule.canAddClaim(address(this)));
     }
 
     function test_CanAddClaim_GovernanceRoleReturnsTrue() public {
@@ -691,9 +691,9 @@ contract ATKFixedYieldScheduleTest is Test {
         assertFalse(yieldSchedule.canAddClaim(user1));
     }
 
-    function test_CanRemoveClaim_FactoryReturnsTrue() public view {
-        // Factory (address(this)) should be able to remove claims
-        assertTrue(yieldSchedule.canRemoveClaim(address(this)));
+    function test_CanRemoveClaim_FactoryReturnsFalse() public view {
+        // Factory (address(this)) should not be able to remove claims
+        assertFalse(yieldSchedule.canRemoveClaim(address(this)));
     }
 
     function test_CanRemoveClaim_GovernanceRoleReturnsTrue() public {


### PR DESCRIPTION
## Summary

Added pause and resume functionality to the ATK Fixed Yield Schedule contract to provide administrators with the ability to temporarily halt and restart yield schedule operations.

## Changes

- **Contract Updates**: Added `pauseSchedule()` and `resumeSchedule()` functions to `ATKFixedYieldScheduleUpgradeable.sol`
- **Access Control**: Implemented proper role-based access controls using existing admin permissions
- **State Management**: Added pause/resume logic with proper state validation
- **Comprehensive Testing**: Added thorough test coverage including:
  - Basic pause/resume functionality
  - Access control validation
  - Edge cases and error handling
  - State verification

## Test Plan

✅ All existing tests pass
✅ New pause/resume functionality tests added
✅ Access control validation tests
✅ Edge case handling verified

The implementation follows existing contract patterns and maintains backward compatibility.

## Summary by Sourcery

Add pause and resume functionality to the ATKFixedYieldScheduleUpgradeable contract and centralize access control checks under a new asset role validation helper, while updating tests to reflect governance-only permissions for claim operations.

New Features:
- Introduce pauseSchedule() and resumeSchedule() functions to halt and restart yield schedule operations.

Enhancements:
- Replace the custom factory-or-governance role helper with a unified _hasAssetRole function and update the onlyFactoryOrGovernance modifier accordingly
- Change canAddClaim and canRemoveClaim to rely solely on the governance role instead of factory privileges

Tests:
- Add comprehensive tests for pause/resume functionality and associated edge cases
- Update factory claim-permission tests to assert false under the new governance-only logic