### PR TITLE
fix: cannot assign default admin role

### DIFF
--- a/packages/zod/src/access-control-roles.ts
+++ b/packages/zod/src/access-control-roles.ts
@@ -61,6 +61,7 @@ export const accessControlRole = z.enum(roles);
 export type AccessControlRole = z.infer<typeof accessControlRole>;
 
 export const assetAccessControlRoles: AccessControlRoles[] = [
+  "admin",
   "custodian",
   "emergency",
   "governance",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add "admin" to the assetAccessControlRoles list to enable default admin role assignment