### PR TITLE
fix: hide airdrops / xvp addons

### DIFF
--- a/kit/dapp/src/components/system-addons/management/addons-management.tsx
+++ b/kit/dapp/src/components/system-addons/management/addons-management.tsx
@@ -25,6 +25,8 @@ import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
+const AVAILABLE_ADDONS = addonTypes.filter((type) => type === "yield");
+
 export function AddonsManagement() {
   const { t } = useTranslation(["onboarding", "common"]);
   const queryClient = useQueryClient();
@@ -151,8 +153,7 @@ export function AddonsManagement() {
     );
   }
 
-  const availableAddons = addonTypes;
-  const hasUndeployedAddons = availableAddons.some(
+  const hasUndeployedAddons = AVAILABLE_ADDONS.some(
     (addon) => !deployedAddons.has(addon)
   );
 
@@ -178,7 +179,7 @@ export function AddonsManagement() {
             )}
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {availableAddons.map((addonType) => {
+              {AVAILABLE_ADDONS.map((addonType) => {
                 const Icon = getAddonIcon(addonType);
                 const isDeployed = deployedAddons.has(addonType);
                 const isSelected = selectedAddons.some(

--- a/kit/dapp/src/components/system-addons/onboarding/system-addons-selection.tsx
+++ b/kit/dapp/src/components/system-addons/onboarding/system-addons-selection.tsx
@@ -22,6 +22,8 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
+const AVAILABLE_ADDONS = addonTypes.filter((type) => type === "yield");
+
 export function SystemAddonsSelection() {
   const { refreshUserState } = useOnboardingNavigation();
   const { t } = useTranslation(["onboarding", "common"]);
@@ -53,28 +55,12 @@ export function SystemAddonsSelection() {
       ),
     [systemDetails?.systemAddonRegistry.systemAddons]
   );
-  // Temporarily hide airdrops and xvp from selection
-  const visibleAddonTypes = useMemo<
-    Exclude<(typeof addonTypes)[number], "airdrops" | "xvp">[]
-  >(
-    () =>
-      addonTypes.filter(
-        (a): a is Exclude<(typeof addonTypes)[number], "airdrops" | "xvp"> =>
-          a !== "airdrops" && a !== "xvp"
-      ),
-    []
-  );
 
   const deployedAddonsConfig = useMemo(() => {
-    return [...deployedAddons]
-      .filter(
-        (addon): addon is (typeof visibleAddonTypes)[number] =>
-          addon !== "airdrops" && addon !== "xvp"
-      )
-      .map((addon) => ({
-        type: addon,
-        name: t(`system-addons.addon-selection.addon-types.${addon}.title`),
-      }));
+    return [...deployedAddons].map((addon) => ({
+      type: addon,
+      name: t(`system-addons.addon-selection.addon-types.${addon}.title`),
+    }));
   }, [deployedAddons, t]);
 
   const form = useAppForm({
@@ -132,8 +118,6 @@ export function SystemAddonsSelection() {
   const { mutateAsync: updateSetting } = useMutation(
     orpc.settings.upsert.mutationOptions()
   );
-
-  const availableAddons = visibleAddonTypes;
 
   const handleAddAddon = (addon: SystemAddonConfig) => {
     const alreadyIncluded = form.state.values.addons.some(
@@ -264,7 +248,7 @@ export function SystemAddonsSelection() {
                           </p>
                         </div>
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                          {availableAddons.map((addon) => {
+                          {AVAILABLE_ADDONS.map((addon) => {
                             const Icon = getAddonIcon(addon);
                             const isYieldRequiredForBond =
                               addon === "yield" && hasBondFactory;


### PR DESCRIPTION
## Summary by Sourcery

Restrict addon visibility to only the "yield" addon by filtering out deprecated "airdrops" and "xvp" in both the SystemAddonsSelection and AddonsManagement components

Bug Fixes:
- Hide airdrops and xvp addons on onboarding and management screens

Enhancements:
- Introduce AVAILABLE_ADDONS constant to centralize and restrict visible addons to only yield

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits selectable addons to only `yield` across management and onboarding flows, replacing prior filtering logic and simplifying deployed addon config handling.
> 
> - **System Addons**:
>   - **Selection restricted**: Introduce `AVAILABLE_ADDONS = addonTypes.filter((type) => type === "yield")` and use it for rendering and checks in `system-addons/onboarding/system-addons-selection.tsx` and `system-addons/management/addons-management.tsx`.
>   - **Logic cleanup**:
>     - Remove `visibleAddonTypes` and special-case filtering for `airdrops`/`xvp`; selection lists now derive from `AVAILABLE_ADDONS`.
>     - Simplify `deployedAddonsConfig` to include all deployed addons without filtering.
>   - **UI impact**: Only the `yield` addon appears selectable; existing disable/required states remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d31d69107c3a2d46106080828261f570ae8b34f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->