### PR TITLE
fix: remove loki warnings

### DIFF
--- a/kit/charts/atk/README.md
+++ b/kit/charts/atk/README.md
@@ -166,7 +166,7 @@ The following table lists the configurable parameters of this chart and their de
 | observability.loki.memcached.image.repository | string | `"docker.io/memcached"` | Memcached Docker image repository |
 | observability.loki.memcachedExporter.image.repository | string | `"docker.io/prom/memcached-exporter"` |  |
 | observability.loki.sidecar.image.repository | string | `"docker.io/kiwigrid/k8s-sidecar"` | The Docker registry and image for the k8s sidecar |
-| observability.loki.singleBinary.extraEnv | object | `{}` |  |
+| observability.loki.singleBinary.extraEnv | list | `[]` |  |
 | observability.loki.singleBinary.persistence.size | string | `"10Gi"` |  |
 | observability.loki.singleBinary.resources | object | `{}` |  |
 | observability.metrics-server.enabled | bool | `true` |  |

--- a/kit/charts/atk/values.yaml
+++ b/kit/charts/atk/values.yaml
@@ -338,7 +338,7 @@ observability:
       persistence:
         size: 10Gi
       resources: {}
-      extraEnv: {}
+      extraEnv: []
         # Keep a little bit lower than memory limits
         # - name: GOMEMLIMIT
         #   value: 3750MiB


### PR DESCRIPTION
```
/Users/oleksandrhrab/work/settlemint/asset-tokenization-kit/kit/charts/tools/values-orbstack.yaml
coalesce.go:301: warning: destination for atk.observability.loki.singleBinary.extraEnv is a table. Ignoring non-table value ([])
coalesce.go:301: warning: destination for atk.observability.loki.singleBinary.extraEnv is a table. Ignoring non-table value ([])
coalesce.go:301: warning: destination for atk.observability.loki.singleBinary.extraEnv is a table. Ignoring non-table value ([])
coalesce.go:301: warning: destination for atk.observability.loki.singleBinary.extraEnv is a table. Ignoring non-table value ([])
coalesce.go:301: warning: destination for atk.observability.loki.singleBinary.extraEnv is a table. Ignoring non-table value ([])
Release "atk" has been upgraded. Happy Helming!
```
We don't have after the changes