### PR TITLE
fix: disable otp verification

### DIFF
--- a/kit/dapp/locales/en-US/onboarding.json
+++ b/kit/dapp/locales/en-US/onboarding.json
@@ -123,7 +123,7 @@
       "title": "Recovery codes"
     },
     "wallet-security": {
-      "description": "Add PIN or OTP authentication",
+      "description": "Add PIN authentication",
       "title": "Secure your wallet"
     }
   },

--- a/kit/dapp/src/components/onboarding/wallet-security/otp-setup-modal.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/otp-setup-modal.tsx
@@ -26,12 +26,12 @@ import { toast } from "sonner";
 
 interface OtpSetupModalProps {
   open: boolean;
-  onOpenChange: (open: false) => void;
+  onClose: () => void;
 }
 
 const logger = createLogger();
 
-export function OtpSetupModal({ open, onOpenChange }: OtpSetupModalProps) {
+export function OtpSetupModal({ open, onClose }: OtpSetupModalProps) {
   const { t } = useTranslation("onboarding");
   const { refreshUserState } = useOnboardingNavigation();
   const [otpUri, setOtpUri] = useState<string | null>(null);
@@ -148,8 +148,8 @@ export function OtpSetupModal({ open, onOpenChange }: OtpSetupModalProps) {
     setOtpSetupError(false);
     setOtpUri(null);
     setOtpSecret(null);
-    onOpenChange(false);
-  }, [form, onOpenChange]);
+    onClose();
+  }, [form, onClose]);
 
   const handleOtpCodeChange = useCallback(
     (value: string) => {

--- a/kit/dapp/src/components/onboarding/wallet-security/otp-setup-modal.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/otp-setup-modal.tsx
@@ -26,7 +26,7 @@ import { toast } from "sonner";
 
 interface OtpSetupModalProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onOpenChange: (open: false) => void;
 }
 
 const logger = createLogger();

--- a/kit/dapp/src/components/onboarding/wallet-security/pin-setup-modal.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/pin-setup-modal.tsx
@@ -18,10 +18,10 @@ import { toast } from "sonner";
 
 interface PinSetupModalProps {
   open: boolean;
-  onOpenChange: (open: false) => void;
+  onClose: () => void;
 }
 
-export function PinSetupModal({ open, onOpenChange }: PinSetupModalProps) {
+export function PinSetupModal({ open, onClose }: PinSetupModalProps) {
   const { refreshUserState } = useOnboardingNavigation();
   const { t } = useTranslation(["onboarding", "common"]);
 
@@ -75,8 +75,8 @@ export function PinSetupModal({ open, onOpenChange }: PinSetupModalProps) {
 
   const handleClose = useCallback(() => {
     form.reset();
-    onOpenChange(false);
-  }, [form, onOpenChange]);
+    onClose();
+  }, [form, onClose]);
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>

--- a/kit/dapp/src/components/onboarding/wallet-security/pin-setup-modal.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/pin-setup-modal.tsx
@@ -18,7 +18,7 @@ import { toast } from "sonner";
 
 interface PinSetupModalProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onOpenChange: (open: false) => void;
 }
 
 export function PinSetupModal({ open, onOpenChange }: PinSetupModalProps) {

--- a/kit/dapp/src/components/onboarding/wallet-security/security-method-selector.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/security-method-selector.tsx
@@ -212,8 +212,18 @@ export function SecurityMethodSelector() {
         </div>
       </div>
 
-      <PinSetupModal open={showModal === "pin"} onOpenChange={setShowModal} />
-      {/* <OtpSetupModal open={showModal === "otp"} onOpenChange={setShowModal} /> */}
+      <PinSetupModal
+        open={showModal === "pin"}
+        onClose={() => {
+          setShowModal(false);
+        }}
+      />
+      {/* <OtpSetupModal
+        open={showModal === "otp"}
+        onClose={() => {
+          setShowModal(false);
+        }}
+      /> */}
     </FormStepLayout>
   );
 }

--- a/kit/dapp/src/components/onboarding/wallet-security/security-method-selector.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/security-method-selector.tsx
@@ -1,17 +1,43 @@
 import { FormStepLayout } from "@/components/form/multi-step/form-step-layout";
-import { OtpSetupModal } from "@/components/onboarding/wallet-security/otp-setup-modal";
+// import { OtpSetupModal } from "@/components/onboarding/wallet-security/otp-setup-modal";
 import { PinSetupModal } from "@/components/onboarding/wallet-security/pin-setup-modal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, CheckCircle, Star, X } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export function SecurityMethodSelector() {
   const { t } = useTranslation(["onboarding"]);
-
-  const [showPinModal, setShowPinModal] = useState(false);
-  const [showOtpModal, setShowOtpModal] = useState(false);
+  const securityMethods = useMemo(
+    () =>
+      [
+        {
+          key: "pin",
+          title: t("wallet-security.method-selector.pin.title"),
+          summary: t("wallet-security.method-selector.pin.summary"),
+          securityLevel: "good",
+          easyToUse: true,
+          requiresPhoneApp: false,
+          offlineAccess: true,
+          recommended: false,
+        },
+        // {
+        //   key: "otp",
+        //   title: t("wallet-security.method-selector.otp.title"),
+        //   summary: t("wallet-security.method-selector.otp.summary"),
+        //   securityLevel: "maximum",
+        //   easyToUse: false,
+        //   requiresPhoneApp: true,
+        //   offlineAccess: true,
+        //   recommended: true,
+        // },
+      ] as const,
+    [t]
+  );
+  const [showModal, setShowModal] = useState<
+    (typeof securityMethods)[number]["key"] | false
+  >(false);
 
   return (
     <FormStepLayout
@@ -27,14 +53,14 @@ export function SecurityMethodSelector() {
               <div className="col-span-4 p-4 font-medium text-foreground text-left">
                 {t("wallet-security.method-selector.comparison.feature")}
               </div>
-              <div className="col-span-3 p-4 font-medium text-foreground text-center">
-                {t("wallet-security.method-selector.pin.title")}
-              </div>
-              <div className="col-span-3 p-4 font-medium text-foreground text-center">
-                <div className="flex flex-col items-center gap-2">
-                  {t("wallet-security.method-selector.otp.title")}
+              {securityMethods.map((method) => (
+                <div
+                  key={method.key}
+                  className="col-span-3 p-4 font-medium text-foreground text-center"
+                >
+                  {method.title}
                 </div>
-              </div>
+              ))}
             </div>
           </div>
 
@@ -47,42 +73,48 @@ export function SecurityMethodSelector() {
                     "wallet-security.method-selector.comparison.security-level"
                   )}
                 </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  {t(
-                    "wallet-security.method-selector.comparison.security-good"
-                  )}
-                </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  {t(
-                    "wallet-security.method-selector.comparison.security-maximum"
-                  )}
-                </div>
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-sm"
+                  >
+                    {t(
+                      `wallet-security.method-selector.comparison.security-${method.securityLevel}`
+                    )}
+                  </div>
+                ))}
               </div>
               <div className="grid grid-cols-10 gap-0 w-full">
                 <div className="col-span-4 p-4 font-medium text-sm">
                   {t("wallet-security.method-selector.comparison.ease-of-use")}
                 </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
-                </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mx-auto" />
-                </div>
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-sm"
+                  >
+                    {method.easyToUse ? (
+                      <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
+                    ) : (
+                      <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mx-auto" />
+                    )}
+                  </div>
+                ))}
               </div>
               <div className="grid grid-cols-10 gap-0 w-full">
                 <div className="col-span-4 p-4 font-medium text-sm">
                   {t("wallet-security.method-selector.comparison.setup-time")}
                 </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  {t(
-                    "wallet-security.method-selector.comparison.setup-time-pin"
-                  )}
-                </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  {t(
-                    "wallet-security.method-selector.comparison.setup-time-otp"
-                  )}
-                </div>
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-sm"
+                  >
+                    {t(
+                      `wallet-security.method-selector.comparison.setup-time-${method.key}`
+                    )}
+                  </div>
+                ))}
               </div>
               <div className="grid grid-cols-10 gap-0 w-full">
                 <div className="col-span-4 p-4 font-medium text-sm">
@@ -90,12 +122,18 @@ export function SecurityMethodSelector() {
                     "wallet-security.method-selector.comparison.requires-phone-app"
                   )}
                 </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  <X className="w-4 h-4 text-red-600 dark:text-red-400 mx-auto" />
-                </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
-                </div>
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-sm"
+                  >
+                    {method.requiresPhoneApp ? (
+                      <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
+                    ) : (
+                      <X className="w-4 h-4 text-red-600 dark:text-red-400 mx-auto" />
+                    )}
+                  </div>
+                ))}
               </div>
               <div className="grid grid-cols-10 gap-0 w-full">
                 <div className="col-span-4 p-4 font-medium text-sm">
@@ -103,81 +141,79 @@ export function SecurityMethodSelector() {
                     "wallet-security.method-selector.comparison.offline-access"
                   )}
                 </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
-                </div>
-                <div className="col-span-3 p-4 text-center text-sm">
-                  <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
-                </div>
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-sm"
+                  >
+                    {method.offlineAccess ? (
+                      <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400 mx-auto" />
+                    ) : (
+                      <X className="w-4 h-4 text-red-600 dark:text-red-400 mx-auto" />
+                    )}
+                  </div>
+                ))}
               </div>
               <div className="grid grid-cols-10 gap-0 w-full">
                 <div className="col-span-4 p-4 font-medium text-sm">
                   {t("wallet-security.method-selector.comparison.description")}
                 </div>
-                <div className="col-span-3 p-4 text-center text-xs text-muted-foreground">
-                  {t("wallet-security.method-selector.pin.summary")}
-                </div>
-                <div className="col-span-3 p-4 text-center text-xs text-muted-foreground">
-                  {t("wallet-security.method-selector.otp.summary")}
-                </div>
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-xs text-muted-foreground"
+                  >
+                    {method.summary}
+                  </div>
+                ))}
               </div>
 
               <div className="grid grid-cols-10 gap-0 w-full">
                 <div className="col-span-4 p-4 font-medium text-sm" />
-                <div className="col-span-3 p-4 text-center text-xs text-muted-foreground">
-                  <Button
-                    onClick={() => {
-                      setShowPinModal(true);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        setShowPinModal(true);
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={t(
-                      "wallet-security.method-selector.comparison.choose-pin"
+                {securityMethods.map((method) => (
+                  <div
+                    key={method.key}
+                    className="col-span-3 p-4 text-center text-xs text-muted-foreground flex flex-col gap-4"
+                  >
+                    <Button
+                      className="self-center"
+                      onClick={() => {
+                        setShowModal(method.key);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setShowModal(false);
+                        }
+                      }}
+                      tabIndex={0}
+                      aria-label={t(
+                        `wallet-security.method-selector.comparison.choose-${method.key}`
+                      )}
+                    >
+                      {t(
+                        `wallet-security.method-selector.comparison.choose-${method.key}`
+                      )}
+                    </Button>
+                    {method.recommended && (
+                      <Badge
+                        variant="default"
+                        className="flex items-center gap-1 self-center text-[0.65rem]"
+                      >
+                        <Star className="w-3 h-3 " />
+                        {t("wallet-security.method-selector.recommended")}
+                      </Badge>
                     )}
-                  >
-                    {t("wallet-security.method-selector.comparison.choose-pin")}
-                  </Button>
-                </div>
-                <div className="col-span-3 p-4 text-center text-xs text-muted-foreground flex flex-col gap-4">
-                  <Button
-                    className="self-center"
-                    onClick={() => {
-                      setShowOtpModal(true);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        setShowOtpModal(true);
-                      }
-                    }}
-                    tabIndex={0}
-                    aria-label={t(
-                      "wallet-security.method-selector.comparison.choose-otp"
-                    )}
-                  >
-                    {t("wallet-security.method-selector.comparison.choose-otp")}
-                  </Button>
-                  <Badge
-                    variant="default"
-                    className="flex items-center gap-1 self-center text-[0.65rem]"
-                  >
-                    <Star className="w-3 h-3 " />
-                    {t("wallet-security.method-selector.recommended")}
-                  </Badge>
-                </div>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      <PinSetupModal open={showPinModal} onOpenChange={setShowPinModal} />
-      <OtpSetupModal open={showOtpModal} onOpenChange={setShowOtpModal} />
+      <PinSetupModal open={showModal === "pin"} onOpenChange={setShowModal} />
+      {/* <OtpSetupModal open={showModal === "otp"} onOpenChange={setShowModal} /> */}
     </FormStepLayout>
   );
 }

--- a/kit/dapp/src/components/onboarding/wallet-security/security-method-selector.tsx
+++ b/kit/dapp/src/components/onboarding/wallet-security/security-method-selector.tsx
@@ -183,7 +183,7 @@ export function SecurityMethodSelector() {
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
-                          setShowModal(false);
+                          setShowModal(method.key);
                         }
                       }}
                       tabIndex={0}


### PR DESCRIPTION
## Summary by Sourcery

Disable OTP verification and refactor the security method selector into a data-driven component that dynamically renders available methods (currently only PIN) using a consolidated state and looping logic.

Enhancements:
- Refactor SecurityMethodSelector to use a useMemo-driven `securityMethods` array and map rendering for comparison rows and action buttons
- Consolidate modal visibility into a single `showModal` state keyed by method instead of separate boolean flags
- Comment out OTP configuration and import to remove the OTP option from the UI
- Simplify event handlers for opening and closing modals by updating onKeyDown logic and aria labels

Chores:
- Restrict `onOpenChange` prop types in PinSetupModal and OtpSetupModal to only accept `false`, preventing reopening the modal externally