### PR TITLE
fix: divide by zero err in subgraph

### DIFF
--- a/kit/subgraph/src/stats/token-distribution-stats.ts
+++ b/kit/subgraph/src/stats/token-distribution-stats.ts
@@ -263,9 +263,11 @@ function calculateTop5HoldersPercentage(
     }
   }
 
-  const percentage = totalBalanceTopHolders
-    .toBigDecimal()
-    .div(token.totalSupplyExact.toBigDecimal());
+  const percentage = token.totalSupplyExact.gt(BigInt.zero())
+    ? totalBalanceTopHolders
+        .toBigDecimal()
+        .div(token.totalSupplyExact.toBigDecimal())
+    : BigDecimal.zero();
   return percentage.times(BigDecimal.fromString("100"));
 }
 

--- a/kit/subgraph/src/stats/token-type-stats.ts
+++ b/kit/subgraph/src/stats/token-type-stats.ts
@@ -250,7 +250,7 @@ function getPercentageOfTotalSupply(
   totalValueInBaseCurrency: BigDecimal,
   totalSystemValueInBaseCurrency: BigDecimal
 ): BigDecimal {
-  const percentage = totalValueInBaseCurrency.gt(BigDecimal.zero())
+  const percentage = totalSystemValueInBaseCurrency.gt(BigDecimal.zero())
     ? totalValueInBaseCurrency.div(totalSystemValueInBaseCurrency)
     : BigDecimal.zero();
   log.info(

--- a/kit/subgraph/src/stats/token-type-stats.ts
+++ b/kit/subgraph/src/stats/token-type-stats.ts
@@ -250,9 +250,9 @@ function getPercentageOfTotalSupply(
   totalValueInBaseCurrency: BigDecimal,
   totalSystemValueInBaseCurrency: BigDecimal
 ): BigDecimal {
-  const percentage = totalValueInBaseCurrency.div(
-    totalSystemValueInBaseCurrency
-  );
+  const percentage = totalValueInBaseCurrency.gt(BigDecimal.zero())
+    ? totalValueInBaseCurrency.div(totalSystemValueInBaseCurrency)
+    : BigDecimal.zero();
   log.info(
     "totalValueInBaseCurrency: {}, totalSystemValueInBaseCurrency: {}, percentage: {}",
     [


### PR DESCRIPTION
## Summary by Sourcery

Fix divide-by-zero errors in subgraph stats calculations by adding conditional checks for zero denominators.

Bug Fixes:
- Guard against zero total supply in calculateTop5HoldersPercentage to avoid division by zero.
- Return zero in getPercentageOfTotalSupply when total value in base currency is zero to prevent division errors.