### PR TITLE
fix: space between related and table

### DIFF
--- a/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/index.tsx
+++ b/kit/dapp/src/routes/_private/_onboarded/_sidebar/token/$factoryAddress/index.tsx
@@ -162,7 +162,7 @@ function RouteComponent() {
         <h1 className="text-3xl font-bold tracking-tight">{factory.name}</h1>
       </div>
 
-      <div className="min-h-full">
+      <div className="min-h-full space-y-8">
         <TokensTable factoryAddress={factoryAddress} />
 
         <TokenFactoryRelated assetType={assetType} />


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add `space-y-8` class to the container div to introduce vertical gap between `TokensTable` and `TokenFactoryRelated`