### PR TITLE
docs: add ghcr login instructions

### DIFF
--- a/kit/docs/content/docs/04-development-environment.md
+++ b/kit/docs/content/docs/04-development-environment.md
@@ -133,6 +133,15 @@ The architecture provides complete separation of concerns while maintaining tigh
 | **Docker Compose** | Latest | Included with Docker Desktop | `docker compose version` |
 | **Git** | Latest | System package manager | `git --version` |
 
+### Authenticate with GitHub Container Registry (GHCR)
+
+Many Docker images used by the development environment are hosted on the GitHub Container Registry. Authenticate once per machine so Docker can pull private SettleMint images:
+
+1. Create a [GitHub Personal Access Token](https://github.com/settings/tokens) with the `read:packages` scope (include `write:packages` if you push images).
+2. Run `echo <token> | docker login ghcr.io -u <github-username> --password-stdin` to store credentials securely in the Docker credential helper.
+3. Verify access with `docker pull ghcr.io/settlemint/asset-tokenization-kit:latest` (or any image you are authorized to use).
+4. Repeat the login on any additional machines or after clearing Docker credentials.
+
 ### Initial Setup Process
 
 ```mermaid


### PR DESCRIPTION
## Summary
- add GitHub Container Registry authentication guidance to the development environment documentation

## Testing
- bun run lint *(fails: forge build requires downloading Solidity binaries; network is unreachable in the execution environment)*
- bun run typecheck *(fails: helm-docs binary is not available in the execution environment)*
- bun run test *(fails: forge build requires downloading Solidity binaries; network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e524d4f2d883328df26b24a74e38ca

## Summary by Sourcery

Documentation:
- Add a GHCR authentication section outlining how to generate a PAT, log in via Docker, and verify access to private SettleMint images

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GHCR authentication section with PAT creation, docker login, and image pull verification to the development environment docs.
> 
> - **Documentation**:
>   - **Development Environment Guide** (`kit/docs/content/docs/04-development-environment.md`):
>     - Add GHCR authentication section: create `read:packages` token, `docker login ghcr.io` via `--password-stdin`, verify with `docker pull ghcr.io/settlemint/asset-tokenization-kit:latest`, note re-login guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16cded979ee9f78500c2e8166965c0c571ed1952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->