### PR TITLE
fix: table pagination

### DIFF
--- a/kit/dapp/locales/en-US/data-table.json
+++ b/kit/dapp/locales/en-US/data-table.json
@@ -114,7 +114,7 @@
     }
   },
   "toggleColumns": "Toggle columns",
-  "totalItems": "Total: {{count}}",
+  "totalItems": "Total:",
   "tryAdjustingFilters": "Try adjusting your filters to find what you're looking for",
   "view": "View",
   "viewDetails": "View details"

--- a/kit/dapp/src/components/data-table/data-table-pagination.tsx
+++ b/kit/dapp/src/components/data-table/data-table-pagination.tsx
@@ -120,7 +120,9 @@ export function DataTablePagination<TData>({
           </div>
         ) : (
           <span className="tabular-nums">
-            <span className="text-muted-foreground">Total: </span>
+            <span className="text-muted-foreground pr-1">
+              {t("totalItems")}
+            </span>
             <span className="text-foreground">{totalCount}</span>
           </span>
         )}

--- a/kit/dapp/src/components/data-table/data-table.tsx
+++ b/kit/dapp/src/components/data-table/data-table.tsx
@@ -528,11 +528,7 @@ function DataTableComponent<TData>({
         </div>
       )}
       {table.getRowModel().rows.length > 0 && (
-        <DataTablePagination
-          table={table}
-          {...pagination}
-          totalCount={serverSidePagination?.totalCount}
-        />
+        <DataTablePagination table={table} {...pagination} />
       )}
 
       {/* Bulk Actions Bar */}

--- a/kit/dapp/src/components/tables/token-holders.tsx
+++ b/kit/dapp/src/components/tables/token-holders.tsx
@@ -408,9 +408,6 @@ export function TokenHoldersTable({ token }: TokenHoldersTableProps) {
             // Pagination essential for large holder lists to maintain performance
             // Token holder lists can grow to thousands of entries
             enablePagination: true,
-          }}
-          serverSidePagination={{
-            enabled: false, // We're still doing client-side pagination
             totalCount,
           }}
           initialSorting={INITIAL_SORTING}

--- a/kit/dapp/src/components/tables/tokens.tsx
+++ b/kit/dapp/src/components/tables/tokens.tsx
@@ -647,9 +647,6 @@ export function TokensTable({ factoryAddress }: TokensTableProps) {
         }}
         pagination={{
           enablePagination: true,
-        }}
-        serverSidePagination={{
-          enabled: false, // We're still doing client-side pagination
           totalCount,
         }}
         initialSorting={INITIAL_SORTING}

--- a/kit/dapp/src/components/users/users-table.tsx
+++ b/kit/dapp/src/components/users/users-table.tsx
@@ -179,6 +179,7 @@ export function UsersTable() {
         }}
         pagination={{
           enablePagination: true,
+          totalCount,
         }}
         initialPageSize={20}
         initialSorting={[


### PR DESCRIPTION
## Summary by Sourcery

Streamline DataTable pagination by consolidating totalCount under the pagination prop, removing serverSidePagination usage, and internationalizing the total items label.

Enhancements:
- Deprecate the serverSidePagination.totalCount prop and remove its usage in DataTableComponent
- Pass totalCount directly via the pagination prop in TokenHoldersTable, TokensTable, and UsersTable
- Replace the hardcoded "Total:" label in DataTablePagination with an internationalized "totalItems" key

Documentation:
- Add a "totalItems" entry to data-table.json for the new translation key

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pagination now reads totalCount from pagination options with a localized "Total:" label, and client-side tables drop redundant serverSidePagination usage.
> 
> - **Data Table**:
>   - **Pagination**: `DataTable` no longer forwards `serverSidePagination.totalCount`; `DataTablePagination` expects `pagination.totalCount` and uses `t("totalItems")` for the label.
> - **Tables**:
>   - `tokens.tsx`, `token-holders.tsx`: Move `totalCount` into `pagination` and remove `serverSidePagination` (client-side pagination remains).
>   - `users-table.tsx`: Add `totalCount` to `pagination` while keeping `serverSidePagination.enabled` for server-driven paging.
> - **i18n**:
>   - Update `en-US/data-table.json`: change `totalItems` to "Total:" (no interpolation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45b49dc3830845fd39a45935008b2650b6875ac6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->