### PR TITLE
feat: add portal openshift route

### DIFF
--- a/kit/charts/atk/README.md
+++ b/kit/charts/atk/README.md
@@ -11,7 +11,6 @@ keys in `values.yaml` (or your environment-specific values file) to point servic
 environment.
 
 ### PostgreSQL Targets
-
 | Service | Values path | Default host | Default port | Default database | Default username | Default password | Default SSL mode |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Blockscout | `blockscout.postgresql` | `postgresql` | `5432` | `blockscout` | `blockscout` | `atk` | `disable` |
@@ -21,7 +20,6 @@ environment.
 | TxSigner | `txsigner.postgresqlConnection` | `postgresql` | `5432` | `txsigner` | `txsigner` | `atk` | `disable` |
 
 ### Redis Targets
-
 | Service | Values path | Default host | Default port | Default database | Default username | Default password |
 | --- | --- | --- | --- | --- | --- | --- |
 | eRPC Cache | `erpc.redis.cacheDb` | `redis` | `6379` | `0` | `default` | `atk` |

--- a/kit/charts/atk/charts/blockscout/README.md
+++ b/kit/charts/atk/charts/blockscout/README.md
@@ -129,9 +129,6 @@ A Helm chart for Blockscout blockchain explorer stack
 | frontend.enabled | bool | `true` |  |
 | frontend.env.NEXT_PUBLIC_AD_BANNER_PROVIDER | string | `"none"` |  |
 | frontend.env.NEXT_PUBLIC_AD_TEXT_PROVIDER | string | `"none"` |  |
-| frontend.env.NEXT_PUBLIC_API_PROTOCOL | string | `"https"` |  |
-| frontend.env.NEXT_PUBLIC_APP_NAME | string | `"Asset Tokenization Kit"` |  |
-| frontend.env.NEXT_PUBLIC_APP_PROTOCOL | string | `"https"` |  |
 | frontend.env.NEXT_PUBLIC_FONT_FAMILY_BODY | string | `"{'name':'Figtree','url':'https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap'}"` |  |
 | frontend.env.NEXT_PUBLIC_FONT_FAMILY_HEADING | string | `"{'name':'Figtree','url':'https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap'}"` |  |
 | frontend.env.NEXT_PUBLIC_HAS_BEACON_CHAIN | string | `"false"` |  |

--- a/kit/charts/atk/charts/portal/README.md
+++ b/kit/charts/atk/charts/portal/README.md
@@ -194,6 +194,30 @@ The following table lists the configurable parameters of the Portal chart and th
 | nodeAffinityPreset.type | string | `""` | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` |
 | nodeAffinityPreset.values | list | `[]` | Node label values to match. Ignored if `affinity` is set |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
+| openShiftRoute | object | `{"alternateBackends":[],"annotations":{},"enabled":false,"graphql":{"alternateBackends":[],"annotations":{},"enabled":true,"host":"","path":"","port":{"targetPort":""},"tls":null,"to":{"weight":""},"wildcardPolicy":""},"host":"portal.k8s.orb.local","path":"/","port":{"targetPort":"http"},"tls":null,"to":{"weight":100},"wildcardPolicy":"None"}` | OpenShift Route parameters |
+| openShiftRoute.alternateBackends | list | `[]` | Additional backends for weighted routing |
+| openShiftRoute.annotations | object | `{}` | Additional annotations for the OpenShift route resource |
+| openShiftRoute.enabled | bool | `false` | Enable OpenShift route creation for Portal |
+| openShiftRoute.graphql | object | `{"alternateBackends":[],"annotations":{},"enabled":true,"host":"","path":"","port":{"targetPort":""},"tls":null,"to":{"weight":""},"wildcardPolicy":""}` | GraphQL route specific configuration |
+| openShiftRoute.graphql.alternateBackends | list | `[]` | Additional backends for weighted routing (same structure as openShiftRoute.alternateBackends) |
+| openShiftRoute.graphql.annotations | object | `{}` | Additional annotations for the GraphQL route resource |
+| openShiftRoute.graphql.enabled | bool | `true` | Enable a dedicated route for the GraphQL endpoint |
+| openShiftRoute.graphql.host | string | `""` | Hostname exposed via the GraphQL route (defaults to openShiftRoute.host when empty) |
+| openShiftRoute.graphql.path | string | `""` | HTTP path exposed via the GraphQL route (defaults to ingress.graphqlPath) |
+| openShiftRoute.graphql.port | object | `{"targetPort":""}` | Service port configuration for the GraphQL route target |
+| openShiftRoute.graphql.port.targetPort | string | `""` | Service target port name (defaults to `graphql`) |
+| openShiftRoute.graphql.tls | string | `nil` | TLS configuration for the GraphQL route |
+| openShiftRoute.graphql.to | object | `{"weight":""}` | Primary service weight configuration for the GraphQL route |
+| openShiftRoute.graphql.to.weight | string | `""` | Weight assigned to the Portal service backend (defaults to openShiftRoute.to.weight) |
+| openShiftRoute.graphql.wildcardPolicy | string | `""` | Wildcard policy to apply to the GraphQL route (defaults to openShiftRoute.wildcardPolicy) |
+| openShiftRoute.host | string | `"portal.k8s.orb.local"` | Hostname exposed via the OpenShift route |
+| openShiftRoute.path | string | `"/"` | HTTP path exposed via the OpenShift route |
+| openShiftRoute.port | object | `{"targetPort":"http"}` | Service port configuration for the route target |
+| openShiftRoute.port.targetPort | string | `"http"` | Service target port name (must exist on the Portal service) |
+| openShiftRoute.tls | string | `nil` | TLS configuration for the OpenShift route |
+| openShiftRoute.to | object | `{"weight":100}` | Primary service weight configuration |
+| openShiftRoute.to.weight | int | `100` | Weight assigned to the Portal service backend |
+| openShiftRoute.wildcardPolicy | string | `"None"` | Wildcard policy to apply to the route |
 | pdb | object | `{"enabled":false,"maxUnavailable":"","minAvailable":""}` | Pod disruption budget configuration |
 | pdb.enabled | bool | `false` | If true, create a pod disruption budget for pods. |
 | pdb.maxUnavailable | string | `""` | Maximum number/percentage of pods that may be made unavailable. Defaults to 1 if both pdb.minAvailable and pdb.maxUnavailable are empty. |

--- a/kit/charts/atk/charts/portal/templates/route.yaml
+++ b/kit/charts/atk/charts/portal/templates/route.yaml
@@ -1,0 +1,114 @@
+{{- /* OpenShift Route for exposing the Portal service when enabled. */ -}}
+{{- $hasRouteAPI := .Capabilities.APIVersions.Has "route.openshift.io/v1" -}}
+{{- if and $hasRouteAPI .Values.openShiftRoute.enabled -}}
+{{- $routeValues := .Values.openShiftRoute -}}
+{{- $fullName := include "common.names.fullname" . -}}
+{{- $targetPort := "http" -}}
+{{- with $routeValues.port }}
+  {{- with .targetPort }}
+    {{- $targetPort = . -}}
+  {{- end }}
+{{- end }}
+{{- $weight := "" -}}
+{{- with $routeValues.to }}
+  {{- with .weight }}
+    {{- $weight = . -}}
+  {{- end }}
+{{- end }}
+{{- $wildcard := default "None" $routeValues.wildcardPolicy -}}
+{{- $baseAnnotations := include "common.tplvalues.merge" ( dict "values" ( list (default (dict) $routeValues.annotations) .Values.commonAnnotations ) "context" . ) -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if $baseAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $baseAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    {{- if $weight }}
+    weight: {{ int $weight }}
+    {{- end }}
+  {{- with $routeValues.alternateBackends }}
+  alternateBackends:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  port:
+    targetPort: {{ $targetPort }}
+  {{- with $routeValues.host }}
+  host: {{ . | quote }}
+  {{- end }}
+  {{- with $routeValues.path }}
+  path: {{ . | quote }}
+  {{- end }}
+  {{- if $wildcard }}
+  wildcardPolicy: {{ $wildcard }}
+  {{- end }}
+  {{- with $routeValues.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+{{- $graphqlValues := default (dict) $routeValues.graphql -}}
+{{- $graphqlPath := default .Values.ingress.graphqlPath $graphqlValues.path -}}
+{{- $graphqlEnabled := and (ne (default true $graphqlValues.enabled) false) $graphqlPath -}}
+{{- if $graphqlEnabled }}
+---
+{{- $graphqlName := printf "%s-graphql" $fullName -}}
+{{- $graphqlTargetPort := "graphql" -}}
+{{- with $graphqlValues.port }}
+  {{- with .targetPort }}
+    {{- $graphqlTargetPort = . -}}
+  {{- end }}
+{{- end }}
+{{- $graphqlWeight := $weight -}}
+{{- with $graphqlValues.to }}
+  {{- with .weight }}
+    {{- $graphqlWeight = . -}}
+  {{- end }}
+{{- end }}
+{{- $graphqlWildcard := default $wildcard $graphqlValues.wildcardPolicy -}}
+{{- $graphqlHost := default $routeValues.host $graphqlValues.host -}}
+{{- $graphqlAnnotations := include "common.tplvalues.merge" ( dict "values" ( list (default (dict) $graphqlValues.annotations) .Values.commonAnnotations ) "context" . ) -}}
+{{- $graphqlTLS := default $routeValues.tls $graphqlValues.tls -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $graphqlName }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if $graphqlAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $graphqlAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    {{- if $graphqlWeight }}
+    weight: {{ int $graphqlWeight }}
+    {{- end }}
+  {{- with $graphqlValues.alternateBackends }}
+  alternateBackends:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  port:
+    targetPort: {{ $graphqlTargetPort }}
+  {{- with $graphqlHost }}
+  host: {{ . | quote }}
+  {{- end }}
+  {{- with $graphqlPath }}
+  path: {{ . | quote }}
+  {{- end }}
+  {{- if $graphqlWildcard }}
+  wildcardPolicy: {{ $graphqlWildcard }}
+  {{- end }}
+  {{- with $graphqlTLS }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/kit/charts/atk/charts/portal/values.yaml
+++ b/kit/charts/atk/charts/portal/values.yaml
@@ -298,6 +298,55 @@ ingress:
   # -- Additional rules to be covered with this ingress record
   extraRules: []
 
+# -- OpenShift Route parameters
+openShiftRoute:
+  # -- Enable OpenShift route creation for Portal
+  enabled: false
+  # -- Additional annotations for the OpenShift route resource
+  annotations: {}
+  # -- Hostname exposed via the OpenShift route
+  host: portal.k8s.orb.local
+  # -- HTTP path exposed via the OpenShift route
+  path: /
+  # -- Wildcard policy to apply to the route
+  wildcardPolicy: None
+  # -- Service port configuration for the route target
+  port:
+    # -- Service target port name (must exist on the Portal service)
+    targetPort: http
+  # -- Primary service weight configuration
+  to:
+    # -- Weight assigned to the Portal service backend
+    weight: 100
+  # -- Additional backends for weighted routing
+  alternateBackends: []
+  # -- TLS configuration for the OpenShift route
+  tls: null
+  # -- GraphQL route specific configuration
+  graphql:
+    # -- Enable a dedicated route for the GraphQL endpoint
+    enabled: true
+    # -- Additional annotations for the GraphQL route resource
+    annotations: {}
+    # -- Hostname exposed via the GraphQL route (defaults to openShiftRoute.host when empty)
+    host: ""
+    # -- HTTP path exposed via the GraphQL route (defaults to ingress.graphqlPath)
+    path: ""
+    # -- Wildcard policy to apply to the GraphQL route (defaults to openShiftRoute.wildcardPolicy)
+    wildcardPolicy: ""
+    # -- Service port configuration for the GraphQL route target
+    port:
+      # -- Service target port name (defaults to `graphql`)
+      targetPort: ""
+    # -- Primary service weight configuration for the GraphQL route
+    to:
+      # -- Weight assigned to the Portal service backend (defaults to openShiftRoute.to.weight)
+      weight: ""
+    # -- Additional backends for weighted routing (same structure as openShiftRoute.alternateBackends)
+    alternateBackends: []
+    # -- TLS configuration for the GraphQL route
+    tls: null
+
 # -- Service account for Portal pods
 serviceAccount:
   # -- Specifies whether a ServiceAccount should be created

--- a/kit/charts/atk/values-openshift.yaml
+++ b/kit/charts/atk/values-openshift.yaml
@@ -82,6 +82,19 @@ graph-node:
 
 # Portal security contexts for OpenShift
 portal:
+  ingress:
+    enabled: false
+
+  openShiftRoute:
+    enabled: true
+    host: portal.apps-crc.testing
+    path: /
+    tls: null
+    graphql:
+      enabled: true
+      host: portal.apps-crc.testing
+      path: /graphql
+
   podSecurityContext:
     fsGroup: null
     runAsUser: null


### PR DESCRIPTION
## Summary by Sourcery

Provide native OpenShift route support in the Portal Helm chart by adding configuration values, templating, and documentation updates

New Features:
- Add openShiftRoute configuration block to the Portal Helm chart values for creating OpenShift Route resources
- Introduce a Helm template to render OpenShift Route CRDs for the Portal service and its GraphQL endpoint

Enhancements:
- Document the openShiftRoute parameters in the Portal chart README
- Enable and configure the Portal OpenShift route in the OpenShift-specific values file

Chores:
- Remove outdated NEXT_PUBLIC environment variables from the Blockscout README
- Clean up extraneous blank lines in the top-level README