### PR TITLE
fix: lazy loading of routes

### DIFF
--- a/kit/dapp/src/orpc/middlewares/auth/session.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/auth/session.middleware.ts
@@ -1,6 +1,6 @@
 import { auth, type Session, type SessionUser } from "@/lib/auth";
 import type { Context } from "@/orpc/context/context";
-import { baseRouter } from "../../procedures/base.router";
+import { baseRouter } from "@/orpc/procedures/base.router";
 
 /**
  * Session middleware for optional authentication context.

--- a/kit/dapp/src/orpc/middlewares/auth/trusted-issuer.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/auth/trusted-issuer.middleware.ts
@@ -1,5 +1,4 @@
 import { theGraphGraphql } from "@/lib/settlemint/the-graph";
-// import type { Context } from "@/orpc/context/context";
 import { baseRouter } from "@/orpc/procedures/base.router";
 import { ethereumAddress } from "@atk/zod/ethereum-address";
 import { getAddress } from "viem";

--- a/kit/dapp/src/orpc/middlewares/services/portal.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/services/portal.middleware.ts
@@ -33,6 +33,7 @@ import { theGraphGraphql } from "@/lib/settlemint/the-graph";
 import type { Context } from "@/orpc/context/context";
 import { getVerificationId } from "@/orpc/helpers/get-verification-id";
 import type { ValidatedTheGraphClient } from "@/orpc/middlewares/services/the-graph.middleware";
+import { baseRouter } from "@/orpc/procedures/base.router";
 import type { EthereumAddress } from "@atk/zod/ethereum-address";
 import {
   ethereumHash,
@@ -48,7 +49,6 @@ import { getOperationAST, print } from "graphql";
 import type { Variables } from "graphql-request";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
-import { baseRouter } from "../../procedures/base.router";
 
 const GET_TRANSACTION_QUERY = portalGraphql(`
   query GetTransaction($transactionHash: String!) {

--- a/kit/dapp/src/orpc/middlewares/services/the-graph.middleware.ts
+++ b/kit/dapp/src/orpc/middlewares/services/the-graph.middleware.ts
@@ -49,6 +49,7 @@
  */
 import { theGraphClient } from "@/lib/settlemint/the-graph";
 import type { Context } from "@/orpc/context/context";
+import { baseRouter } from "@/orpc/procedures/base.router";
 import type { TadaDocumentNode } from "gql.tada";
 import { print } from "graphql";
 import {
@@ -57,7 +58,6 @@ import {
   type Variables,
 } from "graphql-request";
 import { z } from "zod";
-import { baseRouter } from "../../procedures/base.router";
 
 /**
  * Creates a validated TheGraph client with advanced querying capabilities

--- a/kit/dapp/src/orpc/orpc-client.ts
+++ b/kit/dapp/src/orpc/orpc-client.ts
@@ -24,7 +24,7 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { createLogger } from "@settlemint/sdk-utils/logging";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getHeaders } from "@tanstack/react-start/server";
-import type { router as routerType } from "./routes/router";
+import type { router as AppRouter } from "./routes/router";
 
 const logger = createLogger();
 
@@ -44,7 +44,7 @@ const logger = createLogger();
 const getORPCClient = createIsomorphicFn()
   .server(async () => {
     // Import router here to avoid the client loading server code
-    const router = await import("./routes/router");
+    const { router } = await import("./routes/router");
     return createRouterClient(router, {
       context: () => {
         try {
@@ -66,7 +66,7 @@ const getORPCClient = createIsomorphicFn()
       },
     });
   })
-  .client((): RouterClient<typeof routerType> => {
+  .client((): RouterClient<typeof AppRouter> => {
     const link = new RPCLink({
       url: `${globalThis.location.origin}/api/rpc`,
       async fetch(url, options) {

--- a/kit/dapp/src/orpc/orpc-client.ts
+++ b/kit/dapp/src/orpc/orpc-client.ts
@@ -24,7 +24,7 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { createLogger } from "@settlemint/sdk-utils/logging";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getHeaders } from "@tanstack/react-start/server";
-import { router } from "./routes/router";
+import type { router as routerType } from "./routes/router";
 
 const logger = createLogger();
 
@@ -42,7 +42,9 @@ const logger = createLogger();
  * - Points to the `/api` endpoint relative to the current origin
  */
 const getORPCClient = createIsomorphicFn()
-  .server(() => {
+  .server(async () => {
+    // Import router here to avoid the client loading server code
+    const router = await import("./routes/router");
     return createRouterClient(router, {
       context: () => {
         try {
@@ -64,7 +66,7 @@ const getORPCClient = createIsomorphicFn()
       },
     });
   })
-  .client((): RouterClient<typeof router> => {
+  .client((): RouterClient<typeof routerType> => {
     const link = new RPCLink({
       url: `${globalThis.location.origin}/api/rpc`,
       async fetch(url, options) {

--- a/kit/dapp/src/orpc/routes/router.ts
+++ b/kit/dapp/src/orpc/routes/router.ts
@@ -1,4 +1,5 @@
 import { baseRouter } from "../procedures/base.router";
+import settingsRouter from "./settings/settings.router";
 
 /**
  * Main ORPC router configuration.
@@ -79,12 +80,11 @@ export const router = baseRouter.router({
   /**
    * Settings-related API procedures.
    *
-   * Lazy-loaded module containing settings management operations.
+   * The settings router is not lazy-loaded to avoid issues with circular dependencies.
+   * The system router calls procedures from the settings router, which sometimes leads to errors (Cannot access 'default' before initialization.)
    * @see {@link ./settings/settings.router} - Settings router implementation
    */
-  settings: baseRouter.settings.lazy(
-    async () => import("./settings/settings.router")
-  ),
+  settings: settingsRouter,
 
   /**
    * Token-related API procedures.


### PR DESCRIPTION
<img width="730" height="587" alt="Screenshot 2025-09-19 at 11 36 32" src="https://github.com/user-attachments/assets/0e2522ff-e47c-4695-9724-fa2939e236b1" />
Fixes this error

## Summary by Sourcery

Replace lazy loading of settings router with direct import and clean up unused middleware imports to resolve circular dependency initialization errors

Bug Fixes:
- Switch settings route to direct settingsRouter import instead of lazy loading to prevent circular dependency errors
- Remove unused baseRouter import from portal middleware