### PR TITLE
fix: skeleton css styling

### DIFF
--- a/kit/dapp/src/components/charts/chart-skeleton.tsx
+++ b/kit/dapp/src/components/charts/chart-skeleton.tsx
@@ -4,18 +4,18 @@ import { Skeleton } from "@/components/ui/skeleton";
 /**
  * Skeleton loading component for dashboard charts.
  *
- * Provides a consistent loading state for all dashboard chart components
- * with appropriate aspect ratio and shimmer effects.
+ * Uses the card surface palette so loading states blend with cards in both
+ * themes, avoiding the bright accent flash seen in dark mode.
  */
 export function ChartSkeleton() {
   return (
     <Card>
       <CardHeader>
-        <Skeleton className="h-5 w-32" />
-        <Skeleton className="h-3 w-48" />
+        <Skeleton className="h-5 w-32 bg-card/90 dark:bg-card/80" />
+        <Skeleton className="h-3 w-48 bg-card/90 dark:bg-card/80" />
       </CardHeader>
       <CardContent>
-        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-48 w-full rounded-lg border border-border/60 bg-card/95 shadow-inner dark:bg-card/85" />
       </CardContent>
     </Card>
   );

--- a/kit/dapp/src/components/ui/skeleton.tsx
+++ b/kit/dapp/src/components/ui/skeleton.tsx
@@ -1,10 +1,16 @@
 import { cn } from "@/lib/utils";
 
+/**
+ * Provides a surface-toned shimmer so skeletons blend with cards without accent flashes.
+ */
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn(
+        "bg-card/90 dark:bg-card/70 shadow-inner animate-pulse rounded-md",
+        className
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary by Sourcery

Use card surface backgrounds and inner shadows for skeleton loading components to match card styling and avoid bright accent flashes in dark mode.

Enhancements:
- Change default Skeleton component to use surface-toned backgrounds (bg-card/90 dark:bg-card/70) with inner shadows.
- Update ChartSkeleton header and content skeletons to apply card background, border, rounding, and opacity classes for consistent theming.