### PR TITLE
fix: run codestudion before release assets pull request

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -230,6 +230,14 @@ jobs:
         run: |
           bun run docs
 
+      # Build Codestudio before release PR resets the workspace to the tagged commit
+      - name: Build and Push Codestudio
+        if: |
+          github.event_name == 'push' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        run: |
+          bun run docker:codestudio
+
       - name: Create release assets pull request
         if: |
           github.event_name == 'push' &&
@@ -343,13 +351,6 @@ jobs:
           qa_status: ${{ steps.pr-review-check.outputs.qa_status }}
           is_draft: ${{ github.event.pull_request.draft }}
           merge_method: "squash"
-
-      - name: Build and Push Codestudio
-        if: |
-          github.event_name == 'push' &&
-          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-        run: |
-          bun run docker:codestudio
 
   # Handle merged PR notifications
   merged:

--- a/kit/charts/atk/Chart.lock
+++ b/kit/charts/atk/Chart.lock
@@ -1,36 +1,36 @@
 dependencies:
 - name: support
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: observability
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: network
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: erpc
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: ipfs
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: blockscout
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: graph-node
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: portal
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: hasura
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: txsigner
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: dapp
   repository: ""
-  version: 2.0.0-alpha.18
-digest: sha256:3023ebae9e3d12bd4a940cd2cf32dc5d3937a1fc562a01ca689699b6efd9303e
-generated: "2025-10-04T08:02:09.068878+02:00"
+  version: 2.0.0-beta.2
+digest: sha256:05a24623cdc9e0e3af568c9ec0dd53452a3a87b31a9cc6960c1f0ae2546b60b7
+generated: "2025-10-08T15:19:58.069211+03:00"

--- a/kit/charts/atk/README.md
+++ b/kit/charts/atk/README.md
@@ -18,7 +18,7 @@ The following table lists the configurable parameters of this chart and their de
 |blockscout.blockscout.env.API_URL|string|`"https://explorer.k8s.orb.local"`|API URL for Blockscout backend|
 |blockscout.blockscout.env.WEBAPP_URL|string|`"https://explorer.k8s.orb.local"`|Web app URL for Blockscout frontend|
 |blockscout.blockscout.image|object|-|Blockscout backend container image|
-|blockscout.blockscout.image.repository|string|`"harbor.settlemint.com/ghcr.io/blockscout/blockscout"`|OCI registry and repository for Blockscout backend|
+|blockscout.blockscout.image.repository|string|`"ghcr.io/blockscout/blockscout"`|OCI registry and repository for Blockscout backend|
 |blockscout.blockscout.ingress|object|-|Ingress configuration for Blockscout backend|
 |blockscout.blockscout.ingress.className|string|`"atk-nginx"`|IngressClass for Blockscout|
 |blockscout.blockscout.ingress.enabled|bool|`true`|Enable ingress for Blockscout API|
@@ -26,7 +26,7 @@ The following table lists the configurable parameters of this chart and their de
 |blockscout.blockscout.initContainer|object|-|Init container for database readiness|
 |blockscout.blockscout.initContainer.tcpCheck|object|-|TCP check for PostgreSQL|
 |blockscout.blockscout.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|blockscout.blockscout.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|blockscout.blockscout.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |blockscout.blockscout.openShiftRoute|object|-|OpenShift Route configuration|
 |blockscout.blockscout.openShiftRoute.enabled|bool|`false`|Enable OpenShift route|
 |blockscout.blockscout.openShiftRoute.host|string|`"explorer.k8s.orb.local"`|Hostname for OpenShift route|
@@ -39,7 +39,7 @@ The following table lists the configurable parameters of this chart and their de
 |blockscout.frontend|object|-|Blockscout frontend service configuration|
 |blockscout.frontend.enabled|bool|`true`|Enable Blockscout frontend deployment|
 |blockscout.frontend.image|object|-|Blockscout frontend container image|
-|blockscout.frontend.image.repository|string|`"harbor.settlemint.com/ghcr.io/blockscout/frontend"`|OCI registry and repository for Blockscout frontend|
+|blockscout.frontend.image.repository|string|`"ghcr.io/blockscout/frontend"`|OCI registry and repository for Blockscout frontend|
 |blockscout.frontend.ingress|object|-|Ingress configuration for Blockscout UI|
 |blockscout.frontend.ingress.className|string|`"atk-nginx"`|IngressClass for frontend|
 |blockscout.frontend.ingress.enabled|bool|`true`|Enable ingress for frontend|
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of this chart and their de
 |dapp|object|-|DApp frontend application configuration|
 |dapp.enabled|bool|`true`|Enable deployment of the Asset Tokenization Kit web application|
 |dapp.image|object|-|DApp container image configuration|
-|dapp.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/asset-tokenization-kit"`|OCI registry and repository for DApp frontend|
+|dapp.image.repository|string|`"ghcr.io/settlemint/asset-tokenization-kit"`|OCI registry and repository for DApp frontend|
 |dapp.ingress|object|-|Ingress configuration for DApp web interface|
 |dapp.ingress.enabled|bool|`true`|Enable ingress for web application access|
 |dapp.ingress.hosts|list|-|Ingress host rules for DApp|
@@ -63,13 +63,13 @@ The following table lists the configurable parameters of this chart and their de
 |dapp.initContainer|object|-|Init containers for DApp startup dependencies|
 |dapp.initContainer.graphQLCheck|object|-|GraphQL endpoint readiness check|
 |dapp.initContainer.graphQLCheck.image|object|-|curl utility for GraphQL health checks|
-|dapp.initContainer.graphQLCheck.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for curl image|
+|dapp.initContainer.graphQLCheck.image.registry|string|`"docker.io"`|OCI registry for curl image|
 |dapp.initContainer.tcpCheck|object|-|TCP check for backend services|
 |dapp.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|dapp.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|dapp.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |dapp.job|object|-|Post-deployment job configuration for database migrations|
 |dapp.job.image|object|-|Job container image|
-|dapp.job.image.repository|string|`"harbor.settlemint.com/docker.io/node"`|Node.js runtime image for migration scripts|
+|dapp.job.image.repository|string|`"docker.io/node"`|Node.js runtime image for migration scripts|
 |dapp.resources|object|-|Resource requests and limits for DApp pods|
 |dapp.resources.limits.cpu|string|`"3000m"`|CPU limit for DApp pods|
 |dapp.resources.limits.memory|string|`"2048Mi"`|Memory limit for DApp pods|
@@ -81,7 +81,7 @@ The following table lists the configurable parameters of this chart and their de
 |erpc|object|-|ERPC Gateway configuration for RPC load balancing and caching|
 |erpc.enabled|bool|`true`|Enable deployment of ERPC gateway|
 |erpc.image|object|-|ERPC container image|
-|erpc.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|OCI registry for ERPC image|
+|erpc.image.registry|string|`"ghcr.io"`|OCI registry for ERPC image|
 |erpc.ingress|object|-|Ingress configuration for exposing RPC endpoint|
 |erpc.ingress.enabled|bool|`true`|Enable ingress for external RPC access|
 |erpc.ingress.hostname|string|`"rpc.k8s.orb.local"`|Hostname for RPC endpoint. Update for your environment.|
@@ -89,7 +89,7 @@ The following table lists the configurable parameters of this chart and their de
 |erpc.initContainer|object|-|Init container for startup dependency checks|
 |erpc.initContainer.tcpCheck|object|-|TCP readiness check|
 |erpc.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|erpc.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|erpc.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |erpc.openShiftRoute|object|-|OpenShift Route configuration (alternative to Ingress)|
 |erpc.openShiftRoute.enabled|bool|`false`|Enable OpenShift route instead of standard ingress|
 |erpc.openShiftRoute.host|string|`"rpc.k8s.orb.local"`|Hostname for OpenShift route|
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of this chart and their de
 |erpc.resources.requests.memory|string|`"256Mi"`|Memory request for ERPC pods|
 |erpc.tests|object|-|Test container image for ERPC health checks|
 |erpc.tests.image|object|-|Test image configuration|
-|erpc.tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for test utilities|
+|erpc.tests.image.registry|string|`"docker.io"`|OCI registry for test utilities|
 |global|object|-|Global configuration shared across all subcharts|
 |global.chainId|string|`"53771311147"`|Blockchain chain ID used across all network components|
 |global.chainName|string|`"ATK"`|Human-readable name for the blockchain network|
@@ -158,9 +158,9 @@ The following table lists the configurable parameters of this chart and their de
 |graph-node|object|-|The Graph Node configuration for blockchain indexing|
 |graph-node.enabled|bool|`true`|Enable deployment of The Graph indexing protocol|
 |graph-node.global|object|-|Override shared artifacts image configuration|
-|graph-node.global.artifacts.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|OCI registry for shared Graph Node artifacts|
+|graph-node.global.artifacts.image.registry|string|`"ghcr.io"`|OCI registry for shared Graph Node artifacts|
 |graph-node.image|object|-|Graph Node container image|
-|graph-node.image.repository|string|`"harbor.settlemint.com/docker.io/graphprotocol/graph-node"`|OCI registry and repository for Graph Node|
+|graph-node.image.repository|string|`"docker.io/graphprotocol/graph-node"`|OCI registry and repository for Graph Node|
 |graph-node.ingress|object|-|Ingress configuration for Graph Node API|
 |graph-node.ingress.annotations|object|-|Ingress annotations for URL rewriting|
 |graph-node.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target"|string|`"/$1"`|Rewrite target for path normalization|
@@ -186,10 +186,10 @@ The following table lists the configurable parameters of this chart and their de
 |graph-node.ingress.paths[4].servicePortName|string|`"http-status"`|Service port name serving graphman APIs|
 |graph-node.initContainer|object|-|Init containers for Graph Node startup|
 |graph-node.initContainer.image|object|-|Kubernetes client utility for pre-deployment tasks|
-|graph-node.initContainer.image.repository|string|`"harbor.settlemint.com/docker.io/kubesphere/kubectl"`|kubectl utility image repository|
+|graph-node.initContainer.image.repository|string|`"docker.io/kubesphere/kubectl"`|kubectl utility image repository|
 |graph-node.initContainer.tcpCheck|object|-|TCP check for dependencies|
 |graph-node.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|graph-node.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|graph-node.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |graph-node.openShiftRoute|object|-|OpenShift Route configuration|
 |graph-node.openShiftRoute.enabled|bool|`false`|Enable OpenShift route|
 |graph-node.openShiftRoute.host|string|`"graph.k8s.orb.local"`|Hostname for OpenShift route|
@@ -203,7 +203,7 @@ The following table lists the configurable parameters of this chart and their de
 |hasura.fullnameOverride|string|`"hasura"`|Override fullname to simplify service discovery|
 |hasura.image|object|-|Hasura container image configuration|
 |hasura.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy|
-|hasura.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for Hasura image|
+|hasura.image.registry|string|`"docker.io"`|OCI registry for Hasura image|
 |hasura.image.repository|string|`"hasura/graphql-engine"`|Hasura image repository|
 |hasura.image.tag|string|`"v2.48.6"`|Hasura version tag|
 |hasura.ingress|object|-|Ingress configuration for Hasura console and API|
@@ -218,7 +218,7 @@ The following table lists the configurable parameters of this chart and their de
 |hasura.resources.requests.memory|string|`"384Mi"`|Memory request for Hasura pods|
 |ipfs|object|-|IPFS Cluster deployment configuration|
 |ipfs.cluster|object|-|IPFS Cluster control-plane configuration overrides|
-|ipfs.cluster.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for the cluster control-plane image|
+|ipfs.cluster.image.registry|string|`"docker.io"`|OCI registry for the cluster control-plane image|
 |ipfs.cluster.resources|object|-|Resource requests and limits for IPFS Cluster control-plane pods|
 |ipfs.cluster.resources.limits.cpu|string|`"360m"`|CPU limit for cluster pods|
 |ipfs.cluster.resources.limits.memory|string|`"512Mi"`|Memory limit for cluster pods|
@@ -231,27 +231,27 @@ The following table lists the configurable parameters of this chart and their de
 |ipfs.ingress.hostnames.api|string|`"ipfs-cluster.k8s.orb.local"`|Primary hostname serving the IPFS cluster API|
 |ipfs.ingress.ingressClassName|string|`"atk-nginx"`|IngressClass for IPFS cluster ingress resources (Kubernetes 1.19+ standard)|
 |ipfs.ipfs|object|-|IPFS peer configuration overrides|
-|ipfs.ipfs.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for the Kubo image|
+|ipfs.ipfs.image.registry|string|`"docker.io"`|OCI registry for the Kubo image|
 |ipfs.ipfs.resources|object|-|Resource requests and limits for IPFS peer pods|
 |ipfs.ipfs.resources.limits.cpu|string|`"900m"`|CPU limit for IPFS pods|
 |ipfs.ipfs.resources.limits.memory|string|`"1024Mi"`|Memory limit for IPFS pods|
 |ipfs.ipfs.resources.requests.cpu|string|`"150m"`|CPU request for IPFS pods|
 |ipfs.ipfs.resources.requests.memory|string|`"512Mi"`|Memory request for IPFS pods|
 |ipfs.tests|object|-|Test pod image configuration|
-|ipfs.tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|Container registry hosting the chart test image|
+|ipfs.tests.image.registry|string|`"docker.io"`|Container registry hosting the chart test image|
 |network|object|-|Blockchain network infrastructure configuration|
 |network.enabled|bool|`true`|Enable deployment of the blockchain network (validators and RPC nodes)|
 |network.network-bootstrapper|object|-|Network bootstrapper job configuration for genesis and initial setup|
 |network.network-bootstrapper.artifacts|object|-|Pre-deployed contract artifacts configuration|
 |network.network-bootstrapper.artifacts.predeployed|object|-|Configuration for pre-deployed smart contracts in genesis|
 |network.network-bootstrapper.artifacts.predeployed.image|object|-|Image containing pre-deployed contract bytecode|
-|network.network-bootstrapper.artifacts.predeployed.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|OCI registry for pre-deployed artifacts|
+|network.network-bootstrapper.artifacts.predeployed.image.registry|string|`"ghcr.io"`|OCI registry for pre-deployed artifacts|
 |network.network-bootstrapper.image|object|-|Container image for the network bootstrapper job|
-|network.network-bootstrapper.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/network-bootstrapper"`|OCI registry and repository for network bootstrapper|
+|network.network-bootstrapper.image.repository|string|`"ghcr.io/settlemint/network-bootstrapper"`|OCI registry and repository for network bootstrapper|
 |network.network-bootstrapper.initContainer|object|-|Init container configuration for dependency checking|
 |network.network-bootstrapper.initContainer.tcpCheck|object|-|TCP readiness check init container|
 |network.network-bootstrapper.initContainer.tcpCheck.image|object|-|Wait-for-it utility image for TCP checks|
-|network.network-bootstrapper.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|network.network-bootstrapper.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |network.network-bootstrapper.resources|object|-|Resource requests and limits for the bootstrapper job|
 |network.network-bootstrapper.resources.limits.cpu|string|`"600m"`|CPU limit for bootstrapper pods|
 |network.network-bootstrapper.resources.limits.memory|string|`"256Mi"`|Memory limit for bootstrapper pods|
@@ -264,11 +264,11 @@ The following table lists the configurable parameters of this chart and their de
 |network.network-nodes.compileGenesis.resources.requests.cpu|string|`"100m"`|CPU request for genesis compilation|
 |network.network-nodes.compileGenesis.resources.requests.memory|string|`"128Mi"`|Memory request for genesis compilation|
 |network.network-nodes.image|object|-|Hyperledger Besu container image|
-|network.network-nodes.image.repository|string|`"harbor.settlemint.com/docker.io/hyperledger/besu"`|OCI registry and repository for Besu nodes|
+|network.network-nodes.image.repository|string|`"docker.io/hyperledger/besu"`|OCI registry and repository for Besu nodes|
 |network.network-nodes.initContainer|object|-|Init container for node startup dependencies|
 |network.network-nodes.initContainer.tcpCheck|object|-|TCP check before node starts|
 |network.network-nodes.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|network.network-nodes.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|network.network-nodes.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |network.network-nodes.persistence|object|-|Persistent storage configuration for blockchain data|
 |network.network-nodes.persistence.size|string|`"20Gi"`|Storage size for each blockchain node (ledger data)|
 |network.network-nodes.replicaCount|int|`2`|Total Besu pod replicas (validators + RPC). Used for resource summaries.|
@@ -289,15 +289,15 @@ The following table lists the configurable parameters of this chart and their de
 |observability.alloy.alloy.resources.requests.memory|string|`"512Mi"`|Memory request for Alloy pods|
 |observability.alloy.configReloader|object|-|Config reloader sidecar|
 |observability.alloy.configReloader.image|object|-|Config reloader image|
-|observability.alloy.configReloader.image.registry|string|`"harbor.settlemint.com/quay.io"`|OCI registry for config reloader|
+|observability.alloy.configReloader.image.registry|string|`"quay.io"`|OCI registry for config reloader|
 |observability.alloy.image|object|-|Alloy container image|
-|observability.alloy.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for Alloy|
+|observability.alloy.image.registry|string|`"docker.io"`|OCI registry for Alloy|
 |observability.enabled|bool|`true`|Enable deployment of observability infrastructure|
 |observability.grafana|object|-|Grafana visualization and dashboarding|
 |observability.grafana.adminPassword|string|`"atk"`|Grafana admin password. Change for production deployments.|
 |observability.grafana.adminUser|string|`"settlemint"`|Grafana admin username. Change for production deployments.|
 |observability.grafana.image|object|-|Grafana container image|
-|observability.grafana.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for Grafana|
+|observability.grafana.image.registry|string|`"docker.io"`|OCI registry for Grafana|
 |observability.grafana.ingress|object|-|Ingress configuration for Grafana UI|
 |observability.grafana.ingress.hosts|list|-|Hostnames for Grafana access|
 |observability.grafana.resources|object|-|Resource requests and limits for Grafana pods|
@@ -307,10 +307,10 @@ The following table lists the configurable parameters of this chart and their de
 |observability.grafana.resources.requests.memory|string|`"256Mi"`|Memory request for Grafana pods|
 |observability.grafana.sidecar|object|-|Sidecar for dashboard provisioning|
 |observability.grafana.sidecar.image|object|-|Sidecar container image|
-|observability.grafana.sidecar.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for sidecar|
+|observability.grafana.sidecar.image.registry|string|`"docker.io"`|OCI registry for sidecar|
 |observability.kube-state-metrics|object|-|Kube State Metrics for cluster-level metrics|
 |observability.kube-state-metrics.image|object|-|Kube state metrics container image|
-|observability.kube-state-metrics.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|OCI registry for kube-state-metrics|
+|observability.kube-state-metrics.image.registry|string|`"registry.k8s.io"`|OCI registry for kube-state-metrics|
 |observability.kube-state-metrics.resources|object|-|Resource requests and limits for kube-state-metrics|
 |observability.kube-state-metrics.resources.limits.cpu|string|`"240m"`|CPU limit for kube-state-metrics pods|
 |observability.kube-state-metrics.resources.limits.memory|string|`"256Mi"`|Memory limit for kube-state-metrics pods|
@@ -319,7 +319,7 @@ The following table lists the configurable parameters of this chart and their de
 |observability.loki|object|-|Loki log aggregation system|
 |observability.loki.gateway|object|-|Loki gateway for load balancing|
 |observability.loki.gateway.image|object|-|Gateway container image|
-|observability.loki.gateway.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for gateway image|
+|observability.loki.gateway.image.registry|string|`"docker.io"`|OCI registry for gateway image|
 |observability.loki.gateway.resources|object|-|Resource requests and limits for Loki gateway pods|
 |observability.loki.gateway.resources.limits.cpu|string|`"120m"`|CPU limit for gateway pods|
 |observability.loki.gateway.resources.limits.memory|string|`"64Mi"`|Memory limit for gateway pods|
@@ -327,11 +327,11 @@ The following table lists the configurable parameters of this chart and their de
 |observability.loki.gateway.resources.requests.memory|string|`"32Mi"`|Memory request for gateway pods|
 |observability.loki.loki|object|-|Loki server configuration|
 |observability.loki.loki.image|object|-|Loki container image|
-|observability.loki.loki.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for Loki|
+|observability.loki.loki.image.registry|string|`"docker.io"`|OCI registry for Loki|
 |observability.loki.memcached|object|-|Memcached for Loki query result caching|
 |observability.loki.memcached.enabled|bool|`true`|Enable memcached deployment|
 |observability.loki.memcached.image|object|-|Memcached container image|
-|observability.loki.memcached.image.repository|string|`"harbor.settlemint.com/docker.io/memcached"`|Memcached image repository|
+|observability.loki.memcached.image.repository|string|`"docker.io/memcached"`|Memcached image repository|
 |observability.loki.memcached.resources|object|-|Resource requests and limits for Loki memcached pods|
 |observability.loki.memcached.resources.limits.cpu|string|`"240m"`|CPU limit for memcached pods|
 |observability.loki.memcached.resources.limits.memory|string|`"96Mi"`|Memory limit for memcached pods|
@@ -339,7 +339,7 @@ The following table lists the configurable parameters of this chart and their de
 |observability.loki.memcached.resources.requests.memory|string|`"48Mi"`|Memory request for memcached pods|
 |observability.loki.memcachedExporter|object|-|Memcached exporter for Prometheus metrics|
 |observability.loki.memcachedExporter.image|object|-|Memcached exporter image|
-|observability.loki.memcachedExporter.image.repository|string|`"harbor.settlemint.com/docker.io/prom/memcached-exporter"`|Prometheus memcached exporter repository|
+|observability.loki.memcachedExporter.image.repository|string|`"docker.io/prom/memcached-exporter"`|Prometheus memcached exporter repository|
 |observability.loki.memcachedExporter.resources|object|-|Resource requests and limits for memcached exporter pods|
 |observability.loki.memcachedExporter.resources.limits.cpu|string|`"60m"`|CPU limit for memcached exporter pods|
 |observability.loki.memcachedExporter.resources.limits.memory|string|`"48Mi"`|Memory limit for memcached exporter pods|
@@ -347,7 +347,7 @@ The following table lists the configurable parameters of this chart and their de
 |observability.loki.memcachedExporter.resources.requests.memory|string|`"24Mi"`|Memory request for memcached exporter pods|
 |observability.loki.sidecar|object|-|Kubernetes sidecar for dynamic configuration|
 |observability.loki.sidecar.image|object|-|Sidecar container image|
-|observability.loki.sidecar.image.repository|string|`"harbor.settlemint.com/docker.io/kiwigrid/k8s-sidecar"`|k8s-sidecar image repository|
+|observability.loki.sidecar.image.repository|string|`"docker.io/kiwigrid/k8s-sidecar"`|k8s-sidecar image repository|
 |observability.loki.sidecar.resources|object|-|Resource requests and limits for Loki sidecar pods|
 |observability.loki.sidecar.resources.limits.cpu|string|`"720m"`|CPU limit for sidecar pods|
 |observability.loki.sidecar.resources.limits.memory|string|`"192Mi"`|Memory limit for sidecar pods|
@@ -365,7 +365,7 @@ The following table lists the configurable parameters of this chart and their de
 |observability.metrics-server|object|-|Kubernetes Metrics Server for resource metrics|
 |observability.metrics-server.enabled|bool|`true`|Enable Metrics Server deployment|
 |observability.metrics-server.image|object|-|Metrics Server container image|
-|observability.metrics-server.image.repository|string|`"harbor.settlemint.com/registry.k8s.io/metrics-server/metrics-server"`|Official Kubernetes metrics-server image|
+|observability.metrics-server.image.repository|string|`"registry.k8s.io/metrics-server/metrics-server"`|Official Kubernetes metrics-server image|
 |observability.metrics-server.resources|object|-|Resource requests and limits for Metrics Server|
 |observability.metrics-server.resources.limits.cpu|string|`"360m"`|CPU limit for Metrics Server pods|
 |observability.metrics-server.resources.limits.memory|string|`"256Mi"`|Memory limit for Metrics Server pods|
@@ -373,8 +373,8 @@ The following table lists the configurable parameters of this chart and their de
 |observability.metrics-server.resources.requests.memory|string|`"128Mi"`|Memory request for Metrics Server pods|
 |observability.prometheus-node-exporter|object|-|Prometheus Node Exporter for host metrics|
 |observability.prometheus-node-exporter.image|object|-|Node exporter container image|
-|observability.prometheus-node-exporter.image.registry|string|`"harbor.settlemint.com/quay.io"`|OCI registry for node exporter|
-|observability.prometheus-node-exporter.kubeRBACProxy.image.registry|string|`"harbor.settlemint.com/quay.io"`|OCI registry for kube-rbac-proxy sidecar|
+|observability.prometheus-node-exporter.image.registry|string|`"quay.io"`|OCI registry for node exporter|
+|observability.prometheus-node-exporter.kubeRBACProxy.image.registry|string|`"quay.io"`|OCI registry for kube-rbac-proxy sidecar|
 |observability.prometheus-node-exporter.resources|object|-|Resource requests and limits for node exporter DaemonSet|
 |observability.prometheus-node-exporter.resources.limits.cpu|string|`"180m"`|CPU limit for node exporter pods|
 |observability.prometheus-node-exporter.resources.limits.memory|string|`"64Mi"`|Memory limit for node exporter pods|
@@ -388,15 +388,15 @@ The following table lists the configurable parameters of this chart and their de
 |observability.tempo.server.resources.requests.cpu|string|`"60m"`|CPU request for Tempo pods|
 |observability.tempo.server.resources.requests.memory|string|`"160Mi"`|Memory request for Tempo pods|
 |observability.tempo.tempo|object|-|Tempo server image configuration|
-|observability.tempo.tempo.repository|string|`"harbor.settlemint.com/docker.io/grafana/tempo"`|Tempo image repository|
+|observability.tempo.tempo.repository|string|`"docker.io/grafana/tempo"`|Tempo image repository|
 |observability.tempo.tempoQuery|object|-|Tempo query frontend image|
-|observability.tempo.tempoQuery.repository|string|`"harbor.settlemint.com/docker.io/grafana/tempo-query"`|Tempo query image repository|
+|observability.tempo.tempoQuery.repository|string|`"docker.io/grafana/tempo-query"`|Tempo query image repository|
 |observability.victoria-metrics-single|object|-|VictoriaMetrics time-series database for metrics storage|
 |observability.victoria-metrics-single.global|object|-|Global VictoriaMetrics image configuration|
-|observability.victoria-metrics-single.global.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for VictoriaMetrics shared components|
+|observability.victoria-metrics-single.global.image.registry|string|`"docker.io"`|OCI registry for VictoriaMetrics shared components|
 |observability.victoria-metrics-single.server|object|-|VictoriaMetrics server configuration|
 |observability.victoria-metrics-single.server.image|object|-|VictoriaMetrics container image|
-|observability.victoria-metrics-single.server.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for VictoriaMetrics|
+|observability.victoria-metrics-single.server.image.registry|string|`"docker.io"`|OCI registry for VictoriaMetrics|
 |observability.victoria-metrics-single.server.persistentVolume|object|-|Persistent storage for metrics data|
 |observability.victoria-metrics-single.server.persistentVolume.size|string|`"10Gi"`|Storage size for metrics retention|
 |observability.victoria-metrics-single.server.persistentVolume.storageClass|string|`""`|StorageClass for metrics volume (empty uses cluster default)|
@@ -408,7 +408,7 @@ The following table lists the configurable parameters of this chart and their de
 |portal|object|-|Portal identity and access management configuration|
 |portal.enabled|bool|`true`|Enable deployment of Portal IAM service|
 |portal.image|object|-|Portal container image|
-|portal.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|OCI registry for Portal image|
+|portal.image.registry|string|`"ghcr.io"`|OCI registry for Portal image|
 |portal.ingress|object|-|Ingress configuration for Portal API|
 |portal.ingress.enabled|bool|`true`|Enable ingress exposure for Portal|
 |portal.ingress.hostname|string|`"portal.k8s.orb.local"`|Hostname for Portal service. Update for your environment.|
@@ -416,24 +416,24 @@ The following table lists the configurable parameters of this chart and their de
 |portal.initContainer|object|-|Init container for dependency checks|
 |portal.initContainer.tcpCheck|object|-|TCP check for database readiness|
 |portal.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|portal.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|portal.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |portal.resources|object|-|Resource requests and limits for Portal pods|
 |portal.resources.limits.cpu|string|`"360m"`|CPU limit for Portal pods|
 |portal.resources.limits.memory|string|`"512Mi"`|Memory limit for Portal pods|
 |portal.resources.requests.cpu|string|`"60m"`|CPU request for Portal pods|
 |portal.resources.requests.memory|string|`"256Mi"`|Memory request for Portal pods|
 |portal.tests|object|-|Test pod image configuration|
-|portal.tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for Portal test utilities|
+|portal.tests.image.registry|string|`"docker.io"`|OCI registry for Portal test utilities|
 |support|object|-|Support infrastructure (ingress, reloader, databases, object storage)|
 |support.enabled|bool|`true`|Enable deployment of support infrastructure components|
 |support.ingress-nginx|object|-|NGINX Ingress Controller configuration|
 |support.ingress-nginx.controller|object|-|Ingress controller configuration|
 |support.ingress-nginx.controller.image|object|-|Ingress controller container image|
-|support.ingress-nginx.controller.image.repository|string|`"harbor.settlemint.com/registry.k8s.io/ingress-nginx/controller"`|Official Kubernetes ingress-nginx controller image|
+|support.ingress-nginx.controller.image.repository|string|`"registry.k8s.io/ingress-nginx/controller"`|Official Kubernetes ingress-nginx controller image|
 |support.ingress-nginx.controller.opentelemetry|object|-|OpenTelemetry sidecar image configuration|
-|support.ingress-nginx.controller.opentelemetry.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|OCI registry for OpenTelemetry collector|
+|support.ingress-nginx.controller.opentelemetry.image.registry|string|`"registry.k8s.io"`|OCI registry for OpenTelemetry collector|
 |support.ingress-nginx.controller.patch|object|-|Patch job image configuration|
-|support.ingress-nginx.controller.patch.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|OCI registry for ingress-nginx patch job|
+|support.ingress-nginx.controller.patch.image.registry|string|`"registry.k8s.io"`|OCI registry for ingress-nginx patch job|
 |support.ingress-nginx.controller.resources|object|-|Resource requests and limits for ingress controller|
 |support.ingress-nginx.controller.resources.limits.cpu|string|`"720m"`|CPU limit for ingress controller pods|
 |support.ingress-nginx.controller.resources.limits.memory|string|`"512Mi"`|Memory limit for ingress controller pods|
@@ -441,7 +441,7 @@ The following table lists the configurable parameters of this chart and their de
 |support.ingress-nginx.controller.resources.requests.memory|string|`"256Mi"`|Memory request for ingress controller pods|
 |support.ingress-nginx.enabled|bool|`true`|Enable NGINX Ingress Controller deployment|
 |support.ingress-nginx.global|object|-|Global ingress-nginx image configuration|
-|support.ingress-nginx.global.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|OCI registry for ingress-nginx assets|
+|support.ingress-nginx.global.image.registry|string|`"registry.k8s.io"`|OCI registry for ingress-nginx assets|
 |support.ingress-nginx.replicaCount|int|`1`|Number of ingress controller replicas|
 |support.minio|object|-|MinIO object storage configuration|
 |support.minio.consoleIngress|object|-|MinIO console ingress configuration|
@@ -451,14 +451,14 @@ The following table lists the configurable parameters of this chart and their de
 |support.minio.consoleIngress.path|string|`"/"`|Path prefix for MinIO console ingress|
 |support.minio.enabled|bool|`true`|Enable MinIO object storage deployment|
 |support.minio.image|object|-|MinIO server container image|
-|support.minio.image.repository|string|`"harbor.settlemint.com/docker.io/minio/minio"`|MinIO server image repository|
+|support.minio.image.repository|string|`"docker.io/minio/minio"`|MinIO server image repository|
 |support.minio.ingress|object|-|Ingress configuration for MinIO console|
 |support.minio.ingress.enabled|bool|`true`|Enable ingress for MinIO web console|
 |support.minio.ingress.hosts|list|-|Hostnames for MinIO access|
 |support.minio.ingress.ingressClassName|string|`"atk-nginx"`|IngressClass for MinIO|
 |support.minio.ingress.path|string|`"/"`|Path prefix for MinIO console|
 |support.minio.mcImage|object|-|MinIO client (mc) container image|
-|support.minio.mcImage.repository|string|`"harbor.settlemint.com/docker.io/minio/minio"`|MinIO client image repository|
+|support.minio.mcImage.repository|string|`"docker.io/minio/minio"`|MinIO client image repository|
 |support.minio.resources|object|-|Resource requests and limits for MinIO pods|
 |support.minio.resources.limits.cpu|string|`"300m"`|CPU limit for MinIO pods|
 |support.minio.resources.limits.memory|string|`"512Mi"`|Memory limit for MinIO pods|
@@ -467,7 +467,7 @@ The following table lists the configurable parameters of this chart and their de
 |support.postgresql|object|-|PostgreSQL database configuration|
 |support.postgresql.enabled|bool|`true`|Enable PostgreSQL deployment|
 |support.postgresql.image|object|-|PostgreSQL container image|
-|support.postgresql.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for PostgreSQL image|
+|support.postgresql.image.registry|string|`"docker.io"`|OCI registry for PostgreSQL image|
 |support.redis|object|-|Redis in-memory data store configuration|
 |support.redis.auth|object|-|Redis authentication configuration|
 |support.redis.auth.enabled|bool|`true`|Enable Redis password authentication|
@@ -478,7 +478,7 @@ The following table lists the configurable parameters of this chart and their de
 |support.redis.enabled|bool|`true`|Enable Redis deployment|
 |support.redis.fullnameOverride|string|`"redis"`|Override fullname for simpler service discovery|
 |support.redis.image|object|-|Redis container image|
-|support.redis.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for Redis image|
+|support.redis.image.registry|string|`"docker.io"`|OCI registry for Redis image|
 |support.redis.persistence|object|-|Persistent storage for Redis data|
 |support.redis.persistence.enabled|bool|`true`|Enable persistence for Redis AOF/RDB|
 |support.redis.persistence.size|string|`"1Gi"`|Storage size for Redis data|
@@ -492,7 +492,7 @@ The following table lists the configurable parameters of this chart and their de
 |support.reloader|object|-|Stakater Reloader for automatic pod restarts on config changes|
 |support.reloader.enabled|bool|`true`|Enable Reloader deployment|
 |support.reloader.image|object|-|Reloader container image|
-|support.reloader.image.repository|string|`"harbor.settlemint.com/ghcr.io/stakater/reloader"`|Reloader image repository|
+|support.reloader.image.repository|string|`"ghcr.io/stakater/reloader"`|Reloader image repository|
 |support.reloader.resources|object|-|Resource requests and limits for Reloader deployment|
 |support.reloader.resources.limits.cpu|string|`"120m"`|CPU limit for Reloader pods|
 |support.reloader.resources.limits.memory|string|`"128Mi"`|Memory limit for Reloader pods|
@@ -504,14 +504,14 @@ The following table lists the configurable parameters of this chart and their de
 |txsigner.config.mnemonic|string|`"gate yellow grunt wrestle disease obtain mixed nature mansion tape purchase awful"`|BIP39 mnemonic phrase for deterministic key generation. MUST be changed for production.|
 |txsigner.enabled|bool|`true`|Enable deployment of transaction signing service|
 |txsigner.image|object|-|Transaction signer container image|
-|txsigner.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|OCI registry for txsigner image|
+|txsigner.image.registry|string|`"ghcr.io"`|OCI registry for txsigner image|
 |txsigner.ingress|object|-|Ingress configuration for transaction signer API|
 |txsigner.ingress.enabled|bool|`false`|Enable ingress (typically disabled for internal-only services)|
 |txsigner.ingress.hostname|string|`"txsigner.k8s.orb.local"`|Hostname for transaction signer|
 |txsigner.initContainer|object|-|Init container for dependency checks|
 |txsigner.initContainer.tcpCheck|object|-|TCP check for blockchain node readiness|
 |txsigner.initContainer.tcpCheck.image|object|-|Wait-for-it utility image|
-|txsigner.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
+|txsigner.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for TCP check utility|
 |txsigner.resources|object|-|Resource requests and limits for transaction signer|
 |txsigner.resources.limits.cpu|string|`"360m"`|CPU limit for txsigner pods|
 |txsigner.resources.limits.memory|string|`"384Mi"`|Memory limit for txsigner pods|
@@ -519,7 +519,7 @@ The following table lists the configurable parameters of this chart and their de
 |txsigner.resources.requests.memory|string|`"192Mi"`|Memory request for txsigner pods|
 |txsigner.tests|object|-|Test container image for health checks|
 |txsigner.tests.image|object|-|Test image configuration|
-|txsigner.tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|OCI registry for test utilities|
+|txsigner.tests.image.registry|string|`"docker.io"`|OCI registry for test utilities|
 
 ## Resource Summary
 

--- a/kit/charts/atk/charts/blockscout/README.md
+++ b/kit/charts/atk/charts/blockscout/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of this chart and their de
 |blockscout.extraInitContainers|list|-|Additional init containers appended verbatim|
 |blockscout.image|object|-|Blockscout backend image configuration|
 |blockscout.image.pullPolicy|string|`"IfNotPresent"`|Blockscout backend image pull policy|
-|blockscout.image.repository|string|`"harbor.settlemint.com/ghcr.io/blockscout/blockscout"`|Blockscout backend image repository|
+|blockscout.image.repository|string|`"ghcr.io/blockscout/blockscout"`|Blockscout backend image repository|
 |blockscout.image.tag|string|`"9.0.2"`|Blockscout backend image tag (immutable tags are recommended)|
 |blockscout.ingress|object|-|Ingress parameters for Blockscout backend|
 |blockscout.ingress.annotations|object|-|Additional annotations for the Ingress resource|
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of this chart and their de
 |blockscout.initContainer.tcpCheck.enabled|bool|`true`|Enable TCP check init container|
 |blockscout.initContainer.tcpCheck.image|object|-|TCP check container image configuration|
 |blockscout.initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|TCP check container image pull policy|
-|blockscout.initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|TCP check container image repository|
+|blockscout.initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|TCP check container image repository|
 |blockscout.initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|TCP check container image tag|
 |blockscout.initContainer.tcpCheck.resources|object|-|TCP check container resource requests and limits|
 |blockscout.initContainer.tcpCheck.resources.dependencies|list|-|List of service dependencies to check|
@@ -169,7 +169,7 @@ The following table lists the configurable parameters of this chart and their de
 |frontend.env.NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER|string|`"blockscout"`|Transaction interpretation provider|
 |frontend.image|object|-|Blockscout frontend image configuration|
 |frontend.image.pullPolicy|string|`"IfNotPresent"`|Blockscout frontend image pull policy|
-|frontend.image.repository|string|`"harbor.settlemint.com/ghcr.io/blockscout/frontend"`|Blockscout frontend image repository|
+|frontend.image.repository|string|`"ghcr.io/blockscout/frontend"`|Blockscout frontend image repository|
 |frontend.image.tag|string|`"v2.3.4"`|Blockscout frontend image tag (immutable tags are recommended)|
 |frontend.ingress|object|-|Ingress parameters for Blockscout frontend|
 |frontend.ingress.annotations|object|-|Additional annotations for the Ingress resource|

--- a/kit/charts/atk/charts/dapp/README.md
+++ b/kit/charts/atk/charts/dapp/README.md
@@ -27,7 +27,7 @@ The following table lists the configurable parameters of this chart and their de
 |global.labels."kots.io/app-slug"|string|`"settlemint-atk"`|KOTS application slug identifier|
 |image|object|-|dApp image configuration|
 |image.pullPolicy|string|`"IfNotPresent"`|dApp image pull policy|
-|image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/asset-tokenization-kit"`|dApp image repository|
+|image.repository|string|`"ghcr.io/settlemint/asset-tokenization-kit"`|dApp image repository|
 |image.tag|string|`""`|dApp image tag (defaults to chart appVersion)|
 |ingress|object|-|Ingress configuration|
 |ingress.annotations|object|-|Additional annotations for the Ingress resource|
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.graphQLCheck.enabled|bool|`true`|Enable GraphQL endpoint readiness check|
 |initContainer.graphQLCheck.image|object|-|Container image configuration for GraphQL check|
 |initContainer.graphQLCheck.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy|
-|initContainer.graphQLCheck.image.registry|string|`"harbor.settlemint.com/docker.io"`|Container registry|
+|initContainer.graphQLCheck.image.registry|string|`"docker.io"`|Container registry|
 |initContainer.graphQLCheck.image.repository|string|`"curlimages/curl"`|Image repository for curl utility|
 |initContainer.graphQLCheck.image.tag|string|`"8.16.0"`|Image tag|
 |initContainer.graphQLCheck.name|string|`"wait-for-graphql"`|Name of the init container|
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`true`|Enable TCP availability checks|
 |initContainer.tcpCheck.image|object|-|Container image configuration for TCP check init container|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Image repository for wait-for-it utility|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Image repository for wait-for-it utility|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|Image tag for wait-for-it utility|
 |initContainer.tcpCheck.resources|object|-|Resource limits and requests for TCP check init container|
 |initContainer.tcpCheck.resources.limits|object|-|Resource limits|

--- a/kit/charts/atk/charts/erpc/README.md
+++ b/kit/charts/atk/charts/erpc/README.md
@@ -231,7 +231,7 @@ The following table lists the configurable parameters of this chart and their de
 |image.digest|string|`""`|eRPC image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag|
 |image.pullPolicy|string|`"IfNotPresent"`|eRPC image pull policy|
 |image.pullSecrets|list|-|eRPC image pull secrets|
-|image.registry|string|`"harbor.settlemint.com/ghcr.io"`|eRPC image registry|
+|image.registry|string|`"ghcr.io"`|eRPC image registry|
 |image.repository|string|`"erpc/erpc"`|eRPC image repository|
 |image.tag|string|`"0.0.57"`|eRPC image tag (immutable tags are recommended)|
 |ingress|object|-|Ingress parameters|
@@ -261,7 +261,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`true`|Enable TCP dependency checking init container|
 |initContainer.tcpCheck.image|object|-|Container image for TCP check init container|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|TCP check image pull policy|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|TCP check image repository|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|TCP check image repository|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|TCP check image tag|
 |initContainer.tcpCheck.resources|object|-|Resource limits and requests for TCP check container|
 |initContainer.tcpCheck.resources.limits|object|-|Resource limits for TCP check container|
@@ -419,7 +419,7 @@ The following table lists the configurable parameters of this chart and their de
 |tests|object|-|Test parameters|
 |tests.image|object|-|Image for test pods|
 |tests.image.pullPolicy|string|`"IfNotPresent"`|Test image pull policy|
-|tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|Test image registry|
+|tests.image.registry|string|`"docker.io"`|Test image registry|
 |tests.image.repository|string|`"busybox"`|Test image repository|
 |tests.image.tag|string|`"1.37.0"`|Test image tag|
 |tolerations|list|-|Tolerations for pod assignment|

--- a/kit/charts/atk/charts/graph-node/README.md
+++ b/kit/charts/atk/charts/graph-node/README.md
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of this chart and their de
 |global.artifacts|object|-|Artifacts configuration for contract ABIs and genesis files|
 |global.artifacts.image|object|-|Image containing contract ABIs and genesis files|
 |global.artifacts.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy|
-|global.artifacts.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|Image registry|
+|global.artifacts.image.registry|string|`"ghcr.io"`|Image registry|
 |global.artifacts.image.repository|string|`"settlemint/asset-tokenization-kit-artifacts"`|Image repository|
 |global.artifacts.image.tag|string|`""`|Image tag (empty string uses Chart.appVersion)|
 |global.labels|object|-|Labels applied to all resources|
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of this chart and their de
 |graph-node.graphNodeDefaults.subgraph.configMapName|string|`"besu-subgraph"`|Default ConfigMap name for subgraph deployment|
 |image|object|-|Graph Node image configuration|
 |image.pullPolicy|string|`"IfNotPresent"`|Graph Node image pull policy|
-|image.repository|string|`"harbor.settlemint.com/docker.io/graphprotocol/graph-node"`|Image for Graph Node|
+|image.repository|string|`"graphprotocol/graph-node"`|Image for Graph Node|
 |image.tag|string|`"v0.40.2"`|Overrides the image tag. Defaults to Chart.appVersion if not set|
 |imagePullSecrets|list|-|Pull secrets required to fetch the Image|
 |ingress|object|-|Ingress configuration|
@@ -116,7 +116,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer|object|-|Init container configuration|
 |initContainer.image|object|-|Image for init container kubectl|
 |initContainer.image.pullPolicy|string|`"IfNotPresent"`|Kubectl image pull policy|
-|initContainer.image.repository|string|`"harbor.settlemint.com/docker.io/kubesphere/kubectl"`|Kubectl image repository|
+|initContainer.image.repository|string|`"docker.io/kubesphere/kubectl"`|Kubectl image repository|
 |initContainer.image.tag|string|`"v1.33.4"`|Kubectl image tag|
 |initContainer.tcpCheck|object|-|TCP check configuration|
 |initContainer.tcpCheck.dependencies|list|-|List of dependencies to check|
@@ -128,7 +128,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`true`|Enable TCP check init container|
 |initContainer.tcpCheck.image|object|-|TCP check image configuration|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|TCP check image pull policy|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|TCP check image repository|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|TCP check image repository|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|TCP check image tag|
 |initContainer.tcpCheck.ipfsClusterProxy.enabled|bool|`true`|Enable readiness checks against the IPFS cluster proxy|
 |initContainer.tcpCheck.ipfsClusterProxy.host|string|`"ipfs-cluster"`|Hostname for the IPFS cluster proxy service|
@@ -200,7 +200,7 @@ The following table lists the configurable parameters of this chart and their de
 |podSecurityContext|object|-|Pod-wide security context|
 |postgresReadinessCheck|object|-|PostgreSQL readiness check configuration|
 |postgresReadinessCheck.enabled|bool|`true`|Enable PostgreSQL readiness check init container|
-|postgresReadinessCheck.image|string|`"harbor.settlemint.com/docker.io/postgres:18.0-alpine"`|Docker image for PostgreSQL readiness check|
+|postgresReadinessCheck.image|string|`"docker.io/postgres:18.0-alpine"`|Docker image for PostgreSQL readiness check|
 |postgresReadinessCheck.initialWaitTime|int|`2`|Initial wait time between retries (doubles with exponential backoff)|
 |postgresReadinessCheck.maxRetries|int|`30`|Maximum number of connection retries|
 |postgresReadinessCheck.maxWaitTime|int|`30`|Maximum wait time between retries|

--- a/kit/charts/atk/charts/hasura/README.md
+++ b/kit/charts/atk/charts/hasura/README.md
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of this chart and their de
 |healthChecks.startupProbe.timeoutSeconds|int|`5`|Timeout seconds|
 |image|object|-|Hasura image configuration|
 |image.pullPolicy|string|`"IfNotPresent"`|Hasura image pull policy|
-|image.registry|string|`"harbor.settlemint.com/docker.io"`|Hasura image registry|
+|image.registry|string|`"docker.io"`|Hasura image registry|
 |image.repository|string|`"hasura/graphql-engine"`|Hasura image repository|
 |image.tag|string|`"v2.48.6"`|Hasura image tag|
 |imagePullSecrets|list|-|Docker registry secret names as an array|
@@ -114,9 +114,9 @@ The following table lists the configurable parameters of this chart and their de
 |ingress.pathType|string|`"Prefix"`|Ingress path type|
 |ingress.tls|list|-|TLS configuration|
 |initContainers|list|-|Init containers|
-|initContainers[0]|string|`{"command":["/usr/bin/wait-for-it","postgresql:5432","-t","120"],"image":"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit:v7.7.11","imagePullPolicy":"IfNotPresent","name":"wait-for-postgresql","resources":{"limits":{"cpu":"300m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}}`|Container name|
+|initContainers[0]|string|`{"command":["/usr/bin/wait-for-it","postgresql:5432","-t","120"],"image":"ghcr.io/settlemint/btp-waitforit:v7.7.11","imagePullPolicy":"IfNotPresent","name":"wait-for-postgresql","resources":{"limits":{"cpu":"300m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}}`|Container name|
 |initContainers[0].command|list|-|Container command|
-|initContainers[0].image|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit:v7.7.11"`|Container image|
+|initContainers[0].image|string|`"ghcr.io/settlemint/btp-waitforit:v7.7.11"`|Container image|
 |initContainers[0].imagePullPolicy|string|`"IfNotPresent"`|Image pull policy|
 |initContainers[0].resources|object|-|Resource limits and requests|
 |initContainers[0].resources.limits|object|-|Resource limits|

--- a/kit/charts/atk/charts/ipfs/README.md
+++ b/kit/charts/atk/charts/ipfs/README.md
@@ -21,7 +21,7 @@ The following table lists the configurable parameters of this chart and their de
 |cluster.extraVolumeMounts|list|-|Additional volume mounts for the cluster container|
 |cluster.extraVolumes|object|-|Additional volumes for the pod|
 |cluster.image.pullPolicy|string|`"IfNotPresent"`|Cluster image pull policy|
-|cluster.image.registry|string|`"harbor.settlemint.com/docker.io"`|Cluster image registry|
+|cluster.image.registry|string|`"docker.io"`|Cluster image registry|
 |cluster.image.repository|string|`"ipfs/ipfs-cluster"`|Cluster image repository|
 |cluster.image.tag|string|`"v1.1.4"`|Cluster image tag|
 |cluster.nodeSelector|object|-|Node selector|
@@ -188,7 +188,7 @@ The following table lists the configurable parameters of this chart and their de
 |ipfs.extraVolumeMounts|list|-|Additional volume mounts for the IPFS container|
 |ipfs.extraVolumes|object|-|Additional volumes for the pod|
 |ipfs.image.pullPolicy|string|`"IfNotPresent"`|IPFS image pull policy|
-|ipfs.image.registry|string|`"harbor.settlemint.com/docker.io"`|IPFS image registry|
+|ipfs.image.registry|string|`"docker.io"`|IPFS image registry|
 |ipfs.image.repository|string|`"ipfs/kubo"`|IPFS image repository|
 |ipfs.image.tag|string|`"v0.38.0"`|IPFS image tag|
 |ipfs.initContainers|list|-|Additional init containers|
@@ -260,7 +260,7 @@ The following table lists the configurable parameters of this chart and their de
 |sharedSecret|string|`""`|Shared secret for cluster peers. Leave empty to auto-generate.|
 |tests|object|-|Test hook image configuration|
 |tests.image.pullPolicy|string|`"IfNotPresent"`|Test image pull policy|
-|tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|Test image registry|
+|tests.image.registry|string|`"docker.io"`|Test image registry|
 |tests.image.repository|string|`"busybox"`|Test image repository|
 |tests.image.tag|string|`"1.37"`|Test image tag|
 

--- a/kit/charts/atk/charts/network/Chart.lock
+++ b/kit/charts/atk/charts/network/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: network-bootstrapper
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: network-nodes
   repository: ""
-  version: 2.0.0-alpha.18
-digest: sha256:76d88fbc908550d56d7d68e6cda82775f0f9693f945f9cc142f6264b86313dc5
-generated: "2025-10-04T08:02:09.025721+02:00"
+  version: 2.0.0-beta.2
+digest: sha256:e177817975afd535301dc16b1b4f35bc66970dc44163e1dcd47cde23552ac018
+generated: "2025-10-08T15:19:59.065865+03:00"

--- a/kit/charts/atk/charts/network/charts/network-bootstrapper/README.md
+++ b/kit/charts/atk/charts/network/charts/network-bootstrapper/README.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters of this chart and their de
 |global.artifacts|object|-|Container artifacts configuration for contract ABIs and genesis files.|
 |global.artifacts.image|object|-|Image containing contract ABIs and genesis files.|
 |global.artifacts.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy for the artifacts container.|
-|global.artifacts.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|OCI registry hosting the artifacts image.|
+|global.artifacts.image.registry|string|`"ghcr.io"`|OCI registry hosting the artifacts image.|
 |global.artifacts.image.repository|string|`"settlemint/asset-tokenization-kit-artifacts"`|Repository path for the artifacts container image.|
 |global.artifacts.image.tag|string|`""`|Image tag for the artifacts container; leave empty to use chart default.|
 |global.chainId|int|`nil`|Chain ID applied when `settings.chainId` is unset.|
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of this chart and their de
 |global.labels."kots.io/app-slug"|string|`"settlemint-atk"`|KOTS application slug for Replicated platform integration.|
 |image|object|-|Container image configuration for the network bootstrapper.|
 |image.pullPolicy|string|`"IfNotPresent"`|Image pull policy controlling when Kubernetes fetches updated image layers.|
-|image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/network-bootstrapper"`|OCI registry path hosting the network bootstrapper image.|
+|image.repository|string|`"ghcr.io/settlemint/network-bootstrapper"`|OCI registry path hosting the network bootstrapper image.|
 |image.tag|string|`"1.2.3"`|Image tag override; leave empty to inherit the chart appVersion.|
 |imagePullSecrets|list|-|Image pull secrets enabling access to private registries.|
 |initContainer|object|-|Init container configuration shared across the bootstrapper job.|
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`false`|Enable a tcp-check init container before the bootstrapper job starts.|
 |initContainer.tcpCheck.image|object|-|Container image configuration for the tcp-check init container.|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy for the tcp-check init container.|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|OCI image hosting the tcp-check utility.|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|OCI image hosting the tcp-check utility.|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|Image tag for the tcp-check utility.|
 |initContainer.tcpCheck.resources|object|-|CPU and memory resource constraints for the tcp-check init container.|
 |initContainer.tcpCheck.resources.limits|object|-|Maximum resource limits for the tcp-check init container.|

--- a/kit/charts/atk/charts/network/charts/network-nodes/README.md
+++ b/kit/charts/atk/charts/network/charts/network-nodes/README.md
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of this chart and their de
 |httpRoute.rules[0].matches[0].path.value|string|`"/headers"`|Path value used when evaluating the request URL.|
 |image|object|-|Container image configuration shared by validator and RPC pods.|
 |image.pullPolicy|string|`"IfNotPresent"`|Kubernetes image pull policy for Besu containers.|
-|image.repository|string|`"harbor.settlemint.com/docker.io/hyperledger/besu"`|OCI image repository hosting Hyperledger Besu.|
+|image.repository|string|`"docker.io/hyperledger/besu"`|OCI image repository hosting Hyperledger Besu.|
 |image.tag|string|`"25.9.0"`|Specific Besu image tag to deploy.|
 |imagePullSecrets|list|-|Image pull secrets granting registry access for the Besu image.|
 |ingress|object|-|Ingress configuration used to expose RPC services via Kubernetes Ingress resources.|
@@ -105,7 +105,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.compileGenesis.enabled|bool|`true`|Enable the compile-genesis init container that merges allocation ConfigMaps into the runtime genesis file.|
 |initContainer.compileGenesis.image|object|-|Container image configuration for the compile-genesis init container.|
 |initContainer.compileGenesis.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy for the compile-genesis init container.|
-|initContainer.compileGenesis.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/network-bootstrapper"`|OCI image hosting the network-bootstrapper CLI used for genesis compilation.|
+|initContainer.compileGenesis.image.repository|string|`"ghcr.io/settlemint/network-bootstrapper"`|OCI image hosting the network-bootstrapper CLI used for genesis compilation.|
 |initContainer.compileGenesis.image.tag|string|`"1.2.3"`|Image tag for the network-bootstrapper CLI.|
 |initContainer.compileGenesis.outputPath|string|`""`|Filesystem path populated with the compiled genesis JSON. Leave empty to mirror config.genesisFile.|
 |initContainer.compileGenesis.resources|object|-|Optional Kubernetes resource requests/limits for the compile-genesis init container.|
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`false`|Enable a tcp-check init container before Besu pods start.|
 |initContainer.tcpCheck.image|object|-|Container image configuration for the tcp-check init container.|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy for the tcp-check init container.|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|OCI image hosting the tcp-check utility.|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|OCI image hosting the tcp-check utility.|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|Image tag for the tcp-check utility.|
 |initContainer.tcpCheck.resources|object|-|Resource requests and limits for the tcp-check init container.|
 |initContainer.tcpCheck.resources.limits|object|-|Maximum resource limits.|

--- a/kit/charts/atk/charts/observability/README.md
+++ b/kit/charts/atk/charts/observability/README.md
@@ -35,7 +35,7 @@ The following table lists the configurable parameters of this chart and their de
 |alloy.clustername|string|`""`|Cluster name label for metrics and logs|
 |alloy.configReloader|object|-|Config reloader sidecar configuration|
 |alloy.configReloader.image|object|-|Config reloader image configuration|
-|alloy.configReloader.image.registry|string|`"harbor.settlemint.com/ghcr.io"`|Image registry for config reloader|
+|alloy.configReloader.image.registry|string|`"ghcr.io"`|Image registry for config reloader|
 |alloy.controller|object|-|Controller configuration|
 |alloy.controller.type|string|`"deployment"`|Controller type (deployment, daemonset, or statefulset)|
 |alloy.crds|object|-|Custom Resource Definitions configuration|
@@ -119,7 +119,7 @@ The following table lists the configurable parameters of this chart and their de
 |alloy.grafana.fullnameOverride|string|`"grafana"`|String to fully override common.names.fullname|
 |alloy.grafana.global|object|-|Global configuration|
 |alloy.grafana.global.imagePullSecrets|list|-|Global Docker registry secret names as an array|
-|alloy.grafana.global.imageRegistry|string|`"harbor.settlemint.com/docker.io"`|Global image registry|
+|alloy.grafana.global.imageRegistry|string|`"docker.io"`|Global image registry|
 |alloy.grafana.ingress|object|-|Ingress configuration for Grafana|
 |alloy.grafana.ingress.enabled|bool|`true`|Enable ingress for Grafana|
 |alloy.grafana.ingress.hosts|list|-|List of ingress hosts|
@@ -162,7 +162,7 @@ The following table lists the configurable parameters of this chart and their de
 |alloy.grafana.sidecar.plugins|object|-|Plugin sidecar configuration|
 |alloy.grafana.sidecar.plugins.enabled|bool|`true`|Enable plugin sidecar|
 |alloy.image|object|-|Alloy image configuration|
-|alloy.image.registry|string|`"harbor.settlemint.com/docker.io"`|Image registry for Alloy|
+|alloy.image.registry|string|`"docker.io"`|Image registry for Alloy|
 |global|object|-|Global configuration applied to all resources|
 |global.labels|object|-|Labels applied to all resources in the chart|
 |global.labels."kots.io/app-slug"|string|`"settlemint-atk"`|KOTS application slug identifier|
@@ -172,7 +172,7 @@ The following table lists the configurable parameters of this chart and their de
 |kube-state-metrics.enabled|bool|`true`|Enable kube-state-metrics deployment|
 |kube-state-metrics.fullnameOverride|string|`"kube-state-metrics"`|String to fully override common.names.fullname (string)|
 |kube-state-metrics.image|object|-|Kube state metrics image configuration|
-|kube-state-metrics.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|Kube state metrics image registry|
+|kube-state-metrics.image.registry|string|`"registry.k8s.io"`|Kube state metrics image registry|
 |kube-state-metrics.imagePullSecrets|list|-|Global Docker registry secret names as an array (list)|
 |kube-state-metrics.metricLabelsAllowlist|list|-|Allow list for metric labels|
 |kube-state-metrics.podAnnotations|object|-|Annotations for kube-state-metrics pods|
@@ -217,7 +217,7 @@ The following table lists the configurable parameters of this chart and their de
 |loki.gateway.ingress.ingressClassName|string|`"atk-nginx"`|Ingress class name|
 |loki.global|object|-|Global configuration|
 |loki.global.image|object|-|Global image configuration|
-|loki.global.image.registry|string|`"harbor.settlemint.com/docker.io"`|Global image registry|
+|loki.global.image.registry|string|`"docker.io"`|Global image registry|
 |loki.imagePullSecrets|list|-|Global Docker registry secret names as an array|
 |loki.indexGateway|object|-|Index gateway component configuration|
 |loki.indexGateway.replicas|int|`0`|Number of index gateway replicas (0 when using SingleBinary)|
@@ -280,10 +280,10 @@ The following table lists the configurable parameters of this chart and their de
 |loki.lokiCanary.enabled|bool|`false`|Enable Loki canary|
 |loki.memcached|object|-|Memcached configuration|
 |loki.memcached.image|object|-|Memcached image configuration|
-|loki.memcached.image.repository|string|`"harbor.settlemint.com/docker.io/library/memcached"`|Memcached image repository|
+|loki.memcached.image.repository|string|`"docker.io/library/memcached"`|Memcached image repository|
 |loki.memcachedExporter|object|-|Memcached exporter configuration|
 |loki.memcachedExporter.image|object|-|Memcached exporter image configuration|
-|loki.memcachedExporter.image.repository|string|`"harbor.settlemint.com/docker.io/prom/memcached-exporter"`|Memcached exporter image repository|
+|loki.memcachedExporter.image.repository|string|`"docker.io/prom/memcached-exporter"`|Memcached exporter image repository|
 |loki.minio|object|-|MinIO configuration for object storage|
 |loki.minio.enabled|bool|`false`|Enable MinIO deployment|
 |loki.querier|object|-|Querier component configuration|
@@ -298,7 +298,7 @@ The following table lists the configurable parameters of this chart and their de
 |loki.resultsCache.enabled|bool|`false`|Enable results cache|
 |loki.sidecar|object|-|Sidecar configuration for config reloading|
 |loki.sidecar.image|object|-|Sidecar image configuration|
-|loki.sidecar.image.repository|string|`"harbor.settlemint.com/docker.io/kiwigrid/k8s-sidecar"`|The Docker registry and image for the k8s sidecar|
+|loki.sidecar.image.repository|string|`"docker.io/kiwigrid/k8s-sidecar"`|The Docker registry and image for the k8s sidecar|
 |loki.singleBinary|object|-|Single binary deployment configuration|
 |loki.singleBinary.persistence|object|-|Persistent volume configuration|
 |loki.singleBinary.persistence.size|string|`"10Gi"`|Size of persistent volume|
@@ -316,7 +316,7 @@ The following table lists the configurable parameters of this chart and their de
 |metrics-server.enabled|bool|`false`|Enable metrics server deployment|
 |metrics-server.fullnameOverride|string|`"metrics-server"`|String to fully override common.names.fullname (string)|
 |metrics-server.image|object|-|Metrics server image configuration|
-|metrics-server.image.repository|string|`"harbor.settlemint.com/registry.k8s.io/metrics-server/metrics-server"`|Metrics server image repository|
+|metrics-server.image.repository|string|`"registry.k8s.io/metrics-server/metrics-server"`|Metrics server image repository|
 |metrics-server.imagePullSecrets|list|-|Global Docker registry secret names as an array (list)|
 |metrics-server.podLabels|object|-|Additional labels for metrics server pods|
 |metrics-server.podLabels."kots.io/app-slug"|string|`"settlemint-atk"`|KOTS application slug applied to metrics server pods|
@@ -335,13 +335,13 @@ The following table lists the configurable parameters of this chart and their de
 |prometheus-node-exporter.enabled|bool|`true`|Enable Prometheus Node Exporter deployment|
 |prometheus-node-exporter.fullnameOverride|string|`"node-exporter"`|String to fully override common.names.fullname|
 |prometheus-node-exporter.global|object|-|Global configuration|
-|prometheus-node-exporter.global.imageRegistry|string|`"harbor.settlemint.com/quay.io"`|Global image registry|
+|prometheus-node-exporter.global.imageRegistry|string|`"quay.io"`|Global image registry|
 |prometheus-node-exporter.image|object|-|Node exporter image configuration|
-|prometheus-node-exporter.image.registry|string|`"harbor.settlemint.com/quay.io"`|Image registry for node exporter|
+|prometheus-node-exporter.image.registry|string|`"quay.io"`|Image registry for node exporter|
 |prometheus-node-exporter.imagePullSecrets|list|-|Docker registry secret names as an array|
 |prometheus-node-exporter.kubeRBACProxy|object|-|Kube RBAC proxy configuration|
 |prometheus-node-exporter.kubeRBACProxy.image|object|-|Kube RBAC proxy image configuration|
-|prometheus-node-exporter.kubeRBACProxy.image.registry|string|`"harbor.settlemint.com/quay.io"`|Image registry for kube RBAC proxy|
+|prometheus-node-exporter.kubeRBACProxy.image.registry|string|`"quay.io"`|Image registry for kube RBAC proxy|
 |prometheus-node-exporter.nameOverride|string|`"node-exporter"`|String to partially override common.names.name|
 |prometheus-node-exporter.podAnnotations|object|-|Annotations for node exporter pods|
 |prometheus-node-exporter.podAnnotations."cluster-autoscaler.kubernetes.io/safe-to-evict"|string|`"true"`|Mark pod as safe to evict for cluster autoscaler|
@@ -379,7 +379,7 @@ The following table lists the configurable parameters of this chart and their de
 |tempo.tempo.overrides.defaults.ingestion.rate_limit_bytes|int|`30000000`|Rate limit in bytes per second|
 |tempo.tempo.pullSecrets|list|-|Docker registry secret names as an array|
 |tempo.tempo.reportingEnabled|bool|`false`|Enable usage reporting to Grafana Labs|
-|tempo.tempo.repository|string|`"harbor.settlemint.com/docker.io/grafana/tempo"`|Tempo image repository|
+|tempo.tempo.repository|string|`"docker.io/grafana/tempo"`|Tempo image repository|
 |tempo.tempo.resources|object|-|Resource requests and limits for Tempo pods|
 |tempo.tempo.resources.limits.cpu|string|`"720m"`|CPU limit for Tempo pods|
 |tempo.tempo.resources.limits.memory|string|`"384Mi"`|Memory limit for Tempo pods|
@@ -400,7 +400,7 @@ The following table lists the configurable parameters of this chart and their de
 |tempo.tempoQuery.ingress.ingressClassName|string|`"atk-nginx"`|Ingress class name|
 |tempo.tempoQuery.ingress.pathType|string|`"Prefix"`|Path type for ingress rule|
 |tempo.tempoQuery.pullSecrets|list|-|Docker registry secret names as an array|
-|tempo.tempoQuery.repository|string|`"harbor.settlemint.com/docker.io/grafana/tempo-query"`|Tempo query image repository|
+|tempo.tempoQuery.repository|string|`"docker.io/grafana/tempo-query"`|Tempo query image repository|
 |tempo.tempoQuery.resources|object|-|Resource requests and limits for Tempo query pods|
 |tempo.tempoQuery.resources.limits.cpu|string|`"600m"`|CPU limit for Tempo query pods|
 |tempo.tempoQuery.resources.limits.memory|string|`"256Mi"`|Memory limit for Tempo query pods|
@@ -410,7 +410,7 @@ The following table lists the configurable parameters of this chart and their de
 |victoria-metrics-single.enabled|bool|`true`|Enable Victoria Metrics Single deployment|
 |victoria-metrics-single.global|object|-|Global configuration|
 |victoria-metrics-single.global.image|object|-|Global image configuration|
-|victoria-metrics-single.global.image.registry|string|`"harbor.settlemint.com/docker.io"`|Global image registry|
+|victoria-metrics-single.global.image.registry|string|`"docker.io"`|Global image registry|
 |victoria-metrics-single.global.imagePullSecrets|list|-|Global Docker registry secret names as an array (list)|
 |victoria-metrics-single.server|object|-|Victoria Metrics server configuration|
 |victoria-metrics-single.server.extraArgs|object|-|Extra arguments for Victoria Metrics server|

--- a/kit/charts/atk/charts/portal/README.md
+++ b/kit/charts/atk/charts/portal/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of this chart and their de
 |image.digest|string|`""`|Portal image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag|
 |image.pullPolicy|string|`"IfNotPresent"`|Portal image pull policy|
 |image.pullSecrets|list|-|Portal image pull secrets|
-|image.registry|string|`"harbor.settlemint.com/ghcr.io"`|Portal image registry|
+|image.registry|string|`"ghcr.io"`|Portal image registry|
 |image.repository|string|`"settlemint/btp-scs-portal"`|Portal image repository|
 |image.tag|string|`"8.6.9"`|Portal image tag (immutable tags are recommended)|
 |ingress|object|-|Ingress parameters|
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.downloadAbi.enabled|bool|`true`|Enable the ABI download init container that syncs ConfigMaps via network-bootstrapper.|
 |initContainer.downloadAbi.image|object|-|Container image configuration for the ABI downloader|
 |initContainer.downloadAbi.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy for the ABI download init container.|
-|initContainer.downloadAbi.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/network-bootstrapper"`|OCI image hosting the network-bootstrapper CLI.|
+|initContainer.downloadAbi.image.repository|string|`"ghcr.io/settlemint/network-bootstrapper"`|OCI image hosting the network-bootstrapper CLI.|
 |initContainer.downloadAbi.image.tag|string|`"1.2.3"`|Image tag for the network-bootstrapper CLI.|
 |initContainer.downloadAbi.outputDirectory|string|`"/shared-abis"`|Directory where ABI files are written before being shared with the portal container.|
 |initContainer.downloadAbi.resources|object|-|Resource requests and limits for the ABI download init container|
@@ -105,7 +105,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`true`|Enable TCP check init container to wait for dependent services|
 |initContainer.tcpCheck.image|object|-|Container image configuration for TCP check|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|Image pull policy for the TCP check init container|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Repository for the TCP check init container image|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Repository for the TCP check init container image|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|Image tag for the TCP check init container|
 |initContainer.tcpCheck.resources|object|-|Resource requests and limits for the TCP check init container|
 |initContainer.tcpCheck.resources.limits|object|-|Resource limits for the TCP check init container|
@@ -265,7 +265,7 @@ The following table lists the configurable parameters of this chart and their de
 |tests|object|-|Test parameters|
 |tests.image|object|-|Image for test pods|
 |tests.image.pullPolicy|string|`"IfNotPresent"`|Test image pull policy|
-|tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|Test image registry|
+|tests.image.registry|string|`"docker.io"`|Test image registry|
 |tests.image.repository|string|`"busybox"`|Test image repository|
 |tests.image.tag|string|`"1.37.0"`|Test image tag|
 |tolerations|list|-|Tolerations for pod assignment|

--- a/kit/charts/atk/charts/support/Chart.lock
+++ b/kit/charts/atk/charts/support/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 4.13.3
 - name: postgresql
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: redis
   repository: ""
-  version: 2.0.0-alpha.18
+  version: 2.0.0-beta.2
 - name: reloader
   repository: https://stakater.github.io/stakater-charts
   version: 2.2.3
 - name: minio
   repository: ""
-  version: 2.0.0-alpha.18
-digest: sha256:5ca60ede6a4b97c4f8bc4db003008d91f9b50e4959b2baafa4e88712063bedb7
-generated: "2025-10-04T08:02:09.276677+02:00"
+  version: 2.0.0-beta.2
+digest: sha256:5d206797d2aa21ef48b3cee333dfc494d46afd9ba59d6125c75b274267896231
+generated: "2025-10-08T15:19:57.930254+03:00"

--- a/kit/charts/atk/charts/support/README.md
+++ b/kit/charts/atk/charts/support/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of this chart and their de
 |ingress-nginx.controller.image|object|-|Controller container image configuration|
 |ingress-nginx.controller.image.digest|string|`""`|Image digest for immutable deployments|
 |ingress-nginx.controller.image.digestChroot|string|`""`|Image digest for chroot variant|
-|ingress-nginx.controller.image.image|string|`"harbor.settlemint.com/docker.io/ingress-nginx/controller"`|Ingress NGINX controller image name|
+|ingress-nginx.controller.image.image|string|`"ingress-nginx/controller"`|Ingress NGINX controller image name|
 |ingress-nginx.controller.ingressClass|string|`"atk-nginx"`|Ingress class name|
 |ingress-nginx.controller.ingressClassResource|object|-|Ingress class resource configuration|
 |ingress-nginx.controller.ingressClassResource.controllerValue|string|`"k8s.io/atk-nginx"`|Controller value for IngressClass resource|
@@ -119,10 +119,10 @@ The following table lists the configurable parameters of this chart and their de
 |ingress-nginx.controller.opentelemetry|object|-|OpenTelemetry configuration|
 |ingress-nginx.controller.opentelemetry.enabled|bool|`true`|Enable OpenTelemetry sidecar for distributed tracing|
 |ingress-nginx.controller.opentelemetry.image|object|-|OpenTelemetry image configuration|
-|ingress-nginx.controller.opentelemetry.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|OpenTelemetry image registry|
+|ingress-nginx.controller.opentelemetry.image.registry|string|`"registry.k8s.io"`|OpenTelemetry image registry|
 |ingress-nginx.controller.patch|object|-|Patch configuration|
 |ingress-nginx.controller.patch.image|object|-|Patch job image configuration|
-|ingress-nginx.controller.patch.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|Patch job image registry|
+|ingress-nginx.controller.patch.image.registry|string|`"registry.k8s.io"`|Patch job image registry|
 |ingress-nginx.controller.podAnnotations|object|-|Pod annotations|
 |ingress-nginx.controller.podAnnotations."prometheus.io/port"|string|`"10254"`|Prometheus metrics port|
 |ingress-nginx.controller.podAnnotations."prometheus.io/scrape"|string|`"true"`|Enable Prometheus scraping for metrics|
@@ -155,7 +155,7 @@ The following table lists the configurable parameters of this chart and their de
 |ingress-nginx.fullnameOverride|string|`"ingress-nginx"`|String to fully override common.names.fullname (string)|
 |ingress-nginx.global|object|-|Global configuration|
 |ingress-nginx.global.image|object|-|Global image configuration|
-|ingress-nginx.global.image.registry|string|`"harbor.settlemint.com/registry.k8s.io"`|Global image registry|
+|ingress-nginx.global.image.registry|string|`"registry.k8s.io"`|Global image registry|
 |ingress-nginx.imagePullSecrets|list|-|Global Docker registry secret names as an array (list)|
 |minio|object|-|MinIO configuration (object)|
 |minio.buckets|list|-|Automatic bucket creation|
@@ -170,7 +170,7 @@ The following table lists the configurable parameters of this chart and their de
 |minio.enabled|bool|`true`|Enable MinIO deployment (bool)|
 |minio.fullnameOverride|string|`"minio"`|String to fully override common.names.fullname (string)|
 |minio.image|object|-|MinIO image configuration|
-|minio.image.repository|string|`"harbor.settlemint.com/docker.io/minio/minio"`|MinIO image repository|
+|minio.image.repository|string|`"docker.io/minio/minio"`|MinIO image repository|
 |minio.image.tag|string|`"RELEASE.2025-09-07T16-13-09Z"`|MinIO image tag (immutable tags are recommended)|
 |minio.ingress|object|-|Ingress configuration for MinIO API (object)|
 |minio.ingress.enabled|bool|`true`|Enable ingress for MinIO API|
@@ -203,7 +203,7 @@ The following table lists the configurable parameters of this chart and their de
 |postgresql.fullnameOverride|string|`"postgresql"`|String to fully override common.names.fullname (string)|
 |postgresql.image|object|-|PostgreSQL image configuration|
 |postgresql.image.pullPolicy|string|`"IfNotPresent"`|PostgreSQL image pull policy|
-|postgresql.image.registry|string|`"harbor.settlemint.com/docker.io"`|PostgreSQL image registry|
+|postgresql.image.registry|string|`"docker.io"`|PostgreSQL image registry|
 |postgresql.image.repository|string|`"postgres"`|PostgreSQL image repository|
 |postgresql.image.tag|string|`"18.0-alpine"`|PostgreSQL image tag (immutable tags are recommended)|
 |postgresql.imagePullSecrets|list|-|Global Docker registry secret names as an array (list)|
@@ -250,7 +250,7 @@ The following table lists the configurable parameters of this chart and their de
 |reloader.global.imagePullSecrets|list|-|Global Docker registry secret names as an array (list)|
 |reloader.image|object|-|Reloader image configuration|
 |reloader.image.name|string|`"stakater/reloader"`|Reloader image name|
-|reloader.image.repository|string|`"harbor.settlemint.com/ghcr.io/stakater/reloader"`|Reloader image repository|
+|reloader.image.repository|string|`"ghcr.io/stakater/reloader"`|Reloader image repository|
 |reloader.reloader|object|-|Reloader specific configuration (object)|
 |reloader.reloader.autoReloadAll|bool|`true`|Enable auto reload for all resources (bool)|
 |reloader.reloader.containerSecurityContext|object|-|Container security context configuration|

--- a/kit/charts/atk/charts/support/charts/minio/README.md
+++ b/kit/charts/atk/charts/support/charts/minio/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of this chart and their de
 |ignoreChartChecksums|bool|`false`|Disable automatic restart on secret/config changes to avoid unnecessary restarts in GitOps workflows|
 |image|object|-|MinIO image configuration|
 |image.pullPolicy|string|`"IfNotPresent"`|MinIO image pull policy|
-|image.repository|string|`"harbor.settlemint.com/docker.io/minio/minio"`|MinIO image repository|
+|image.repository|string|`"docker.io/minio/minio"`|MinIO image repository|
 |image.tag|string|`"RELEASE.2025-09-07T16-13-09Z"`|MinIO image tag (immutable tags are recommended)|
 |imagePullSecrets|list|-|Global Docker registry secret names as an array|
 |ingress|object|-|Ingress configuration for MinIO S3 API|
@@ -108,7 +108,7 @@ The following table lists the configurable parameters of this chart and their de
 |makeUserJob.securityContext|object|-|Security context for the makeUserJob|
 |mcImage|object|-|MinIO client image configuration|
 |mcImage.pullPolicy|string|`"IfNotPresent"`|MinIO client image pull policy|
-|mcImage.repository|string|`"harbor.settlemint.com/docker.io/minio/minio"`|MinIO client image repository|
+|mcImage.repository|string|`"docker.io/minio/minio"`|MinIO client image repository|
 |mcImage.tag|string|`"RELEASE.2025-09-07T16-13-09Z"`|MinIO client image tag|
 |metrics|object|-|Prometheus metrics configuration|
 |metrics.serviceMonitor|object|-|ServiceMonitor configuration for Prometheus Operator|

--- a/kit/charts/atk/charts/support/charts/postgresql/README.md
+++ b/kit/charts/atk/charts/support/charts/postgresql/README.md
@@ -19,7 +19,7 @@ The following table lists the configurable parameters of this chart and their de
 |fullnameOverride|string|`"postgresql"`|String to fully override common.names.fullname (string)|
 |image|object|-|Image configuration|
 |image.pullPolicy|string|`"IfNotPresent"`|Image pull policy|
-|image.registry|string|`"harbor.settlemint.com/docker.io"`|Image registry|
+|image.registry|string|`"docker.io"`|Image registry|
 |image.repository|string|`"postgres"`|Image repository|
 |image.tag|string|`"18.0-alpine"`|Image tag|
 |initdb|object|-|Database initialization configuration (object)|

--- a/kit/charts/atk/charts/support/charts/redis/README.md
+++ b/kit/charts/atk/charts/support/charts/redis/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of this chart and their de
 |image|object|-|Redis image configuration|
 |image.pullPolicy|string|`"IfNotPresent"`|Redis image pull policy|
 |image.pullSecrets|list|-|Redis image pull secrets (list)|
-|image.registry|string|`"harbor.settlemint.com/docker.io"`|Redis image registry|
+|image.registry|string|`"docker.io"`|Redis image registry|
 |image.repository|string|`"redis"`|Redis image repository|
 |image.tag|string|`"8.2.2-alpine"`|Redis image tag|
 |livenessProbe|object|-|Liveness probe configuration|

--- a/kit/charts/atk/charts/txsigner/README.md
+++ b/kit/charts/atk/charts/txsigner/README.md
@@ -109,7 +109,7 @@ The following table lists the configurable parameters of this chart and their de
 |image.digest|string|`""`|TxSigner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag|
 |image.pullPolicy|string|`"IfNotPresent"`|TxSigner image pull policy|
 |image.pullSecrets|list|-|TxSigner image pull secrets (list)|
-|image.registry|string|`"harbor.settlemint.com/ghcr.io"`|TxSigner image registry|
+|image.registry|string|`"ghcr.io"`|TxSigner image registry|
 |image.repository|string|`"settlemint/btp-signer"`|TxSigner image repository|
 |image.tag|string|`"7.15.13"`|TxSigner image tag (immutable tags are recommended)|
 |ingress|object|-|Ingress parameters (object)|
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of this chart and their de
 |initContainer.tcpCheck.enabled|bool|`true`|Enable TCP check init container|
 |initContainer.tcpCheck.image|object|-|Init container image configuration|
 |initContainer.tcpCheck.image.pullPolicy|string|`"IfNotPresent"`|Init container image pull policy|
-|initContainer.tcpCheck.image.repository|string|`"harbor.settlemint.com/ghcr.io/settlemint/btp-waitforit"`|Init container image repository|
+|initContainer.tcpCheck.image.repository|string|`"ghcr.io/settlemint/btp-waitforit"`|Init container image repository|
 |initContainer.tcpCheck.image.tag|string|`"v7.7.11"`|Init container image tag|
 |initContainer.tcpCheck.resources|object|-|Init container resource requests and limits|
 |initContainer.tcpCheck.resources.limits|object|-|Resource limits|
@@ -275,7 +275,7 @@ The following table lists the configurable parameters of this chart and their de
 |tests|object|-|Test parameters (object)|
 |tests.image|object|-|Image for test pods|
 |tests.image.pullPolicy|string|`"IfNotPresent"`|Test image pull policy|
-|tests.image.registry|string|`"harbor.settlemint.com/docker.io"`|Test image registry|
+|tests.image.registry|string|`"docker.io"`|Test image registry|
 |tests.image.repository|string|`"busybox"`|Test image repository|
 |tests.image.tag|string|`"1.37.0"`|Test image tag|
 |tolerations|list|-|Tolerations for pod assignment (list)|


### PR DESCRIPTION
Last release, when codestudio build after `create release assets pull request`, it was tagged with `beta.1` instead of `beta.2` tag