### PR TITLE
feat: add hasura openshift route

### DIFF
--- a/kit/charts/atk/README.md
+++ b/kit/charts/atk/README.md
@@ -379,6 +379,15 @@ The following table lists the configurable parameters of this chart and their de
 | hasura.graphql-engine.labels."app.kubernetes.io/component" | string | `"hasura"` |  |
 | hasura.graphql-engine.labels."app.kubernetes.io/instance" | string | `"atk"` |  |
 | hasura.graphql-engine.labels."kots.io/app-slug" | string | `"settlemint-atk"` |  |
+| hasura.graphql-engine.openShiftRoute.alternateBackends | list | `[]` |  |
+| hasura.graphql-engine.openShiftRoute.annotations | object | `{}` |  |
+| hasura.graphql-engine.openShiftRoute.enabled | bool | `false` |  |
+| hasura.graphql-engine.openShiftRoute.host | string | `"hasura.k8s.orb.local"` |  |
+| hasura.graphql-engine.openShiftRoute.path | string | `"/"` |  |
+| hasura.graphql-engine.openShiftRoute.port.targetPort | string | `"http"` |  |
+| hasura.graphql-engine.openShiftRoute.tls | string | `nil` |  |
+| hasura.graphql-engine.openShiftRoute.to.weight | int | `100` |  |
+| hasura.graphql-engine.openShiftRoute.wildcardPolicy | string | `"None"` |  |
 | hasura.graphql-engine.replicas | int | `1` |  |
 | hasura.graphql-engine.secret.extraSecrets.DEFAULT_DB_URL | string | `"postgresql://hasura:atk@postgresql:5432/hasura?sslmode=disable"` |  |
 | hasura.graphql-engine.secret.metadataDbUrl | string | `"postgresql://hasura:atk@postgresql:5432/hasura?sslmode=disable"` |  |

--- a/kit/charts/atk/charts/hasura/README.md
+++ b/kit/charts/atk/charts/hasura/README.md
@@ -58,6 +58,15 @@ A Helm chart for the hasura components
 | graphql-engine.labels."app.kubernetes.io/part-of" | string | `"settlemint-atk"` |  |
 | graphql-engine.labels."kots.io/app-slug" | string | `"settlemint-atk"` |  |
 | graphql-engine.nameOverride | string | `"hasura"` |  |
+| graphql-engine.openShiftRoute.alternateBackends | list | `[]` |  |
+| graphql-engine.openShiftRoute.annotations | object | `{}` |  |
+| graphql-engine.openShiftRoute.enabled | bool | `false` |  |
+| graphql-engine.openShiftRoute.host | string | `"hasura.k8s.orb.local"` |  |
+| graphql-engine.openShiftRoute.path | string | `"/"` |  |
+| graphql-engine.openShiftRoute.port.targetPort | string | `"http"` |  |
+| graphql-engine.openShiftRoute.tls | string | `nil` |  |
+| graphql-engine.openShiftRoute.to.weight | int | `100` |  |
+| graphql-engine.openShiftRoute.wildcardPolicy | string | `"None"` |  |
 | graphql-engine.postgres.enabled | bool | `false` |  |
 | graphql-engine.replicas | int | `1` |  |
 | graphql-engine.secret.adminSecret | string | `"atk"` |  |

--- a/kit/charts/atk/charts/hasura/templates/route.yaml
+++ b/kit/charts/atk/charts/hasura/templates/route.yaml
@@ -1,0 +1,64 @@
+{{- /* OpenShift Route for exposing the Hasura graphql-engine service when enabled. */ -}}
+{{- $hasRouteAPI := .Capabilities.APIVersions.Has "route.openshift.io/v1" -}}
+{{- $hasuraValues := index .Values "graphql-engine" -}}
+{{- $routeValues := default dict $hasuraValues.openShiftRoute -}}
+{{- if and $hasRouteAPI $routeValues $routeValues.enabled -}}
+{{- $servicePrefix := .Release.Name -}}
+{{- if and $hasuraValues $hasuraValues.global $hasuraValues.global.prefixOverride -}}
+  {{- $servicePrefix = $hasuraValues.global.prefixOverride -}}
+{{- end -}}
+{{- $serviceName := default (printf "%s-graphql-engine" $servicePrefix) $hasuraValues.nameOverride -}}
+{{- $routeName := default $serviceName $routeValues.name -}}
+{{- $targetPort := "http" -}}
+{{- with $routeValues.port }}
+  {{- with .targetPort }}
+    {{- $targetPort = . -}}
+  {{- end }}
+{{- end }}
+{{- $weight := "" -}}
+{{- with $routeValues.to }}
+  {{- with .weight }}
+    {{- $weight = . -}}
+  {{- end }}
+{{- end }}
+{{- $wildcard := default "None" $routeValues.wildcardPolicy -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $routeName }}
+  labels:
+    app: {{ $routeName }}
+    {{- with $hasuraValues.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $routeValues.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  to:
+    kind: Service
+    name: {{ $serviceName }}
+    {{- if $weight }}
+    weight: {{ int $weight }}
+    {{- end }}
+  {{- with $routeValues.alternateBackends }}
+  alternateBackends:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  port:
+    targetPort: {{ $targetPort }}
+  {{- with $routeValues.host }}
+  host: {{ . | quote }}
+  {{- end }}
+  {{- with $routeValues.path }}
+  path: {{ . | quote }}
+  {{- end }}
+  {{- if $wildcard }}
+  wildcardPolicy: {{ $wildcard }}
+  {{- end }}
+  {{- with $routeValues.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kit/charts/atk/charts/hasura/values.yaml
+++ b/kit/charts/atk/charts/hasura/values.yaml
@@ -14,6 +14,18 @@ graphql-engine:
     enabled: true
     ingressClassName: "atk-nginx"
     hostName: "hasura.k8s.orb.local"
+  openShiftRoute:
+    enabled: false
+    annotations: {}
+    host: hasura.k8s.orb.local
+    path: /
+    wildcardPolicy: None
+    port:
+      targetPort: http
+    to:
+      weight: 100
+    alternateBackends: []
+    tls: null
   config:
     metadataOnly: false
     enableInternalConsoleAssets: true

--- a/kit/charts/atk/values-openshift.yaml
+++ b/kit/charts/atk/values-openshift.yaml
@@ -337,6 +337,15 @@ observability:
 # Hasura configuration for OpenShift
 hasura:
   graphql-engine:
+    ingress:
+      enabled: false
+
+    openShiftRoute:
+      enabled: true
+      host: hasura.apps-crc.testing
+      path: /
+      wildcardPolicy: None
+
     podSecurityContext:
       runAsNonRoot: true
       fsGroup: null

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -491,6 +491,18 @@ hasura:
       app.kubernetes.io/instance: atk
       kots.io/app-slug: settlemint-atk
       app.kubernetes.io/component: hasura
+    openShiftRoute:
+      enabled: false
+      annotations: {}
+      host: hasura.k8s.orb.local
+      path: /
+      wildcardPolicy: None
+      port:
+        targetPort: http
+      to:
+        weight: 100
+      alternateBackends: []
+      tls: null
     image:
       repository: docker.io/hasura/graphql-engine
       tag: v2.48.5


### PR DESCRIPTION
## Summary by Sourcery

Add optional OpenShift Route support for the Hasura GraphQL engine in the Helm charts by introducing configuration parameters, a new route template, and updated documentation

New Features:
- Add openShiftRoute configuration block to the Hasura subchart and root chart values for optional OpenShift route support
- Introduce a new route.yaml Helm template to generate an OpenShift Route for the Hasura GraphQL engine when enabled
- Enable the OpenShift route by default in the values-openshift.yaml and disable the existing ingress for Hasura

Documentation:
- Add README entries for the openShiftRoute parameters in both the root chart and Hasura subchart